### PR TITLE
Methods in TagObject count values/counters/stats at once, not each me were invoked

### DIFF
--- a/src/main/java/net/masterthought/cucumber/ReportInformation.java
+++ b/src/main/java/net/masterthought/cucumber/ReportInformation.java
@@ -311,14 +311,14 @@ public class ReportInformation {
         return counter;
     }
 
-    private void addScenarioUnlessExists(List<ScenarioTag> scenarioList, ScenarioTag scenarioToAdd) {
-        for (ScenarioTag scenarioTag : scenarioList) {
+    private void addScenarioUnlessExists(TagObject tagObject, ScenarioTag scenarioToAdd) {
+        for (ScenarioTag scenarioTag : tagObject.getScenarios()) {
             if (scenarioTag.getScenario().getId().equals(scenarioToAdd.getScenario().getId())
                     && scenarioTag.getScenario().equals(scenarioToAdd.getScenario())) {
                 return;
             }
         }
-        scenarioList.add(scenarioToAdd);
+        tagObject.addScenarios(scenarioToAdd);
     }
 
     private void addScenarioTagsToTagMap(Tag[] scenarioTagsAllScenarios, List<ScenarioTag> scenariosWithoutBackground) {
@@ -328,7 +328,7 @@ public class ReportInformation {
             for (ScenarioTag scenarioTag : scenariosWithoutBackground) {
                 for (Tag tag2 : scenarioTag.getScenario().getTags()) {
                     if (tag2.getName().equals(tag.getName())) {
-                        addScenarioUnlessExists(tagObject.getScenarios(), scenarioTag);
+                        addScenarioUnlessExists(tagObject, scenarioTag);
                         break;
                     }
                 }

--- a/src/main/java/net/masterthought/cucumber/json/Feature.java
+++ b/src/main/java/net/masterthought/cucumber/json/Feature.java
@@ -171,7 +171,7 @@ public class Feature {
         return stepResults.getNumberOfUndefined();
     }
 
-    public String getDurationOfSteps() {
+    public String getTotalDuration() {
         return stepResults.getTotalDurationAsString();
     }
 

--- a/src/main/resources/templates/pages/featureOverview.vm
+++ b/src/main/resources/templates/pages/featureOverview.vm
@@ -369,7 +369,7 @@ if (AC_FL_RunContent == 0 || DetectFlashVer == 0) {
           <td id="stats-number-steps-pending-$sf"   #if($feature.getNumberOfPending() > 0)   style="background-color:#FBB907;" #end>$feature.getNumberOfPending()</td>
           <td id="stats-number-steps-undefined-$sf" #if($feature.getNumberOfUndefined() > 0) style="background-color:#FBB957;" #end>$feature.getNumberOfUndefined()</td>
           <td id="stats-number-steps-missing-$sf"   #if($feature.getNumberOfMissing() > 0)   style="background-color:#FBB9A7;" #end>$feature.getNumberOfMissing()</td>
-          <td id="stats-duration-$sf" style="text-align:right;white-space:nowrap">$feature.getDurationOfSteps()</td>
+          <td id="stats-duration-$sf" style="text-align:right;white-space:nowrap">$feature.getTotalDuration()</td>
           <td id="stats-status-$sf" style="background-color: $bgcolour;">$feature.getRawStatus()</td>
           </tr>
       #end

--- a/src/main/resources/templates/pages/featureReport.vm
+++ b/src/main/resources/templates/pages/featureReport.vm
@@ -44,7 +44,7 @@
                         <td id="stats-number-steps-pending-$sf"   #if($feature.getNumberOfPending() > 0)   style="background-color:#FBB907;" #end>$feature.getNumberOfPending()</td>
                         <td id="stats-number-steps-undefined-$sf" #if($feature.getNumberOfUndefined() > 0) style="background-color:#FBB957;" #end>$feature.getNumberOfUndefined()</td>
                         <td id="stats-number-steps-missing-$sf"   #if($feature.getNumberOfMissing() > 0)   style="background-color:#FBB9A7;" #end>$feature.getNumberOfMissing()</td>
-                        <td id="stats-duration-$sf" style="text-align:right;white-space:nowrap">$feature.getDurationOfSteps()</td>
+                        <td id="stats-duration-$sf" style="text-align:right;white-space:nowrap">$feature.getTotalDuration()</td>
                         <td id="stats-status-$sf" style="background-color: $report_status_colour;">$feature.getRawStatus()</td></tr>
 
                 </table>

--- a/src/main/resources/templates/pages/tagOverview.vm
+++ b/src/main/resources/templates/pages/tagOverview.vm
@@ -278,7 +278,7 @@
                         <td #if($tag.getNumberOfPending() > 0)   style="background-color:#FBB907;" #end>$tag.getNumberOfPending()</td>
                         <td #if($tag.getNumberOfUndefined() > 0) style="background-color:#FBB957;" #end>$tag.getNumberOfUndefined()</td>
                         <td #if($tag.getNumberOfMissing() > 0)   style="background-color:#FBB9A7;" #end>$tag.getNumberOfMissing()</td>
-                        <td style="text-align:right;white-space:nowrap">$tag.getDurationOfSteps()</td>
+                        <td style="text-align:right;white-space:nowrap">$tag.getTotalDuration()</td>
                         <td style="background-color: $bgcolour;">$tag.getRawStatus()</td>
                     </tr>
                 #end

--- a/src/main/resources/templates/pages/tagReport.vm
+++ b/src/main/resources/templates/pages/tagReport.vm
@@ -34,7 +34,7 @@
                         <td #if($tag.getNumberOfPending() > 0)   style="background-color:#FBB907;" #end>$tag.getNumberOfPending()</td>
                         <td #if($tag.getNumberOfUndefined() > 0) style="background-color:#FBB957;" #end>$tag.getNumberOfUndefined()</td>
                         <td #if($tag.getNumberOfMissing() > 0)   style="background-color:#FBB9A7;" #end>$tag.getNumberOfMissing()</td>
-                        <td style="text-align:right;white-space:nowrap">$tag.getDurationOfSteps()</td>
+                        <td style="text-align:right;white-space:nowrap">$tag.getTotalDuration()</td>
                         <td style="background-color: $report_status_colour;">$tag.getRawStatus()</td></tr>
 
                 </table>

--- a/src/test/java/net/masterthought/cucumber/FeatureTest.java
+++ b/src/test/java/net/masterthought/cucumber/FeatureTest.java
@@ -114,8 +114,8 @@ public class FeatureTest {
     }
 
     @Test
-    public void shouldGetDurationOfSteps() {
-        assertThat(passingFeature.getDurationOfSteps(), StringContains.containsString("ms"));
+    public void shouldgetTotalDuration() {
+        assertThat(passingFeature.getTotalDuration(), StringContains.containsString("ms"));
     }
 
     @Test


### PR DESCRIPTION
Issue #122
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/223?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/223'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>