### PR TITLE
Wrapping step error message in div.

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/Step.java
+++ b/src/main/java/net/masterthought/cucumber/json/Step.java
@@ -137,7 +137,7 @@ public class Step {
         sb.append("</span>");
 
         if (status == Status.FAILED || status == Status.MISSING) {
-            sb.append("<div class=\"step-error-message\"><pre>").append(formatError(errorMessage)).append("</pre></div>");
+            sb.append("<div class=\"step-error-message\"><pre class=\"step-error-message-content\">").append(formatError(errorMessage)).append("</pre></div>");
 
         }
         sb.append("</div>");

--- a/src/main/resources/styles/reporting.css
+++ b/src/main/resources/styles/reporting.css
@@ -48,6 +48,14 @@
 	border: 1px solid #D88A8A;
 }
 
+.step-error-message-content {
+	white-space: pre-wrap;
+	white-space: -moz-pre-wrap;
+	white-space: -pre-wrap;
+	white-space: -o-pre-wrap;
+	word-wrap: break-word;
+}
+
 .step-duration {
 	float: right;
 	padding-right: 15px;

--- a/src/test/java/net/masterthought/cucumber/StepTest.java
+++ b/src/test/java/net/masterthought/cucumber/StepTest.java
@@ -60,7 +60,7 @@ public class StepTest {
         Feature feature = reportParser.getFeatures().entrySet().iterator().next().getValue().get(0);
         Step step = feature.getElements().get(0).getSteps().get(0);
         feature.processSteps();
-        assertThat(step.getName(), is("<div class=\"missing\"><span class=\"step-keyword\">Given  </span><span class=\"step-name\">a &quot;Big&quot; customer</span><span class=\"step-duration\"></span><div class=\"step-error-message\"><pre><span class=\"missing\">Result was missing for this step</span></pre></div></div>"));
+        assertThat(step.getName(), is("<div class=\"missing\"><span class=\"step-keyword\">Given  </span><span class=\"step-name\">a &quot;Big&quot; customer</span><span class=\"step-duration\"></span><div class=\"step-error-message\"><pre class=\"step-error-message-content\"><span class=\"missing\">Result was missing for this step</span></pre></div></div>"));
     }
 
     @Test


### PR DESCRIPTION
I've added css class for wrapping error message in a parent div.

Before:
![before](https://cloud.githubusercontent.com/assets/11270518/8927074/269e530c-3515-11e5-9b36-cc4702021777.png)

After:
![after](https://cloud.githubusercontent.com/assets/11270518/8927080/2d4a4f12-3515-11e5-9ebd-895950d04b26.png)

