### PR TITLE
Fixes very slow report generation  

### DIFF
--- a/src/main/java/net/masterthought/cucumber/util/Util.java
+++ b/src/main/java/net/masterthought/cucumber/util/Util.java
@@ -106,6 +106,7 @@ public class Util {
         while (m.find()) {
             res = res.replaceAll("\\" + m.group(0),
                     Character.toString((char) Integer.parseInt(m.group(1), 16)));
+            m = p.matcher(res);
         }
         return res;
     }


### PR DESCRIPTION
With this fix our report generation goes from 30 minutes to 2 seconds. The problem is U2U method is invoking replaceAll for each occurrence of the word to be replaced.
Matching again the document avoids this problem.
