### PR TITLE
Fixed parsing of Step output field that is an array of String

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 env:
   global:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created

--- a/src/main/java/net/masterthought/cucumber/json/Step.java
+++ b/src/main/java/net/masterthought/cucumber/json/Step.java
@@ -5,10 +5,11 @@ import java.util.List;
 
 import org.apache.commons.lang.StringEscapeUtils;
 
-import edu.emory.mathcs.backport.java.util.Arrays;
 import net.masterthought.cucumber.json.support.ResultsWithMatch;
 import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.util.Util;
+
+import com.google.gson.JsonElement;
 
 public class Step implements ResultsWithMatch {
 
@@ -19,7 +20,7 @@ public class Step implements ResultsWithMatch {
     private final Row[] rows = new Row[0];
     private final Match match = null;
     private final Embedded[] embeddings = new Embedded[0];
-    private final String[][] output = new String[0][0];
+    private final JsonElement[] output = new JsonElement[0];
     private final DocString doc_string = null;
 
     public DocString getDocString() {
@@ -30,10 +31,17 @@ public class Step implements ResultsWithMatch {
         return rows;
     }
 
-    public String[] getOutputAsArray() {
+    public String[] getOutput() {
         List<String> list = new ArrayList<>();
-        for (String[] array : output) {
-            list.addAll(Arrays.asList(array));
+        for (JsonElement element : this.output){
+            if (element.isJsonPrimitive() && element.getAsJsonPrimitive().isString()) {
+                String elementString = element.getAsString();
+                list.add(StringEscapeUtils.escapeHtml(elementString));
+            }
+            else {
+                String elementString = element.toString();
+                list.add(StringEscapeUtils.escapeHtml(elementString));
+            }
         }
         return list.toArray(new String[list.size()]);
     }

--- a/src/main/resources/templates/pages/featureReport.vm
+++ b/src/main/resources/templates/pages/featureReport.vm
@@ -77,7 +77,7 @@
                         </div>
                     #end
                     <div class="output-data">
-                    #foreach($output in $step.getOutputAsArray())
+                    #foreach($output in $step.getOutput())
                         <div>$output</div>
                     #end
                     </div>

--- a/src/test/java/net/masterthought/cucumber/StepTest.java
+++ b/src/test/java/net/masterthought/cucumber/StepTest.java
@@ -71,7 +71,7 @@ public class StepTest {
 
     @Test
     public void shouldReturnOutput() {
-        assertThat(withOutput.getOutputAsArray(), is(new String[] { "some other text", "wooops", "matchedColumns" }));
+        assertThat(withOutput.getOutput(), is(new String[] { "[&quot;some other text&quot;,&quot;wooops&quot;]", "[&quot;matchedColumns&quot;]", "[]" }));
     }
 
     @Test


### PR DESCRIPTION
This fixes a problem with parsing of output field that is an array of String, that was introduced in #188, now both single and double array is parsable.
I've also added 'sudo: required' in .travis.yml since now the default for new repositories is 'sudo: false', and my builds were broken.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23issuecomment-143474403%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23issuecomment-143476551%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23issuecomment-143478664%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23issuecomment-143491758%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23discussion_r40497909%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23discussion_r40497915%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23discussion_r40497939%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23discussion_r40497989%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23issuecomment-143835938%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23discussion_r40590567%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23discussion_r40606123%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23issuecomment-143875830%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23issuecomment-144472833%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23issuecomment-145447709%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23issuecomment-143474403%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6087.84%25%60%5Cn%3E%20Merging%20%2A%2A%23200%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20decrease%20coverage%20by%20%2A%2A-0.05%25%2A%2A%20as%20of%20%5B%60207dbd5%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23200%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%2032%20%20%20%20%20%2033%20%20%20%20%20%2B1%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%201148%20%20%20%201160%20%20%20%20%2B12%5Cn%20%20Branches%20%20%20%20%20%20%20161%20%20%20%20%20164%20%20%20%20%20%2B3%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hit%20%20%20%20%20%20%20%20%20%20%201009%20%20%20%201019%20%20%20%20%2B10%5Cn-%20Partial%20%20%20%20%20%20%20%20%2043%20%20%20%20%20%2044%20%20%20%20%20%2B1%5Cn-%20Missed%20%20%20%20%20%20%20%20%20%2096%20%20%20%20%20%2097%20%20%20%20%20%2B1%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%60207dbd5%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting%3Fref%3D207dbd5b83ebf376d048b8ba36a88400507e9c62%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions%3Fref%3D207dbd5b83ebf376d048b8ba36a88400507e9c62%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/commit/207dbd5b83ebf376d048b8ba36a88400507e9c62%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/compare/9a0104c3206d3c962dca6429a5e1628e1f8ccf5f...207dbd5b83ebf376d048b8ba36a88400507e9c62%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222015-09-26T17%3A36%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20believe%20there%20is%20only%20one%20correct%20output%20format%20so%20there%20is%20no%20need%20to%20maintain%20both.%20Also%20I%20don%27t%20the%20way%20how%20it%20was%20solved%2C%20looks%20like%20hardcoded%20solution%20for%20%60output%60%20node.%5Cr%5Cn%5Cr%5CnI%27m%20not%20sure%20if%20the%20correct%20format%20is%20single%20or%20dual%20dimension%20%28maybe%20one%20is%20deprecated%29.%20How%20did%20you%20produce%20the%20one%20dimension%20output%20in%20your%20code%3F%22%2C%20%22created_at%22%3A%20%222015-09-26T18%3A03%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20used%20%5BSceniaro.write%28String%20method%29%5D%28http%3A//cucumber.github.io/api/cucumber/jvm/javadoc/cucumber/api/Scenario.html%23write-java.lang.String-%29%20method%20which%20in%20the%20end%20uses%20%5Bthis%20method%5D%28https%3A//github.com/cucumber/gherkin/blob/master/java/src/main/java/gherkin/formatter/JSONFormatter.java%23L135%29.%5Cr%5CnIn%20BeforeAfterHooks%20similar%20to%20%5Bthis%5D%28https%3A//github.com/kowalcj0/cucumber-testng-parallel-selenium/blob/master/src/test/java/cucumber/examples/java/testNG/stepDefinitions/BeforeAfterHooks.java%23L43%29%22%2C%20%22created_at%22%3A%20%222015-09-26T18%3A38%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looking%20at%20this%20code%20I%20understand%20that%20it%20provides%20one%20dimensional%20array%20of%20the%20%60String%60%20so%20I%20guess%20Ruby%20provides%20%60String%5B%5D%60.%20If%20this%20is%20true%20we%20have%20problem%20as%20described%20above%3A%20we%20need%20to%20support%20both%20%3A%28%5Cr%5Cn%5Cr%5CnI%20will%20add%20some%20notes%20to%20this%20PR%22%2C%20%22created_at%22%3A%20%222015-09-26T20%3A14%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20looked%20at%20the%20issue%20again%20and%20it%27s%20a%20bug%20in%20cucumber-ruby%20that%20output%20is%20parsed%20as%20json%20and%20not%20added%20as%20string.%20i%27ve%20also%20notice%20that%20html%20tags%20are%20not%20escaped.%20I%27m%20commiting%20a%20proper%20fix.%22%2C%20%22created_at%22%3A%20%222015-09-28T18%3A31%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20once%20the%20fix%20will%20be%20release%20we%20may%20consider%20to%20drop%20this%20patch%2C%20is%20that%20correct%3F%20However%20we%20probably%20leave%20for%20a%20long%20time%20to%20have%20support%20for%20older%20ruby%20implementations...%22%2C%20%22created_at%22%3A%20%222015-09-28T21%3A13%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20we%20may%20drop%20it%20when%20the%20bug%20is%20fixed%2C%20but%20i%20don%27t%20expect%20it%20to%20be%20any%20time%20soon%20since%20gherkin2%20development%20was%20stopped%2C%20and%20gherkin3%20is%20work-in-progress.%20%22%2C%20%22created_at%22%3A%20%222015-09-30T16%3A47%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40damianszczepanik%20can%20you%20merge%20the%20pull%20request%3F%22%2C%20%22created_at%22%3A%20%222015-10-05T07%3A19%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208ea06323651dbd34078f3a7f8c3df4941d9c0ba9%20.travis.yml%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23discussion_r40497909%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20see%20any%20code%20here%20that%20requires%20such%20change.%5Cr%5Cn%5Cr%5CnBased%20on%20this%20information%20http%3A//docs.travis-ci.com/user/workers/standard-infrastructure/%20I%20don%27t%20see%20any%20reason%20to%20use%20this.%20Please%20explain%22%2C%20%22created_at%22%3A%20%222015-09-26T20%3A16%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22As%20you%20wrote%20here%3A%20https%3A//github.com/damianszczepanik/cucumber-reporting/pull/127%23issuecomment-128846165%20coverage%20uploader%20doesn%27t%20work%20properly%20on%20container-based%20infrastructure.%20Without%20specifing%20that%20sudo%20is%20required%20travis%20%5Broutes%20builds%20of%20linux%20projects%20that%20were%20added%20after%2001.01.2015%20to%20container-based%20infrastructure%5D%28http%3A//docs.travis-ci.com/user/workers/container-based-infrastructure/%29%2C%20so%20it%20won%27t%20work%20for%20new%20contibutors%27%20forks%20of%20the%20project.%20You%27re%20right%20that%20it%20isn%27t%20related%20to%20my%20code%20changes%2C%20so%20if%20you%20prefer%20i%20will%20remove%20it.%20%22%2C%20%22created_at%22%3A%20%222015-09-28T18%3A55%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20might%20be%20a%20problem%20with%20coverage%20but%20anyway%20I%20don%27t%20want%20to%20limit%20forks.%5Cr%5Cn%5Cr%5CnNot%20good%20but%20better%20that%20was%20-%20leave%20it%21%22%2C%20%22created_at%22%3A%20%222015-09-28T21%3A11%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20.travis.yml%3AL1-6%22%7D%2C%20%22Pull%208ea06323651dbd34078f3a7f8c3df4941d9c0ba9%20src/main/java/net/masterthought/cucumber/json/support/StepAdapter.java%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23discussion_r40497915%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22white%20some%20notes%20why%20we%20need%20to%20have%20custom%20deserializer%20-%20for%20the%20future%22%2C%20%22created_at%22%3A%20%222015-09-26T20%3A18%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/support/StepAdapter.java%3AL1-34%22%7D%2C%20%22Pull%208ea06323651dbd34078f3a7f8c3df4941d9c0ba9%20src/main/java/net/masterthought/cucumber/json/support/StepAdapter.java%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23discussion_r40497939%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22export%20this%20as%20private%20final%20String%20OUTPUT_KEY%20%3D%20%5C%22output%5C%22%5Cr%5Cn%5Cr%5Cnso%20you%20can%20use%20this%20here%20and%20below%22%2C%20%22created_at%22%3A%20%222015-09-26T20%3A19%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/support/StepAdapter.java%3AL1-34%22%7D%2C%20%22Pull%208ea06323651dbd34078f3a7f8c3df4941d9c0ba9%20src/main/java/net/masterthought/cucumber/json/support/StepAdapter.java%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/200%23discussion_r40497989%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20wonder%20if%20you%20need%20to%20create%20%60Gson%60%20each%20time%20or%20you%20can%20make%20it%20once%3F%22%2C%20%22created_at%22%3A%20%222015-09-26T20%3A25%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/support/StepAdapter.java%3AL1-34%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/200#issuecomment-143474403'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `87.84%`
> Merging **#200** into **master** will decrease coverage by **-0.05%** as of [`207dbd5`][3]
```diff
@@            master    #200   diff @@
======================================
Files           32      33     +1
Stmts         1148    1160    +12
Branches       161     164     +3
Methods          0       0
======================================
+ Hit           1009    1019    +10
- Partial         43      44     +1
- Missed          96      97     +1
```
> Review entire [Coverage Diff][4] as of [`207dbd5`][3]
[1]: https://codecov.io/github/damianszczepanik/cucumber-reporting?ref=207dbd5b83ebf376d048b8ba36a88400507e9c62
[2]: https://codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions?ref=207dbd5b83ebf376d048b8ba36a88400507e9c62
[3]: https://codecov.io/github/damianszczepanik/cucumber-reporting/commit/207dbd5b83ebf376d048b8ba36a88400507e9c62
[4]: https://codecov.io/github/damianszczepanik/cucumber-reporting/compare/9a0104c3206d3c962dca6429a5e1628e1f8ccf5f...207dbd5b83ebf376d048b8ba36a88400507e9c62
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> I believe there is only one correct output format so there is no need to maintain both. Also I don't the way how it was solved, looks like hardcoded solution for `output` node.
I'm not sure if the correct format is single or dual dimension (maybe one is deprecated). How did you produce the one dimension output in your code?
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> I've used [Sceniaro.write(String method)](http://cucumber.github.io/api/cucumber/jvm/javadoc/cucumber/api/Scenario.html#write-java.lang.String-) method which in the end uses [this method](https://github.com/cucumber/gherkin/blob/master/java/src/main/java/gherkin/formatter/JSONFormatter.java#L135).
In BeforeAfterHooks similar to [this](https://github.com/kowalcj0/cucumber-testng-parallel-selenium/blob/master/src/test/java/cucumber/examples/java/testNG/stepDefinitions/BeforeAfterHooks.java#L43)
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Looking at this code I understand that it provides one dimensional array of the `String` so I guess Ruby provides `String[]`. If this is true we have problem as described above: we need to support both :(
I will add some notes to this PR
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> I've looked at the issue again and it's a bug in cucumber-ruby that output is parsed as json and not added as string. i've also notice that html tags are not escaped. I'm commiting a proper fix.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> So once the fix will be release we may consider to drop this patch, is that correct? However we probably leave for a long time to have support for older ruby implementations...
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> Yes, we may drop it when the bug is fixed, but i don't expect it to be any time soon since gherkin2 development was stopped, and gherkin3 is work-in-progress.
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> @damianszczepanik can you merge the pull request?
- [ ] <a href='#crh-comment-Pull 8ea06323651dbd34078f3a7f8c3df4941d9c0ba9 .travis.yml 1'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/200#discussion_r40497909'>File: .travis.yml:L1-6</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> I don't see any code here that requires such change.
Based on this information http://docs.travis-ci.com/user/workers/standard-infrastructure/ I don't see any reason to use this. Please explain
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> As you wrote here: https://github.com/damianszczepanik/cucumber-reporting/pull/127#issuecomment-128846165 coverage uploader doesn't work properly on container-based infrastructure. Without specifing that sudo is required travis [routes builds of linux projects that were added after 01.01.2015 to container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/), so it won't work for new contibutors' forks of the project. You're right that it isn't related to my code changes, so if you prefer i will remove it.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> That might be a problem with coverage but anyway I don't want to limit forks.
Not good but better that was - leave it!
- [ ] <a href='#crh-comment-Pull 8ea06323651dbd34078f3a7f8c3df4941d9c0ba9 src/main/java/net/masterthought/cucumber/json/support/StepAdapter.java 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/200#discussion_r40497915'>File: src/main/java/net/masterthought/cucumber/json/support/StepAdapter.java:L1-34</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> white some notes why we need to have custom deserializer - for the future
- [ ] <a href='#crh-comment-Pull 8ea06323651dbd34078f3a7f8c3df4941d9c0ba9 src/main/java/net/masterthought/cucumber/json/support/StepAdapter.java 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/200#discussion_r40497939'>File: src/main/java/net/masterthought/cucumber/json/support/StepAdapter.java:L1-34</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> export this as private final String OUTPUT_KEY = "output"
so you can use this here and below
- [ ] <a href='#crh-comment-Pull 8ea06323651dbd34078f3a7f8c3df4941d9c0ba9 src/main/java/net/masterthought/cucumber/json/support/StepAdapter.java 30'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/200#discussion_r40497989'>File: src/main/java/net/masterthought/cucumber/json/support/StepAdapter.java:L1-34</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> I wonder if you need to create `Gson` each time or you can make it once?


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/200?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/200?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/200'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>