### PR TITLE
fix for multiple json files containing results for features with same name

### DIFF
--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -151,9 +151,9 @@ public class ReportBuilder {
      *            mark steps with skipped status as failure
      * @param pendingFails
      *            mark steps with pending status as failure
-     * @param undefinedFailsmark
+     * @param undefinedFails
      *            steps with undefined status as failure
-     * @param missingFailsmark
+     * @param missingFails
      *            steps with missing status as failure
      * @param flashCharts
      *            set to true when expect to have generated report in Flash technology, false for JavaScript

--- a/src/main/java/net/masterthought/cucumber/ReportInformation.java
+++ b/src/main/java/net/masterthought/cucumber/ReportInformation.java
@@ -21,6 +21,7 @@ public class ReportInformation {
     private final Map<String, List<Feature>> featureMap;
     private final Map<String, StepObject> stepObjects = new HashMap<>();
     private List<Feature> features;
+    private final Map<String, Integer> featureNamesCount= new HashMap<>();
 
     private int numberOfScenarios;
     private int numberOfSteps;
@@ -240,6 +241,16 @@ public class ReportInformation {
             List<ScenarioTag> scenarioList = new ArrayList<>();
             Element[] scenarios = feature.getElements();
             numberOfScenarios = getNumberOfScenarios(scenarios);
+
+            // set filenames for features
+            int count = 1;
+            if (featureNamesCount.containsKey(feature.getFileName())) {
+                count = featureNamesCount.get(feature.getFileName());
+                count++;
+            }
+            featureNamesCount.put(feature.getFileName(),count);
+            feature.setFileName(count);
+
             // build map with tags
             if (feature.hasTags()) {
                 for (Element e : feature.getElements()) {

--- a/src/main/java/net/masterthought/cucumber/ReportInformation.java
+++ b/src/main/java/net/masterthought/cucumber/ReportInformation.java
@@ -21,7 +21,7 @@ public class ReportInformation {
     private final Map<String, List<Feature>> featureMap;
     private final Map<String, StepObject> stepObjects = new HashMap<>();
     private List<Feature> features;
-    private final Map<String, Integer> featureNamesCount= new HashMap<>();
+    private final Map<String, Integer> featureIdsCount= new HashMap<>();
 
     private int numberOfScenarios;
     private int numberOfSteps;
@@ -244,11 +244,11 @@ public class ReportInformation {
 
             // set filenames for features
             int count = 1;
-            if (featureNamesCount.containsKey(feature.getFileName())) {
-                count = featureNamesCount.get(feature.getFileName());
+            if (featureIdsCount.containsKey(feature.getId())) {
+                count = featureIdsCount.get(feature.getId());
                 count++;
             }
-            featureNamesCount.put(feature.getFileName(),count);
+            featureIdsCount.put(feature.getId(), count);
             feature.setFileName(count);
 
             // build map with tags

--- a/src/main/java/net/masterthought/cucumber/json/Feature.java
+++ b/src/main/java/net/masterthought/cucumber/json/Feature.java
@@ -72,7 +72,7 @@ public class Feature {
                 fileName = fileName + "-" + getDeviceName();
         }
         if (count>1) {
-            this.fileName = fileName + "_" + count.toString() + ".html";
+            this.fileName = fileName + "-" + count.toString() + ".html";
         }
         else {
             this.fileName = fileName + ".html";

--- a/src/main/java/net/masterthought/cucumber/json/Feature.java
+++ b/src/main/java/net/masterthought/cucumber/json/Feature.java
@@ -221,4 +221,7 @@ public class Feature {
     }
 
 
+    public String getId() {
+        return id;
+    }
 }

--- a/src/main/java/net/masterthought/cucumber/json/Feature.java
+++ b/src/main/java/net/masterthought/cucumber/json/Feature.java
@@ -27,6 +27,7 @@ public class Feature {
     private ScenarioResults scenarioResults;
 
     private String jsonFile = "";
+    private String fileName = null;
 
     public String getDeviceName() {
         String name = "";
@@ -45,6 +46,11 @@ public class Feature {
     }
 
     public String getFileName() {
+        if (fileName==null) setFileName(1);
+        return fileName;
+    }
+
+    public void setFileName(Integer count) {
         List<String> matches = new ArrayList<String>();
         for (String line : StringUtils.split(uri, "/|\\\\")) {
             String modified = line.replaceAll("\\)|\\(", "");
@@ -63,8 +69,13 @@ public class Feature {
             if (splitedJsonFile.length > 1)
                 fileName = fileName + "-" + getDeviceName();
         }
-        fileName = fileName + ".html";
-        return fileName;
+        if (count>1) {
+            this.fileName = fileName + "_" + count.toString() + ".html";
+        }
+        else {
+            this.fileName = fileName + ".html";
+        }
+
     }
 
     public String getUri(){

--- a/src/main/java/net/masterthought/cucumber/json/Feature.java
+++ b/src/main/java/net/masterthought/cucumber/json/Feature.java
@@ -46,7 +46,9 @@ public class Feature {
     }
 
     public String getFileName() {
-        if (fileName==null) setFileName(1);
+        if (fileName==null) {
+            setFileName(1);
+        }
         return fileName;
     }
 


### PR DESCRIPTION
If i want to combine two cucumber json reports with same features, only one feature-page with scenario results is generated instead of two.
This pr fixes it by adding  _2 to feature-page filename.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23issuecomment-137006657%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23discussion_r38576160%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23discussion_r38576377%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23discussion_r38576400%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23issuecomment-137227256%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23issuecomment-137708626%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23issuecomment-137818676%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23issuecomment-146795197%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23issuecomment-147855682%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23issuecomment-137006657%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6086.86%25%60%5Cn%3E%20Merging%20%2A%2A%23175%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20increase%20coverage%20by%20%2A%2A%2B0.50%25%2A%2A%20as%20of%20%5B%603e86146%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23175%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%2036%20%20%20%20%20%2036%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%201247%20%20%20%201294%20%20%20%20%2B47%5Cn%20%20Branches%20%20%20%20%20%20%20182%20%20%20%20%20186%20%20%20%20%20%2B4%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hit%20%20%20%20%20%20%20%20%20%20%201077%20%20%20%201124%20%20%20%20%2B47%5Cn%2B%20Partial%20%20%20%20%20%20%20%20%2057%20%20%20%20%20%2056%20%20%20%20%20-1%5Cn-%20Missed%20%20%20%20%20%20%20%20%20113%20%20%20%20%20114%20%20%20%20%20%2B1%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%603e86146%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting%3Fref%3D3e8614608c0b3679852327955db64309385323e6%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions%3Fref%3D3e8614608c0b3679852327955db64309385323e6%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/commit/3e8614608c0b3679852327955db64309385323e6%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/compare/808f624153998417280c259a5d08f0210d9e4f07...3e8614608c0b3679852327955db64309385323e6%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222015-09-02T09%3A52%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20did%20some%20notes%20but%20I%20have%20more%20important%20question%20for%20this%20PR.%20What%20is%20you%20expectation%20if%20you%20generate%20report%20from%20the%20same%20feature%20when%20first%20passed%20and%20second%20fails%3F%20Assume%20that%20both%20have%20the%20same%20ID.%22%2C%20%22created_at%22%3A%20%222015-09-02T19%3A59%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20expect%20two%20diffrent%20reports%20for%20that%20feature%2C%20for%20ex.%20feature-overview%20looks%20like%20this%3A%5Cr%5Cn%21%5Bimage%5D%28https%3A//cloud.githubusercontent.com/assets/11270518/9682184/89b35980-5304-11e5-936a-d7395ef290a7.png%29%20but%20when%20generating%20feature-report%20pages%20both%20have%20same%20filename%20and%20second%20result%20overwrites%20the%20first%20one.%20So%20with%20this%20PR%20istead%20of%20geneating%20for%20example%20%27examples-java-calculator-testowy.feature.html%27%20twice%20overwrting%20first%20result%2C%20we%20genatate%20%27examples-java-calculator-testowy.feature.html%27%20and%20%27examples-java-calculator-testowy.feature-2.html%27%22%2C%20%22created_at%22%3A%20%222015-09-04T11%3A12%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20sounds%20good%20to%20me.%20How%20about%20tags%3A%20you%20have%20two%20features%20files%2C%20each%20have%20own%20tag%20named%20%5C%22bank%5C%22%20but%20this%20tag%20has%20different%20meeting%20in%20first%20feature%20and%20different%20in%20second%20one.%20Tags%20have%20no%20ID%20so%20in%20tag%20overview%20you%20will%20combine%20two%20different%20tags%20into%20one.%5Cr%5Cn%5Cr%5CnIs%20it%20what%20user%20expect%3F%22%2C%20%22created_at%22%3A%20%222015-09-04T18%3A47%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%27s%20exacly%20what%20i%20would%20expect.%20How%20about%20renaming%20feature%20name%3F%20For%20the%20previous%20%20example%3A%5Cr%5Cn-%20Basic%20Arithmetic%5Cr%5Cn-%20Basic%20Arithmetic%20%282%29%22%2C%20%22created_at%22%3A%20%222015-10-09T08%3A23%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20is%20easy%20to%20say%20and%20hopefully%20to%20implement%20but%20it%20also%20introduces%20confusing%3A%20you%20have%20the%20same%20test%20executed%20twice%20and%20one%20passes%20while%20another%20one%20doesn%27t.%20Why%20is%20that%3F%20Which%20one%20is%20which%3F%5Cr%5Cn%5Cr%5CnI%27m%20not%20convinced%20to%20this%20solution...%22%2C%20%22created_at%22%3A%20%222015-10-13T21%3A13%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%202c2e8b253a6627167c7f93b75050a64f37eadc09%20src/main/java/net/masterthought/cucumber/json/Feature.java%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23discussion_r38576400%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%7B%5Cr%5Cn%7D%22%2C%20%22created_at%22%3A%20%222015-09-02T19%3A55%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Feature.java%3AL46-57%22%7D%2C%20%22Pull%202c2e8b253a6627167c7f93b75050a64f37eadc09%20src/main/java/net/masterthought/cucumber/ReportInformation.java%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23discussion_r38576377%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22file%20name%20is%20used%20when%20generating%20html%20files%20so%20in%20that%20case%20we%20lost%20such%20information%20and%20use%20number%20values%20as%20the%20file%20name%20-%20is%20that%20correct%3F%20If%20so%2C%20I%20don%27t%20want%20to%20loose%20such%20information.%22%2C%20%22created_at%22%3A%20%222015-09-02T19%3A55%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/ReportInformation.java%3AL241-257%22%7D%2C%20%22Pull%202c2e8b253a6627167c7f93b75050a64f37eadc09%20src/main/java/net/masterthought/cucumber/ReportInformation.java%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/175%23discussion_r38576160%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Feature%20is%20identified%20by%20unique%20ID%2C%20not%20file%20name%22%2C%20%22created_at%22%3A%20%222015-09-02T19%3A53%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/ReportInformation.java%3AL241-257%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/175#issuecomment-137006657'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `86.86%`
> Merging **#175** into **master** will increase coverage by **+0.50%** as of [`3e86146`][3]
```diff
@@            master    #175   diff @@
======================================
Files           36      36
Stmts         1247    1294    +47
Branches       182     186     +4
Methods          0       0
======================================
+ Hit           1077    1124    +47
+ Partial         57      56     -1
- Missed         113     114     +1
```
> Review entire [Coverage Diff][4] as of [`3e86146`][3]
[1]: https://codecov.io/github/damianszczepanik/cucumber-reporting?ref=3e8614608c0b3679852327955db64309385323e6
[2]: https://codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions?ref=3e8614608c0b3679852327955db64309385323e6
[3]: https://codecov.io/github/damianszczepanik/cucumber-reporting/commit/3e8614608c0b3679852327955db64309385323e6
[4]: https://codecov.io/github/damianszczepanik/cucumber-reporting/compare/808f624153998417280c259a5d08f0210d9e4f07...3e8614608c0b3679852327955db64309385323e6
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> I did some notes but I have more important question for this PR. What is you expectation if you generate report from the same feature when first passed and second fails? Assume that both have the same ID.
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> I expect two diffrent reports for that feature, for ex. feature-overview looks like this:
![image](https://cloud.githubusercontent.com/assets/11270518/9682184/89b35980-5304-11e5-936a-d7395ef290a7.png) but when generating feature-report pages both have same filename and second result overwrites the first one. So with this PR istead of geneating for example 'examples-java-calculator-testowy.feature.html' twice overwrting first result, we genatate 'examples-java-calculator-testowy.feature.html' and 'examples-java-calculator-testowy.feature-2.html'
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> This sounds good to me. How about tags: you have two features files, each have own tag named "bank" but this tag has different meeting in first feature and different in second one. Tags have no ID so in tag overview you will combine two different tags into one.
Is it what user expect?
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> That's exacly what i would expect. How about renaming feature name? For the previous  example:
- Basic Arithmetic
- Basic Arithmetic (2)
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> That is easy to say and hopefully to implement but it also introduces confusing: you have the same test executed twice and one passes while another one doesn't. Why is that? Which one is which?
I'm not convinced to this solution...
- [ ] <a href='#crh-comment-Pull 2c2e8b253a6627167c7f93b75050a64f37eadc09 src/main/java/net/masterthought/cucumber/ReportInformation.java 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/175#discussion_r38576160'>File: src/main/java/net/masterthought/cucumber/ReportInformation.java:L241-257</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Feature is identified by unique ID, not file name
- [ ] <a href='#crh-comment-Pull 2c2e8b253a6627167c7f93b75050a64f37eadc09 src/main/java/net/masterthought/cucumber/ReportInformation.java 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/175#discussion_r38576377'>File: src/main/java/net/masterthought/cucumber/ReportInformation.java:L241-257</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> file name is used when generating html files so in that case we lost such information and use number values as the file name - is that correct? If so, I don't want to loose such information.
- [ ] <a href='#crh-comment-Pull 2c2e8b253a6627167c7f93b75050a64f37eadc09 src/main/java/net/masterthought/cucumber/json/Feature.java 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/175#discussion_r38576400'>File: src/main/java/net/masterthought/cucumber/json/Feature.java:L46-57</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> {
}


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/175?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/175?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/175'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>