### PR TITLE
Handle Scenario Outlines with missing results

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/Step.java
+++ b/src/main/java/net/masterthought/cucumber/json/Step.java
@@ -117,7 +117,7 @@ public class Step {
             content = Util.result(getStatus()) + "<span class=\"step-keyword\">" + keyword + " </span><span class=\"step-name\">" + name + "</span><span class=\"step-duration\">" + Util.formatDuration(result.getDuration()) + "</span><div class=\"step-error-message\"><pre>" + formatError(errorMessage) + "</pre></div>" + Util.closeDiv() + getImageTags();
         } else if (getStatus() == Util.Status.MISSING) {
             String errorMessage = "<span class=\"missing\">Result was missing for this step</span>";
-            content = Util.result(getStatus()) + "<span class=\"step-keyword\">" + keyword + " </span><span class=\"step-name\">" + name + "</span><span class=\"step-duration\">" + Util.formatDuration(result.getDuration()) + "</span><div class=\"step-error-message\"><pre>" + formatError(errorMessage) + "</pre></div>" + Util.closeDiv();
+            content = Util.result(getStatus()) + "<span class=\"step-keyword\">" + keyword + " </span><span class=\"step-name\">" + name + "</span>" + "<div class=\"step-error-message\"><pre>" + formatError(errorMessage) + "</pre></div>" + Util.closeDiv();
         } else {
             content = getNameAndDuration();
         }


### PR DESCRIPTION
Sometimes the json formatter does not include results in step elements of a Scenario Outline.
For example, see: https://github.com/cucumber/gherkin/issues/165

This caused an NPE when generating reports:

```
org.apache.velocity.exception.MethodInvocationException: Invocation of
method 'getName' in class net.masterthought.cucumber.json.Step threw
exception java.lang.NullPointerException at
templates/featureReport.vm[line 210, column 25]
```

This looks like a regression introduced in 906b9b92a12c5e4c8512b466ca725d2cb74e2653.
