### PR TITLE
'Missing Step' error workaround

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/Result.java
+++ b/src/main/java/net/masterthought/cucumber/json/Result.java
@@ -10,6 +10,10 @@ public class Result {
 
     }
 
+    public Result(String status) {
+        this.status = status;
+    }
+    
     public String getStatus() {
         return status;
     }

--- a/src/main/java/net/masterthought/cucumber/json/Step.java
+++ b/src/main/java/net/masterthought/cucumber/json/Step.java
@@ -18,7 +18,7 @@ public class Step {
     private Object[] embeddings;
 
     public Step() {
-
+        result = new Result("passed");
     }
 
     public Row[] getRows() {
@@ -123,7 +123,7 @@ public class Step {
 
     private String formatError(String errorMessage) {
         String result = errorMessage;
-        if (errorMessage != null || !errorMessage.isEmpty()) {
+        if (errorMessage != null && !errorMessage.isEmpty()) {
             result = errorMessage.replaceAll("\\\\n", "<br/>");
         }
         return result;


### PR DESCRIPTION
Unfortunately, downgrading cucumber-jvm to 1.0.8 to get rid of the nasty 'Missing step' warnings in the cucumber report was not an option for me. Therefore I amended cucumber-reporting to initialize Step objects with "passed" Result objects in their Constructor. So, anytime I would end up with a resultless Step, I get a Step with a passed Result instead. So the generated reports look good again.
I admit that this is more a hack than a fix, but in case you find it useful, feel free to pull.  
