### PR TITLE
Reducing complexity + code clean-up

### DIFF
--- a/src/main/java/net/masterthought/cucumber/Background.java
+++ b/src/main/java/net/masterthought/cucumber/Background.java
@@ -27,8 +27,9 @@ public class Background {
     public int getTotalScenarios() {
         return totalScenarios;
     }
-    public int addTotalScenarios(int add) {
-        return totalScenarios+=add;
+
+    public int incrTotalScenarios() {
+        return totalScenarios++;
     }
 
     public int getTotalScenariosPassed() {

--- a/src/main/java/net/masterthought/cucumber/generators/FeatureReportPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/FeatureReportPage.java
@@ -25,7 +25,7 @@ public class FeatureReportPage extends AbstractPage {
                 contextMap.putAll(getGeneralParameters());
                 contextMap.put("parallel", ReportBuilder.isParallel());
                 contextMap.put("feature", feature);
-                contextMap.put("report_status_colour", reportInformation.getReportStatusColour(feature));
+                contextMap.put("report_status_colour", feature.getStatus().color);
                 contextMap.put("scenarios", feature.getScenarios());
                 contextMap.put("artifactsEnabled", ConfigurationOptions.instance().artifactsEnabled());
 

--- a/src/main/java/net/masterthought/cucumber/generators/TagReportPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/TagReportPage.java
@@ -17,7 +17,7 @@ public class TagReportPage extends AbstractPage {
             super.generatePage();
 
             contextMap.put("tag", tagObject);
-            contextMap.put("report_status_colour", reportInformation.getTagReportStatusColour(tagObject));
+            contextMap.put("report_status_colour", tagObject.getStatus().color);
 
             generateReport(tagObject.getFileName());
         }

--- a/src/main/java/net/masterthought/cucumber/json/Feature.java
+++ b/src/main/java/net/masterthought/cucumber/json/Feature.java
@@ -134,7 +134,7 @@ public class Feature {
         if (elements != null) {
             List<Scenario> elementList = new ArrayList<Scenario>();
             for (Scenario element : elements) {
-                if (!element.isBackground()) {
+                if (element.isScenario()) {
                     elementList.add(element);
                 }
             }
@@ -208,7 +208,7 @@ public class Feature {
     }
 
     private void calculateScenarioStats(List<Scenario> passedScenarios, List<Scenario> failedScenarios, Scenario element) {
-        if (!element.isBackground()) {
+        if (element.isScenario()) {
             if (element.getStatus() == Status.PASSED) {
                 passedScenarios.add(element);
             } else if (element.getStatus() == Status.FAILED) {

--- a/src/main/java/net/masterthought/cucumber/json/Scenario.java
+++ b/src/main/java/net/masterthought/cucumber/json/Scenario.java
@@ -12,8 +12,8 @@ import net.masterthought.cucumber.util.Util;
 
 public class Scenario {
 
-    /** Refers to background step. Is defined in json file. */
-    private final static String BACKGROUND_TYPE = "background";
+    /** Refers to scenario (not background) step. Is defined in json file. */
+    private final static String SCENARIO_TYPE = "scenario";
 
     private final String id = null;
     private final String name = null;
@@ -125,8 +125,8 @@ public class Scenario {
         return steps.length > 0;
     }
 
-    public boolean isBackground() {
-        return BACKGROUND_TYPE.equals(type);
+    public boolean isScenario() {
+        return SCENARIO_TYPE.equals(type);
     }
 
     public String getTagsList() {

--- a/src/main/java/net/masterthought/cucumber/json/Tag.java
+++ b/src/main/java/net/masterthought/cucumber/json/Tag.java
@@ -2,7 +2,7 @@ package net.masterthought.cucumber.json;
 
 public class Tag {
 
-    public final String name = null;
+    private final String name = null;
 
     public String getName() {
         return name;

--- a/src/test/java/net/masterthought/cucumber/ReportInformationTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportInformationTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import net.masterthought.cucumber.json.Feature;
+import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.TagObject;
 
 public class ReportInformationTest {
@@ -110,12 +111,12 @@ public class ReportInformationTest {
 
     @Test
     public void shouldReturnReportStatusColour() {
-        assertThat(reportInformation.getReportStatusColour(reportInformation.getFeatures().get(0)), is("#00CE00"));
+        assertThat(reportInformation.getFeatures().get(0).getStatus().color, is(Status.PASSED.color));
     }
 
     @Test
     public void shouldReturnTagReportStatusColour() {
-        assertThat(reportInformation.getTagReportStatusColour(reportInformation.getTags().get(0)), is("#00CE00"));
+        assertThat(reportInformation.getTags().get(0).getStatus().color, is(Status.PASSED.color));
     }
 
     @Test


### PR DESCRIPTION
Issue #122
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/217%23issuecomment-155218460%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/217%23issuecomment-155219887%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/217%23issuecomment-155218460%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20first%20step%20of%20making%20generation%20process%20shorter%20-%20some%20methods%20with%20O%28n%29%20complexity%20were%20executed%20all%20the%20time.%20Some%20other%20are%20still%20there%20but%20it%20takes%20time%20to%20make%20sure%20that%20there%20is%20no%20regression%22%2C%20%22created_at%22%3A%20%222015-11-09T22%3A25%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6087.63%25%60%5Cn%3E%20Merging%20%2A%2A%23217%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20decrease%20coverage%20by%20%2A%2A-0.03%25%2A%2A%20as%20of%20%5B%60d79a5a9%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23217%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%2032%20%20%20%20%20%2032%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%201167%20%20%20%201165%20%20%20%20%20-2%5Cn%20%20Branches%20%20%20%20%20%20%20165%20%20%20%20%20162%20%20%20%20%20-3%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hit%20%20%20%20%20%20%20%20%20%20%201023%20%20%20%201021%20%20%20%20%20-2%5Cn%20%20Partial%20%20%20%20%20%20%20%20%2045%20%20%20%20%20%2045%20%20%20%20%20%20%20%5Cn%20%20Missed%20%20%20%20%20%20%20%20%20%2099%20%20%20%20%20%2099%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%60d79a5a9%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting%3Fref%3Dd79a5a9bf7a93b2f429586a3cab08cfd3bea0143%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions%3Fref%3Dd79a5a9bf7a93b2f429586a3cab08cfd3bea0143%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/commit/d79a5a9bf7a93b2f429586a3cab08cfd3bea0143%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/compare/893726c59ec162a7e6167c7121edfb19c31bc2a5...d79a5a9bf7a93b2f429586a3cab08cfd3bea0143%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222015-11-09T22%3A31%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/217#issuecomment-155218460'>General Comment</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> This is first step of making generation process shorter - some methods with O(n) complexity were executed all the time. Some other are still there but it takes time to make sure that there is no regression
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `87.63%`
> Merging **#217** into **master** will decrease coverage by **-0.03%** as of [`d79a5a9`][3]
```diff
@@            master    #217   diff @@
======================================
Files           32      32
Stmts         1167    1165     -2
Branches       165     162     -3
Methods          0       0
======================================
- Hit           1023    1021     -2
Partial         45      45
Missed          99      99
```
> Review entire [Coverage Diff][4] as of [`d79a5a9`][3]
[1]: https://codecov.io/github/damianszczepanik/cucumber-reporting?ref=d79a5a9bf7a93b2f429586a3cab08cfd3bea0143
[2]: https://codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions?ref=d79a5a9bf7a93b2f429586a3cab08cfd3bea0143
[3]: https://codecov.io/github/damianszczepanik/cucumber-reporting/commit/d79a5a9bf7a93b2f429586a3cab08cfd3bea0143
[4]: https://codecov.io/github/damianszczepanik/cucumber-reporting/compare/893726c59ec162a7e6167c7121edfb19c31bc2a5...d79a5a9bf7a93b2f429586a3cab08cfd3bea0143
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/217?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/217?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/217'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>