### PR TITLE
Gherkin syntax is not properly HTML escaped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,11 @@
             <version>1.5-20060721.044818</version>
         </dependency>
         <dependency>
+            <groupId>velocity-tools</groupId>
+            <artifactId>velocity-tools</artifactId>
+            <version>1.4</version>
+        </dependency>
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.1</version>

--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -9,6 +9,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.tools.generic.EscapeTool;
 
 import java.io.*;
 import java.net.URISyntaxException;
@@ -108,6 +109,7 @@ public class ReportBuilder {
                 context.put("jenkins_base", pluginUrlPath);
                 context.put("fromJenkins", runWithJenkins);
                 context.put("artifactsEnabled", ConfigurationOptions.artifactsEnabled());
+                context.put("esc", new EscapeTool());
                 generateReport(feature.getFileName(), featureResult, context);
             }
         }

--- a/src/main/resources/templates/featureReport.vm
+++ b/src/main/resources/templates/featureReport.vm
@@ -234,7 +234,7 @@ table.data-table td {
                       #foreach($row in $step.getRows())
                        <tr>
                            #foreach($cell in $row.getCells())
-                           <td>$cell</td>
+                           <td>$esc.html($cell)</td>
                            #end
                        </tr>
                       #end


### PR DESCRIPTION
When the Gherkin scenario contains e.g. XML, then it's not properly escaped when displayed on the cucumber-reporting HTML page.
