### PR TITLE
Error message is not formatted

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/Step.java
+++ b/src/main/java/net/masterthought/cucumber/json/Step.java
@@ -98,7 +98,8 @@ public class Step implements ResultsWithMatch {
         sb.append("</span>");
 
         if (status == Status.FAILED || status == Status.MISSING) {
-            sb.append("<div class=\"step-error-message\"><pre class=\"step-error-message-content\">").append(formatError(errorMessage)).append("</pre></div>");
+            sb.append("<div class=\"step-error-message\"><pre class=\"step-error-message-content\">")
+                    .append(convertEOL(errorMessage)).append("</pre></div>");
 
         }
         sb.append("</div>");
@@ -122,18 +123,12 @@ public class Step implements ResultsWithMatch {
                 + doc_string.getEscapedValue() + "</div></div>";
     }
 
-    private String formatError(String errorMessage) {
-        String result = errorMessage;
-        if (errorMessage != null && !errorMessage.isEmpty()) {
-            if (errorMessage.startsWith( "<" )) {
-                result = errorMessage.replaceAll( "\\\\n", "<br/>" );
-            } else {
-                int id = ++labelCount;
-                String[] headLineAndTrace = StringUtils.split( errorMessage , "\n", 2 );
-                result = String.format( "<input class=\"collapse\" id=\"_%d\" type=\"checkbox\"><label for=\"_%d\">%s</label><div>%s</div>", id, id, headLineAndTrace[0], headLineAndTrace[1].replaceAll( "\n", "<br/>" ) );
-            }
+    private String convertEOL(String errorMessage) {
+        if (StringUtils.isEmpty(errorMessage)) {
+            return StringUtils.EMPTY;
+        } else {
+            return errorMessage.replaceAll("\\\\n", "<br/>");
         }
-        return result;
     }
 
     public String getAttachments() {


### PR DESCRIPTION
Issue #252
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/253%23issuecomment-161744485%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/253%23issuecomment-161744485%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6088.23%25%60%5Cn%3E%20Merging%20%2A%2A%23253%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20decrease%20coverage%20by%20%2A%2A-0.15%25%2A%2A%20as%20of%20%5B%60d03b104%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23253%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%2029%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%20%20956%20%20%20%20%20952%20%20%20%20%20-4%5Cn%20%20Branches%20%20%20%20%20%20%20%2099%20%20%20%20%20%2098%20%20%20%20%20-1%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hit%20%20%20%20%20%20%20%20%20%20%20%20845%20%20%20%20%20840%20%20%20%20%20-5%5Cn%20%20Partial%20%20%20%20%20%20%20%20%2020%20%20%20%20%20%2020%20%20%20%20%20%20%20%5Cn-%20Missed%20%20%20%20%20%20%20%20%20%2091%20%20%20%20%20%2092%20%20%20%20%20%2B1%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%60d03b104%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting%3Fref%3Dd03b104edce5db7c483ad1d82e03265ecd9728a8%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions%3Fref%3Dd03b104edce5db7c483ad1d82e03265ecd9728a8%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/commit/d03b104edce5db7c483ad1d82e03265ecd9728a8%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/compare/5a6303b1567d1862c4f66d0b7748f39d37254593...d03b104edce5db7c483ad1d82e03265ecd9728a8%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222015-12-03T18%3A47%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/253#issuecomment-161744485'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `88.23%`
> Merging **#253** into **master** will decrease coverage by **-0.15%** as of [`d03b104`][3]
```diff
@@            master    #253   diff @@
======================================
Files           29      29
Stmts          956     952     -4
Branches        99      98     -1
Methods          0       0
======================================
- Hit            845     840     -5
Partial         20      20
- Missed          91      92     +1
```
> Review entire [Coverage Diff][4] as of [`d03b104`][3]
[1]: https://codecov.io/github/damianszczepanik/cucumber-reporting?ref=d03b104edce5db7c483ad1d82e03265ecd9728a8
[2]: https://codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions?ref=d03b104edce5db7c483ad1d82e03265ecd9728a8
[3]: https://codecov.io/github/damianszczepanik/cucumber-reporting/commit/d03b104edce5db7c483ad1d82e03265ecd9728a8
[4]: https://codecov.io/github/damianszczepanik/cucumber-reporting/compare/5a6303b1567d1862c4f66d0b7748f39d37254593...d03b104edce5db7c483ad1d82e03265ecd9728a8
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/253?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/253?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/253'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>