### PR TITLE
Make docstring sections HTML safe

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/DocString.java
+++ b/src/main/java/net/masterthought/cucumber/json/DocString.java
@@ -1,5 +1,7 @@
 package net.masterthought.cucumber.json;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 /**
  * Doc Strings are handy for specifying a larger piece of text. This is inspired from Python’s Docstring syntax.
  *
@@ -36,6 +38,14 @@ public class DocString {
 
     public Integer getLine() {
         return line;
+    }
+
+    /**
+     * Returns getValue but escaped for HTML and to preserve whitespace
+     */
+    public String getEscapedValue() {
+        String html = StringEscapeUtils.escapeHtml(this.getValue());
+        return html.replaceAll("\n", "<br/>").replaceAll(" ", "&nbsp;");
     }
 
     /**

--- a/src/main/java/net/masterthought/cucumber/json/Step.java
+++ b/src/main/java/net/masterthought/cucumber/json/Step.java
@@ -158,7 +158,7 @@ public class Step {
         }
         return Util.result(getStatus()) +
                  "<div class=\"doc-string\">" +
-                    getDocString().getValue().replaceAll("\n", "<br/>").replaceAll(" ", "&nbsp;") +
+                    getDocString().getEscapedValue() +
                  Util.closeDiv() +
                Util.closeDiv();
     }

--- a/src/test/java/net/masterthought/cucumber/DocStringTest.java
+++ b/src/test/java/net/masterthought/cucumber/DocStringTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,6 +53,15 @@ public class DocStringTest {
                                                         "_&nbsp;O&nbsp;X" +
                                                       "</div>" +
                                                     "</div>"));
+    }
+
+    @Test
+    public void shouldEscapeForHtml() throws NoSuchFieldException, IllegalAccessException {
+        DocString ds = new DocString();
+        Field field = DocString.class.getDeclaredField("value");
+        field.setAccessible(true);
+        field.set(ds, "<a><b>cat</b></a>");
+        assertThat("&lt;a&gt;&lt;b&gt;cat&lt;/b&gt;&lt;/a&gt;", is(ds.getEscapedValue()));
     }
 
 }


### PR DESCRIPTION
Make docstring sections HTML safe so that they can be used for things like xml snippets, i.e.

Given an xml snippet :
"""
  &lt;myxmlsnippet /&gt;
"""
