### PR TITLE
Copied zip-resources to temporary file before extracting them.

### DIFF
--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -6,6 +6,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.velocity.exception.VelocityException;
 
 import net.masterthought.cucumber.generators.ErrorPage;
@@ -178,10 +179,19 @@ public class ReportBuilder {
     }
 
     private void copyResource(String resourceLocation, String resourceName) throws IOException, URISyntaxException {
-        File source = new File(ReportBuilder.class.getResource("/" + resourceLocation + "/" + resourceName).toURI());
-        Util.unzipToFile(source, reportDirectory.getAbsolutePath());
+    	File tempFile = copyToTempFile(resourceLocation, resourceName);
+        Util.unzipToFile(tempFile, reportDirectory.getAbsolutePath());
+        tempFile.delete();
     }
 
+    private File copyToTempFile(String resourceLocation, String resourceName) throws IOException {
+    	File tempFile = new File(reportDirectory.getAbsoluteFile(), resourceName);
+    	FileUtils.copyInputStreamToFile(
+    			this.getClass().getResourceAsStream("/" + resourceLocation + "/" + resourceName),
+    			tempFile);
+    	return tempFile;
+    }
+    
     private String getPluginUrlPath(String path) {
         return path.isEmpty() ? "/" : path;
     }


### PR DESCRIPTION
I added some code to read the zip-file as a class path resource and copy in to a temporary file before unzipping it. The reason is that when running this from e.g. a maven plugin it is not possible to build a URI that points to the zip-resources inside a jar file. 

I had problems getting maven-cucumber-reporting to run before this, but with this change it works fine.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/215%23issuecomment-154734346%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/215%23issuecomment-154734346%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6087.66%25%60%5Cn%3E%20Merging%20%2A%2A%23215%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20increase%20coverage%20by%20%2A%2A%2B0.06%25%2A%2A%20as%20of%20%5B%601798ea4%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23215%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%2032%20%20%20%20%20%2032%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%201162%20%20%20%201167%20%20%20%20%20%2B5%5Cn%20%20Branches%20%20%20%20%20%20%20165%20%20%20%20%20165%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hit%20%20%20%20%20%20%20%20%20%20%201018%20%20%20%201023%20%20%20%20%20%2B5%5Cn%20%20Partial%20%20%20%20%20%20%20%20%2045%20%20%20%20%20%2045%20%20%20%20%20%20%20%5Cn%20%20Missed%20%20%20%20%20%20%20%20%20%2099%20%20%20%20%20%2099%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%601798ea4%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting%3Fref%3D1798ea4c19a9e75047dad200da9b74127f16f756%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions%3Fref%3D1798ea4c19a9e75047dad200da9b74127f16f756%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/commit/1798ea4c19a9e75047dad200da9b74127f16f756%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/compare/ba7859bad068ce767ea2db98660c8aa6f30a030a...1798ea4c19a9e75047dad200da9b74127f16f756%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222015-11-07T18%3A29%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/215#issuecomment-154734346'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `87.66%`
> Merging **#215** into **master** will increase coverage by **+0.06%** as of [`1798ea4`][3]
```diff
@@            master    #215   diff @@
======================================
Files           32      32
Stmts         1162    1167     +5
Branches       165     165
Methods          0       0
======================================
+ Hit           1018    1023     +5
Partial         45      45
Missed          99      99
```
> Review entire [Coverage Diff][4] as of [`1798ea4`][3]
[1]: https://codecov.io/github/damianszczepanik/cucumber-reporting?ref=1798ea4c19a9e75047dad200da9b74127f16f756
[2]: https://codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions?ref=1798ea4c19a9e75047dad200da9b74127f16f756
[3]: https://codecov.io/github/damianszczepanik/cucumber-reporting/commit/1798ea4c19a9e75047dad200da9b74127f16f756
[4]: https://codecov.io/github/damianszczepanik/cucumber-reporting/compare/ba7859bad068ce767ea2db98660c8aa6f30a030a...1798ea4c19a9e75047dad200da9b74127f16f756
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/215?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/215?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/215'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>