### PR TITLE
Show full stacktrace as html message when crash happens

### DIFF
--- a/src/main/java/net/masterthought/cucumber/generators/ErrorPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/ErrorPage.java
@@ -2,6 +2,8 @@ package net.masterthought.cucumber.generators;
 
 import java.io.IOException;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
 import net.masterthought.cucumber.ReportBuilder;
 
 public class ErrorPage extends AbstractPage {
@@ -17,7 +19,7 @@ public class ErrorPage extends AbstractPage {
     public void generatePage() throws IOException {
         super.generatePage();
 
-        contextMap.put("error_message", exception);
+        contextMap.put("error_message", ExceptionUtils.getStackTrace(exception));
         contextMap.put("json_files", reportBuilder.getJsonFiles());
 
         super.generateReport("feature-overview.html");

--- a/src/main/resources/templates/pages/errorPage.vm
+++ b/src/main/resources/templates/pages/errorPage.vm
@@ -42,7 +42,7 @@
 
 	<br/>
 
-	<div id="error-message" class="error-message">$error_message</div>
+	<div id="error-message" class="error-message"><pre>$error_message</pre></div>
         <br/>
         <span class="subhead">Trying to generate report from following files. Make sure they are valid cucumber report files:</span>
             #foreach($file in $json_files)

--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -86,7 +87,8 @@ public class ReportBuilderTest {
         File input = new File(rd, "feature-overview.html");
         Document doc = Jsoup.parse(input, "UTF-8", "");
         assertThat(fromId("overview-title", doc).text(), is("Oops Something went wrong with cucumber-reporting build: 1"));
-        assertThat(fromId("error-message", doc).text(), is("com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Unterminated object at line 19 column 18 path $[0].elements[0].keyword"));
+        assertTrue(fromId("error-message", doc).text().contains(
+                "com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Unterminated object at line 19 column 18 path $[0].elements[0].keyword"));
     }
 
     @Test
@@ -100,7 +102,7 @@ public class ReportBuilderTest {
         File input = new File(rd, "feature-overview.html");
         Document doc = Jsoup.parse(input, "UTF-8", "");
         assertThat(fromId("overview-title", doc).text(), is("Oops Something went wrong with cucumber-reporting build: 1"));
-        assertThat(fromId("error-message", doc).text(), is("java.lang.NullPointerException"));
+        assertTrue(fromId("error-message", doc).text().contains("java.lang.NullPointerException"));
     }
 
     @Test


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/178%23issuecomment-138005106%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/178%23issuecomment-138005106%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6086.65%25%60%5Cn%3E%20Merging%20%2A%2A%23178%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20not%20affect%20coverage%20as%20of%20%5B%607710e65%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23178%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%2036%20%20%20%20%20%2036%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%201281%20%20%20%201281%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20183%20%20%20%20%20183%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hit%20%20%20%20%20%20%20%20%20%20%201110%20%20%20%201110%20%20%20%20%20%20%20%5Cn%20%20Partial%20%20%20%20%20%20%20%20%2057%20%20%20%20%20%2057%20%20%20%20%20%20%20%5Cn%20%20Missed%20%20%20%20%20%20%20%20%20114%20%20%20%20%20114%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%607710e65%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting%3Fref%3D7710e65eefbea4d73ab3fde8746fda842d4af51a%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions%3Fref%3D7710e65eefbea4d73ab3fde8746fda842d4af51a%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/commit/7710e65eefbea4d73ab3fde8746fda842d4af51a%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/compare/4c76dea1dad3129c0d63c4037448afa94ee7b9bb...7710e65eefbea4d73ab3fde8746fda842d4af51a%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222015-09-05T22%3A43%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/178#issuecomment-138005106'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `86.65%`
> Merging **#178** into **master** will not affect coverage as of [`7710e65`][3]
```diff
@@            master    #178   diff @@
======================================
Files           36      36
Stmts         1281    1281
Branches       183     183
Methods          0       0
======================================
Hit           1110    1110
Partial         57      57
Missed         114     114
```
> Review entire [Coverage Diff][4] as of [`7710e65`][3]
[1]: https://codecov.io/github/damianszczepanik/cucumber-reporting?ref=7710e65eefbea4d73ab3fde8746fda842d4af51a
[2]: https://codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions?ref=7710e65eefbea4d73ab3fde8746fda842d4af51a
[3]: https://codecov.io/github/damianszczepanik/cucumber-reporting/commit/7710e65eefbea4d73ab3fde8746fda842d4af51a
[4]: https://codecov.io/github/damianszczepanik/cucumber-reporting/compare/4c76dea1dad3129c0d63c4037448afa94ee7b9bb...7710e65eefbea4d73ab3fde8746fda842d4af51a
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/178?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/178?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/178'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>