### PR TITLE
Using setters instead of writing to variables directly.

### DIFF
--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -165,15 +165,15 @@ public class ReportBuilder {
             boolean missingFails, boolean flashCharts, boolean runWithJenkins, boolean artifactsEnabled,
             String artifactConfig, boolean highCharts, boolean parallelTesting) throws IOException, VelocityException {
         try {
-            this.reportDirectory = reportDirectory;
-            this.buildNumber = buildNumber;
-            this.buildProject = buildProject;
-            this.pluginUrlPath = getPluginUrlPath(pluginUrlPath);
-            this.flashCharts = flashCharts;
-            this.runWithJenkins = runWithJenkins;
+            setReportDirectory(reportDirectory);
+            setBuildNumber(buildNumber);
+            setBuildProject(buildProject);
+            setPluginUrlPath(getPluginUrlPath(pluginUrlPath));
+            setFlashCharts(flashCharts);
+            setHighCharts(highCharts);
+            setRunWithJenkins(runWithJenkins);
+            setParallel(parallelTesting);
             this.artifactsEnabled = artifactsEnabled;
-            this.highCharts = highCharts;
-            ReportBuilder.parallel = parallelTesting;
 
             ConfigurationOptions configuration = ConfigurationOptions.instance();
             configuration.setSkippedFailsBuild(skippedFails);
@@ -187,10 +187,10 @@ public class ReportBuilder {
             }
 
             ReportParser reportParser = new ReportParser(jsonReports);
-            this.reportInformation = new ReportInformation(reportParser.getFeatures());
+            setRi(new ReportInformation(reportParser.getFeatures()));
             // whatever happens we want to provide at least error page instead of empty report
         } catch (Exception exception) {
-            parsingError = true;
+            setParsingError(true);
             generateErrorPage(exception);
         }
     }
@@ -220,7 +220,7 @@ public class ReportBuilder {
             new TagOverviewPage(this).generatePage();
             // whatever happens we want to provide at least error page instead of empty report
         } catch (Exception exception) {
-            if (!parsingError) {
+            if (!isParsingError()) {
                 generateErrorPage(exception);
             }
         }


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/144%23issuecomment-132353935%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/144%23issuecomment-132354024%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/144%23issuecomment-132354714%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/144%23issuecomment-132357027%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/144%23issuecomment-132353935%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6088.34%25%60%5Cn%3E%20Merging%20%2A%2A%23144%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20increase%20coverage%20by%20%2A%2A%2B1.74%25%2A%2A%20as%20of%20%5B%606608306%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23144%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%2030%20%20%20%20%20%2030%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%201209%20%20%20%201209%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20180%20%20%20%20%20180%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hit%20%20%20%20%20%20%20%20%20%20%201047%20%20%20%201068%20%20%20%20%2B21%5Cn%20%20Partial%20%20%20%20%20%20%20%20%2054%20%20%20%20%20%2054%20%20%20%20%20%20%20%5Cn%2B%20Missed%20%20%20%20%20%20%20%20%20108%20%20%20%20%20%2087%20%20%20%20-21%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%606608306%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting%3Fref%3D660830629145ba900cd636d24db6b402d177d6de%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions%3Fref%3D660830629145ba900cd636d24db6b402d177d6de%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/commit/660830629145ba900cd636d24db6b402d177d6de%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/compare/e2a742d4d1e33f0184759f99932c83739d361efe...660830629145ba900cd636d24db6b402d177d6de%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A14%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Since%20setters%20have%20no%20logic%2C%20what%20is%20the%20advantages%20of%20this%20change%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A15%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22only%20increasted%20code%20coverage.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A18%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20think%20it%27s%20the%20way%20we%20want%20to%20do%20this.%20I%20have%20a%20plan%20to%20separate%20input%20data%20from%20ReportBuilder.%20You%20can%20do%20this%20in%20that%20way%20and%20testing%20would%20be%20more%20natural.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A28%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/144#issuecomment-132353935'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `88.34%`
> Merging **#144** into **master** will increase coverage by **+1.74%** as of [`6608306`][3]
```diff
@@            master    #144   diff @@
======================================
Files           30      30
Stmts         1209    1209
Branches       180     180
Methods          0       0
======================================
+ Hit           1047    1068    +21
Partial         54      54
+ Missed         108      87    -21
```
> Review entire [Coverage Diff][4] as of [`6608306`][3]
[1]: https://codecov.io/github/damianszczepanik/cucumber-reporting?ref=660830629145ba900cd636d24db6b402d177d6de
[2]: https://codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions?ref=660830629145ba900cd636d24db6b402d177d6de
[3]: https://codecov.io/github/damianszczepanik/cucumber-reporting/commit/660830629145ba900cd636d24db6b402d177d6de
[4]: https://codecov.io/github/damianszczepanik/cucumber-reporting/compare/e2a742d4d1e33f0184759f99932c83739d361efe...660830629145ba900cd636d24db6b402d177d6de
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Since setters have no logic, what is the advantages of this change?
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> only increasted code coverage.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> I don't think it's the way we want to do this. I have a plan to separate input data from ReportBuilder. You can do this in that way and testing would be more natural.


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/144?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/144?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/144'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>