### PR TITLE
Handling different location object from cucumber-ruby json.

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/Match.java
+++ b/src/main/java/net/masterthought/cucumber/json/Match.java
@@ -1,13 +1,82 @@
 package net.masterthought.cucumber.json;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.LinkedList;
+import java.util.List;
+
 public class Match {
 
     // Start: attributes from JSON file report
-    private final String location = null;
+    private final JsonElement location = null;
     // End: attributes from JSON file report
 
     public String getLocation() {
-        return location;
+        if (location == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        JsonObject locationObject;
+
+        if (location.isJsonPrimitive() && location.getAsJsonPrimitive().isString()) {
+            return location.getAsString();
+        } else {
+            locationObject = location.getAsJsonObject();
+            String filename;
+            if (locationObject.has("file") && locationObject.get("file").getAsJsonPrimitive().isString()) {
+                filename = locationObject.get("file").getAsString();
+            } else if (locationObject.has("filepath") && locationObject.get("filepath").isJsonObject()) {
+                JsonObject filePath = locationObject.get("filepath").getAsJsonObject();
+                if (filePath.has("filename") && filePath.get("filename").getAsJsonPrimitive().isString()) {
+                    filename = filePath.get("filename").getAsString();
+                } else {
+                    return null;
+                }
+            } else {
+                return null;
+            }
+
+            sb.append(filename).append(":");
+
+            LinkedList<Integer> lineList = new LinkedList<>();
+            if (locationObject.has("lines") && locationObject.get("lines").isJsonObject()) {
+                JsonObject lines = locationObject.get("lines").getAsJsonObject();
+                if (lines.has("data") && lines.get("data").isJsonArray()) {
+                    JsonArray data = lines.get("data").getAsJsonArray();
+                    for (JsonElement lineElement : data) {
+                        try {
+                            int line = Integer.parseInt(lineElement.getAsString());
+                            lineList.add(line);
+                        } catch (NumberFormatException e) {
+                            return null;
+                        }
+                    }
+                } else {
+                    return null;
+                }
+            } else {
+                return null;
+            }
+
+            if (lineList.size() > 1 && areConsecutive(lineList)) {
+                sb.append(lineList.getFirst()).append("..").append(lineList.getLast());
+            } else {
+                sb.append(StringUtils.join(lineList, ','));
+            }
+            return sb.toString();
+        }
     }
 
+    private boolean areConsecutive(List<Integer> lines) {
+        int firstLine = lines.get(0);
+        for (int i = 1; i < lines.size(); i++) {
+            if (!(lines.get(i).equals(firstLine + i))) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/test/java/net/masterthought/cucumber/LocationTest.java
+++ b/src/test/java/net/masterthought/cucumber/LocationTest.java
@@ -1,0 +1,63 @@
+package net.masterthought.cucumber;
+
+import net.masterthought.cucumber.json.Feature;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.masterthought.cucumber.FileReaderUtil.getAbsolutePathFromResource;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class LocationTest {
+
+    private final Configuration configuration = new Configuration(new File(""), "testProject");
+
+
+    @Test
+    public void shouldHandleBrokenLocation() throws IOException {
+
+        List<String> jsonReports = new ArrayList<>();
+        jsonReports.add(getAbsolutePathFromResource("net/masterthought/cucumber/location_formats.json"));
+
+        ReportParser reportParser = new ReportParser(configuration);
+        List<Feature> features = reportParser.parseJsonResults(jsonReports);
+
+        String location = features.get(0).getElements()[0].getSteps()[0].getMatch().getLocation();
+        assertThat(location,is("features/step_definitions/selenium/selenium.rb:5"));
+
+        String locationWithRange = features.get(0).getElements()[0].getAfter()[0].getMatch().getLocation();
+        assertThat(locationWithRange,is("json_spec-1.1.4/lib/json_spec/cucumber.rb:5..7"));
+
+        String locationNonConsecutive = features.get(0).getElements()[0].getSteps()[1].getMatch().getLocation();
+        assertThat(locationNonConsecutive,is("features/step_definitions/selenium/selenium.rb:5,7,8"));
+
+        String missingLocation = features.get(0).getElements()[0].getSteps()[2].getMatch().getLocation();
+        assertThat(missingLocation,is(nullValue()));
+
+        String correctLocation = features.get(0).getElements()[0].getSteps()[3].getMatch().getLocation();
+        assertThat(correctLocation, is("cucumber.rb:6"));
+
+        String anotherLocationType = features.get(0).getElements()[0].getAfter()[1].getMatch().getLocation();
+        assertThat(anotherLocationType, is("ruby/core/support/hooks.rb:19"));
+
+        String invalidFormat1 = features.get(0).getElements()[0].getAfter()[2].getMatch().getLocation();
+        assertThat(invalidFormat1,is(nullValue()));
+
+        String invalidFormat2 = features.get(0).getElements()[0].getAfter()[3].getMatch().getLocation();
+        assertThat(invalidFormat2,is(nullValue()));
+
+        String invalidFormat3 = features.get(0).getElements()[0].getAfter()[4].getMatch().getLocation();
+        assertThat(invalidFormat3,is(nullValue()));
+
+        String invalidFormat4 = features.get(0).getElements()[0].getAfter()[5].getMatch().getLocation();
+        assertThat(invalidFormat4,is(nullValue()));
+
+        String invalidFormat5 = features.get(0).getElements()[0].getAfter()[6].getMatch().getLocation();
+        assertThat(invalidFormat5,is(nullValue()));
+    }
+}

--- a/src/test/resources/net/masterthought/cucumber/location_formats.json
+++ b/src/test/resources/net/masterthought/cucumber/location_formats.json
@@ -1,0 +1,211 @@
+[
+  {
+    "uri": "features/selenium.feature",
+    "id": "test",
+    "keyword": "Feature",
+    "name": "test",
+    "description": "",
+    "line": 1,
+    "elements": [
+      {
+        "id": "test;test1",
+        "keyword": "Scenario",
+        "name": "test1",
+        "description": "",
+        "line": 2,
+        "type": "scenario",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "We are using selenium to test with chrome",
+            "line": 3,
+            "match": {
+              "location": {
+                "filepath": {
+                  "filename": "features/step_definitions/selenium/selenium.rb"
+                },
+                "lines": {
+                  "data": [
+                    "5"
+                  ]
+                }
+              }
+            },
+            "result": {
+              "status": "passed",
+              "duration": 1717150000
+            }
+          },
+          {
+            "keyword": "And ",
+            "name": "Something",
+            "line": 4,
+            "match": {
+              "location": {
+                "filepath": {
+                  "filename": "features/step_definitions/selenium/selenium.rb"
+                },
+                "lines": {
+                  "data": [
+                    "5",
+                    "7",
+                    "8"
+                  ]
+                }
+              }
+            },
+            "result": {
+              "status": "passed",
+              "duration": 1717150000
+            }
+          },
+          {
+            "keyword": "Then ",
+            "name": "Something else",
+            "line": 5,
+            "match": {
+            },
+            "result": {
+              "status": "passed",
+              "duration": 1717150000
+            }
+          },
+
+          {
+            "keyword": "And ",
+            "name": "blabla",
+            "line": 6,
+            "match": {
+              "location": "cucumber.rb:6"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 1717150000
+            }
+          }
+        ],
+        "after": [
+          {
+            "match": {
+              "location": {
+                "filepath": {
+                  "filename": "json_spec-1.1.4/lib/json_spec/cucumber.rb"
+                },
+                "lines": {
+                  "data": [
+                    "5",
+                    "6",
+                    "7"
+                  ]
+                }
+              }
+            },
+            "result": {
+              "status": "passed",
+              "duration": 0
+            }
+          },
+          {
+            "match": {
+              "location": {
+                "file": "ruby/core/support/hooks.rb",
+                "lines": {
+                  "data": [
+                    19
+                  ]
+                }
+              }
+            },
+            "result": {
+              "status": "failed",
+              "error_message": "undefined method `cookies' for nil:NilClass (NoMethodError)",
+              "duration": 128000
+            }
+          },
+          {
+            "match": {
+              "location": {
+                "file": 5,
+                "lines": {
+                  "data": [
+                    19
+                  ]
+                }
+              }
+            },
+            "result": {
+              "status": "failed",
+              "error_message": "undefined method `cookies' for nil:NilClass (NoMethodError)",
+              "duration": 128000
+            }
+          },
+          {
+            "match": {
+              "location": {
+                "filepath": {
+                  "filename": 5
+                },
+                "lines": {
+                  "data": [
+                    19
+                  ]
+                }
+              }
+            },
+            "result": {
+              "status": "failed",
+              "error_message": "undefined method `cookies' for nil:NilClass (NoMethodError)",
+              "duration": 128000
+            }
+          },
+          {
+            "match": {
+              "location": {
+                "file": "cucumber.rb:12",
+                "lines": {
+                  "data": [
+                    "x"
+                  ]
+                }
+              }
+            },
+            "result": {
+              "status": "failed",
+              "error_message": "undefined method `cookies' for nil:NilClass (NoMethodError)",
+              "duration": 128000
+            }
+          },
+          {
+            "match": {
+              "location": {
+                "file": "cucumber.rb:12",
+                "lines": {
+                  "data": 5
+                }
+              }
+            },
+            "result": {
+              "status": "failed",
+              "error_message": "undefined method `cookies' for nil:NilClass (NoMethodError)",
+              "duration": 128000
+            }
+          },
+
+          {
+            "match": {
+              "location": {
+                "file": "cucumber.rb:12"
+              }
+            },
+            "result": {
+              "status": "failed",
+              "error_message": "undefined method `cookies' for nil:NilClass (NoMethodError)",
+              "duration": 128000
+            }
+          }
+
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-175429133%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51052843%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51053213%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51053293%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51053815%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51054481%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51054635%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51055019%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51174345%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51174700%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51174898%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51175051%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51179469%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51188877%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51189248%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-177830058%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51478192%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51478197%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51478269%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51478622%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51478825%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51479005%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51479348%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-178186614%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51488127%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51489192%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51489967%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51493133%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-182769362%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-182827508%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-182884546%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-182919840%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-183001400%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r52645840%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-184561656%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r52979692%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r52982615%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r53051761%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r53051883%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r53052008%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r53052333%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r53052752%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r53055027%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-187111091%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-187114502%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-187161960%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-191153446%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r55257960%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r55667361%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2041fc4cf07e188c454a0b66034b0f9b940a45a3b6%20src/main/java/net/masterthought/cucumber/json/Match.java%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51478197%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22empty%20or%20null%3F%22%2C%20%22created_at%22%3A%20%222016-02-01T20%3A48%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22gson%20leaves%20location%20as%20null%20when%20this%20element%20is%20not%20found.%5Cr%5CnWe%20have%20to%20return%20empty%20string%2C%20because%20of%20usage%20of%20.getLocation%28%29%20without%20null%20checking%20in%20net/masterthought/cucumber/json/Element.java%3A174%22%2C%20%22created_at%22%3A%20%222016-02-01T22%3A38%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-56%22%7D%2C%20%22Pull%2088992c94486bf4fd2a4e2ab95249d5f8e4c8dd7b%20src/main/java/net/masterthought/cucumber/json/Match.java%2065%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r52979692%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%21%5BCodacy%5D%28https%3A//www.codacy.com/versioned/images/favicon.png%29%20Issue%20found%3A%20%5BAn%20empty%20statement%20%28semicolon%29%20not%20part%20of%20a%20loop%5D%28https%3A//www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2048973241/issues/source%3Fbid%3D3059308%26fileBranchId%3D3097149%23l63%29%22%2C%20%22created_at%22%3A%20%222016-02-16T08%3A26%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222016-02-16T08%3A57%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-83%22%7D%2C%20%22Pull%2041fc4cf07e188c454a0b66034b0f9b940a45a3b6%20src/main/java/net/masterthought/cucumber/json/Match.java%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51478269%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22List%3CInteger%3E%20should%20be%20fine%22%2C%20%22created_at%22%3A%20%222016-02-01T20%3A49%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22if%20i%20change%20it%20to%20List%20i%20would%20have%20to%20change%20lineList.getFirst%28%29%20and%20lineList.getLast%28%29%20to%20%5Cr%5CnlineList.get%280%29%20and%20lineList.get%28lineList.size%28%29-1%29%20%20which%20are%20less%20readable%22%2C%20%22created_at%22%3A%20%222016-02-01T22%3A00%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-56%22%7D%2C%20%22Pull%2088a3862cd056ad0a595f2059bc5bda603cd4bdd0%20src/test/java/net/masterthought/cucumber/LocationTest.java%2048%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r53052752%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20code%20%60features.get%280%29.getElements%28%29%5B0%5D%60%20is%20repeated%20all%20the%20time%2C%20save%20in%20temp%20variable%22%2C%20%22created_at%22%3A%20%222016-02-16T18%3A16%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/java/net/masterthought/cucumber/LocationTest.java%3AL1-64%22%7D%2C%20%22Pull%2088a3862cd056ad0a595f2059bc5bda603cd4bdd0%20src/main/java/net/masterthought/cucumber/json/Match.java%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r53055027%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%21%5BCodacy%5D%28https%3A//www.codacy.com/versioned/images/favicon.png%29%20Issue%20found%3A%20%5BThe%20method%20getLocation%28%29%20has%20an%20NPath%20complexity%20of%20298%5D%28https%3A//www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2054722975/issues/source%3Fbid%3D3059308%26fileBranchId%3D3097149%23l17%29%22%2C%20%22created_at%22%3A%20%222016-02-16T18%3A31%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-83%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23issuecomment-175429133%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6089.56%25%60%5Cn%3E%20Merging%20%2A%2A%23316%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20decrease%20coverage%20by%20%2A%2A-0.05%25%2A%2A%20as%20of%20%5B%606c054d4%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23316%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%2028%20%20%20%20%20%2028%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%20%20799%20%20%20%20%20805%20%20%20%20%20%2B6%5Cn%20%20Branches%20%20%20%20%20%20%20%2099%20%20%20%20%20100%20%20%20%20%20%2B1%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hit%20%20%20%20%20%20%20%20%20%20%20%20716%20%20%20%20%20721%20%20%20%20%20%2B5%5Cn-%20Partial%20%20%20%20%20%20%20%20%2025%20%20%20%20%20%2026%20%20%20%20%20%2B1%5Cn%20%20Missed%20%20%20%20%20%20%20%20%20%2058%20%20%20%20%20%2058%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%606c054d4%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting%3Fref%3D6c054d4bc8e1091e720594cd114ab068e7619586%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions%3Fref%3D6c054d4bc8e1091e720594cd114ab068e7619586%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/commit/6c054d4bc8e1091e720594cd114ab068e7619586%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/damianszczepanik/cucumber-reporting/compare/910f506c35a9d849f15b3855c68c7fe4ee2881c8...6c054d4bc8e1091e720594cd114ab068e7619586%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222016-01-27T06%3A31%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40damianszczepanik%20can%20you%20recheck%3F%22%2C%20%22created_at%22%3A%20%222016-02-01T07%3A53%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20added%20comments%2C%20also%20you%20don%27t%20have%20default%20formatter%20that%20puts%20spaces%20between%20brackets%20and%20operators%22%2C%20%22created_at%22%3A%20%222016-02-01T20%3A59%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40damianszczepanik%20can%20you%20recheck%3F%22%2C%20%22created_at%22%3A%20%222016-02-11T08%3A47%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hey%20guys%2C%20any%20ideea%20when%20this%20fixed%20will%20be%20released%3F%20I%27m%20still%20facing%20https%3A//github.com/damianszczepanik/cucumber-reporting-jenkins/issues/61%5Cr%5Cn%5Cr%5CnThanks%2C%20%5Cr%5CnSergiu%22%2C%20%22created_at%22%3A%20%222016-02-11T12%3A02%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12070051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/hojbota%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20believe%20the%20pr%20is%20ready%20to%20be%20merged.%20%5Cr%5CnSergiu%20if%20you%20are%20in%20a%20hurry%20you%20can%20build%20the%20plugin%20yourself.%5Cr%5CnHere%27s%20commands%20for%20it.%5Cr%5Cn%60%60%60bash%5Cr%5Cngit%20clone%20-b%20%20location%20https%3A//github.com/tommywo/cucumber-reporting.git%5Cr%5Cngit%20clone%20https%3A//github.com/jenkinsci/cucumber-reports-plugin.git%5Cr%5Cncd%20cucumber-reporting%5Cr%5Cnmvn%20install%5Cr%5Cncd%20../cucumber-reports-plugin%5Ct%5Cr%5Cnmvn%20versions%3Aset%20-DartifactId%3Dcucumber-reporting%20-DgroupId%3Dnet.masterthought%20-DoldVersion%3D1.3.0%20-DnewVersion%3D1.3.0-SNAPSHOT%20%5Cr%5Cnmvn%20package%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-02-11T14%3A22%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%2C%20thank%20you%2C%20I%20tried%20it%20and%20got%20this%20error%3A%20%5Cr%5Cn%5Cr%5Cnjava.lang.NullPointerException%5Cr%5Cn%5Ctat%20net.masterthought.cucumber.json.Match.getLocation%28Match.java%3A24%29%5Cr%5Cn%5Ctat%20net.masterthought.cucumber.json.Element.calculateAttachments%28Element.java%3A174%29%5Cr%5Cn%5Ctat%20net.masterthought.cucumber.json.Element.setMedaData%28Element.java%3A149%29%5Cr%5Cn%5Ctat%20net.masterthought.cucumber.json.Feature.setMetaData%28Feature.java%3A141%29%5Cr%5Cn%5Ctat%20net.masterthought.cucumber.ReportParser.setMetadata%28ReportParser.java%3A51%29%5Cr%5Cn%5Ctat%20net.masterthought.cucumber.ReportParser.parseJsonResults%28ReportParser.java%3A39%29%5Cr%5Cn%5Ctat%20net.masterthought.cucumber.ReportBuilder.generateReports%28ReportBuilder.java%3A48%29%5Cr%5Cn%5Ctat%20net.masterthought.jenkins.CucumberReportPublisher.perform%28CucumberReportPublisher.java%3A134%29%5Cr%5Cn%5Ctat%20hudson.tasks.BuildStepMonitor%241.perform%28BuildStepMonitor.java%3A20%29%5Cr%5Cn%5Ctat%20hudson.model.AbstractBuild%24AbstractBuildExecution.perform%28AbstractBuild.java%3A782%29%5Cr%5Cn%5Ctat%20hudson.model.AbstractBuild%24AbstractBuildExecution.performAllBuildSteps%28AbstractBuild.java%3A723%29%5Cr%5Cn%5Ctat%20hudson.model.Build%24BuildExecution.post2%28Build.java%3A185%29%5Cr%5Cn%5Ctat%20hudson.model.AbstractBuild%24AbstractBuildExecution.post%28AbstractBuild.java%3A668%29%5Cr%5Cn%5Ctat%20hudson.model.Run.execute%28Run.java%3A1763%29%5Cr%5Cn%5Ctat%20hudson.model.FreeStyleBuild.run%28FreeStyleBuild.java%3A43%29%5Cr%5Cn%5Ctat%20hudson.model.ResourceController.execute%28ResourceController.java%3A98%29%5Cr%5Cn%5Ctat%20hudson.model.Executor.run%28Executor.java%3A410%29%5Cr%5Cn%5Cr%5Cnattached%20the%20json%5Cr%5Cn%5Cr%5CnThank%20you%2C%5Cr%5Cn%5Cr%5CnSergiu%5Cr%5Cn%5Cr%5Cn%5Bfeature_report.json%202.zip%5D%28https%3A//github.com/damianszczepanik/cucumber-reporting/files/126616/feature_report.json.2.zip%29%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-02-11T15%3A37%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12070051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/hojbota%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40tommywo%20your%20code%20causes%20NPE%2C%20make%20it%20null%20safe%22%2C%20%22created_at%22%3A%20%222016-02-11T18%3A37%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40damianszczepanik%20I%20made%20it%20null%20safe%2C%20added%20format%20from%20%40hojbota%20json%2C%20and%20squashed%20commits..%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-02-16T07%3A42%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%20guys%2C%20%5Cr%5Cn%5Cr%5CnAny%20news%20on%20this%3F%20I%20would%20like%20to%20try%20it%20out.%20%5Cr%5Cn%5Cr%5CnThanks%2C%20%5Cr%5Cn%5Cr%5CnSergiu%22%2C%20%22created_at%22%3A%20%222016-02-22T10%3A23%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12070051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/hojbota%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40hojbota%20you%20can%20build%20the%20plugin%20again%20with%20same%20commands%20-%20it%20should%20work%20now%2C%20but%20it%20will%20not%20be%20merged%20until%20i%20improve%20code%20quality.%20%5Cr%5CnNote%20-%20fix%20for%20this%20issue%20was%20merged%20to%20cucumber-ruby%20master%20-%20https%3A//github.com/cucumber/cucumber-ruby/pull/949%22%2C%20%22created_at%22%3A%20%222016-02-22T10%3A29%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Just%20tried%20it%2C%20getting%20this%20error%20now%3A%20%5Cr%5Cn%5Cr%5Cncom.google.gson.JsonSyntaxException%3A%20java.lang.IllegalStateException%3A%20Expected%20a%20string%20but%20was%20BEGIN_OBJECT%20at%20line%201%20column%20679%20path%20%24%5B0%5D.elements%5B0%5D.before%5B0%5D.match.location%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.ReflectiveTypeAdapterFactory%24Adapter.read%28ReflectiveTypeAdapterFactory.java%3A221%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.ReflectiveTypeAdapterFactory%241.read%28ReflectiveTypeAdapterFactory.java%3A117%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.ReflectiveTypeAdapterFactory%24Adapter.read%28ReflectiveTypeAdapterFactory.java%3A217%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read%28TypeAdapterRuntimeTypeWrapper.java%3A40%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.ArrayTypeAdapter.read%28ArrayTypeAdapter.java%3A72%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.ReflectiveTypeAdapterFactory%241.read%28ReflectiveTypeAdapterFactory.java%3A117%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.ReflectiveTypeAdapterFactory%24Adapter.read%28ReflectiveTypeAdapterFactory.java%3A217%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read%28TypeAdapterRuntimeTypeWrapper.java%3A40%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.ArrayTypeAdapter.read%28ArrayTypeAdapter.java%3A72%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.ReflectiveTypeAdapterFactory%241.read%28ReflectiveTypeAdapterFactory.java%3A117%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.ReflectiveTypeAdapterFactory%24Adapter.read%28ReflectiveTypeAdapterFactory.java%3A217%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read%28TypeAdapterRuntimeTypeWrapper.java%3A40%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.ArrayTypeAdapter.read%28ArrayTypeAdapter.java%3A72%29%5Cr%5Cn%5Ctat%20com.google.gson.Gson.fromJson%28Gson.java%3A861%29%5Cr%5Cn%5Ctat%20com.google.gson.Gson.fromJson%28Gson.java%3A799%29%5Cr%5Cn%5Ctat%20net.masterthought.cucumber.ReportParser.parseJsonResults%28ReportParser.java%3A35%29%5Cr%5Cn%5Ctat%20net.masterthought.cucumber.ReportBuilder.generateReports%28ReportBuilder.java%3A49%29%5Cr%5Cn%5Ctat%20net.masterthought.jenkins.CucumberReportPublisher.perform%28CucumberReportPublisher.java%3A134%29%5Cr%5Cn%5Ctat%20hudson.tasks.BuildStepMonitor%241.perform%28BuildStepMonitor.java%3A20%29%5Cr%5Cn%5Ctat%20hudson.model.AbstractBuild%24AbstractBuildExecution.perform%28AbstractBuild.java%3A782%29%5Cr%5Cn%5Ctat%20hudson.model.AbstractBuild%24AbstractBuildExecution.performAllBuildSteps%28AbstractBuild.java%3A723%29%5Cr%5Cn%5Ctat%20hudson.model.Build%24BuildExecution.post2%28Build.java%3A185%29%5Cr%5Cn%5Ctat%20hudson.model.AbstractBuild%24AbstractBuildExecution.post%28AbstractBuild.java%3A668%29%5Cr%5Cn%5Ctat%20hudson.model.Run.execute%28Run.java%3A1763%29%5Cr%5Cn%5Ctat%20hudson.model.FreeStyleBuild.run%28FreeStyleBuild.java%3A43%29%5Cr%5Cn%5Ctat%20hudson.model.ResourceController.execute%28ResourceController.java%3A98%29%5Cr%5Cn%5Ctat%20hudson.model.Executor.run%28Executor.java%3A410%29%5Cr%5CnCaused%20by%3A%20java.lang.IllegalStateException%3A%20Expected%20a%20string%20but%20was%20BEGIN_OBJECT%20at%20line%201%20column%20679%20path%20%24%5B0%5D.elements%5B0%5D.before%5B0%5D.match.location%5Cr%5Cn%5Ctat%20com.google.gson.stream.JsonReader.nextString%28JsonReader.java%3A838%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.TypeAdapters%2416.read%28TypeAdapters.java%3A422%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.TypeAdapters%2416.read%28TypeAdapters.java%3A410%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.ReflectiveTypeAdapterFactory%241.read%28ReflectiveTypeAdapterFactory.java%3A117%29%5Cr%5Cn%5Ctat%20com.google.gson.internal.bind.ReflectiveTypeAdapterFactory%24Adapter.read%28ReflectiveTypeAdapterFactory.java%3A217%29%5Cr%5Cn%5Ct...%2026%20more%5Cr%5CnTrying%20to%20generate%20report%20from%20following%20files.%20Make%20sure%20they%20are%20valid%20cucumber%20report%20files%3A%20%5Cr%5Cn/Users/sergiuhojbota/.jenkins/jobs/e2e_test/builds/60/cucumber-html-reports/Yieldify-Testing/ruby/projects/yieldify-khaleesi-e2e/reports/feature_report.json%5Cr%5Cn%5Cr%5Cn%5Cr%5Cnjson%20report%3A%5Cr%5Cn%5Bfeature_report.json.zip%5D%28https%3A//github.com/damianszczepanik/cucumber-reporting/files/140606/feature_report.json.zip%29%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-02-22T13%3A04%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12070051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/hojbota%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5Cn%5Cn%5CnReviewed%203%20of%203%20files%20at%20r1.%5CnReview%20status%3A%20all%20files%20reviewed%20at%20latest%20revision%2C%205%20unresolved%20discussions%2C%20some%20commit%20checks%20failed.%5Cn%5Cn---%5Cn%5Cn%5Cn%5Cn%2AComments%20from%20the%20%5Breview%20on%20Reviewable.io%5D%28https%3A//reviewable.io%3A443/reviews/damianszczepanik/cucumber-reporting/316%29%2A%5Cn%3C%21--%20Sent%20from%20Reviewable.io%20--%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-03-02T09%3A32%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12070051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/hojbota%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ec500cf5130298fc5253d88d011c90d564a05945%20src/main/java/net/masterthought/cucumber/json/Match.java%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r55257960%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%21%5BCodacy%5D%28https%3A//www.codacy.com/assets/images/favicon.png%29%20Issue%20found%3A%20%5BThe%20method%20getLocation%28%29%20has%20an%20NPath%20complexity%20of%20298%5D%28https%3A//www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2183564530/issues/source%3Fbid%3D3059308%26fileBranchId%3D3097149%23l17%29%22%2C%20%22created_at%22%3A%20%222016-03-07T19%3A33%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hi%2C%20I%20built%20the%20plugin%20again%20using%20these%20steps%3A%5Cn%5Cngit%20clone%20-b%20%20location%20https%3A//github.com/tommywo/cucumber-reporting.git%5Cngit%20clone%20https%3A//github.com/jenkinsci/cucumber-reports-plugin.git%5Cncd%20cucumber-reporting%5Cnmvn%20install%5Cncd%20../cucumber-reports-plugin%5Cnmvn%20versions%3Aset%20-DartifactId%3Dcucumber-reporting%5Cn-DgroupId%3Dnet.masterthought%20-DoldVersion%3D1.3.0%5Cn-DnewVersion%3D1.3.0-SNAPSHOT%5Cnmvn%20package%5Cn%5CnAnd%20got%20the%20same%20error%5Cn%5Cn%5CnThanks%2C%5Cn%5CnSergiu%5Cn%5Cn%5CnOn%207%20March%202016%20at%2019%3A33%2C%20Damian%20Szczepanik%20%3Cnotifications%40github.com%3E%5Cnwrote%3A%5Cn%5Cn%3E%20In%20src/main/java/net/masterthought/cucumber/json/Match.java%5Cn%3E%20%3Chttps%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r55257960%3E%5Cn%3E%20%3A%5Cn%3E%5Cn%3E%20%3E%20%20public%20class%20Match%20%7B%5Cn%3E%20%3E%5Cn%3E%20%3E%20%20%20%20%20%20//%20Start%3A%20attributes%20from%20JSON%20file%20report%5Cn%3E%20%3E%20-%20%20%20%20private%20final%20String%20location%20%3D%20null%3B%5Cn%3E%20%3E%20%2B%20%20%20%20private%20final%20JsonElement%20location%20%3D%20null%3B%5Cn%3E%20%3E%20%20%20%20%20%20//%20End%3A%20attributes%20from%20JSON%20file%20report%5Cn%3E%20%3E%5Cn%3E%20%3E%20%20%20%20%20%20public%20String%20getLocation%28%29%20%7B%5Cn%3E%5Cn%3E%20%5Bimage%3A%20Codacy%5D%5Cn%3E%20%3Chttps%3A//camo.githubusercontent.com/37ddd55708a38212f4e9de4e3eac98358fefe597/68747470733a2f2f7777772e636f646163792e636f6d2f6173736574732f696d616765732f66617669636f6e2e706e67%3E%5Cn%3E%20Issue%20found%3A%20The%20method%20getLocation%28%29%20has%20an%20NPath%20complexity%20of%20298%5Cn%3E%20%3Chttps%3A//www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2183564530/issues/source%3Fbid%3D3059308%26fileBranchId%3D3097149%23l17%3E%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/damianszczepanik/cucumber-reporting/pull/316/files%23r55257960%3E%5Cn%3E%20.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-03-10T11%3A38%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12070051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/hojbota%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-96%22%7D%2C%20%22Pull%2088a3862cd056ad0a595f2059bc5bda603cd4bdd0%20src/main/java/net/masterthought/cucumber/json/Match.java%2047%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r53052333%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%22lines%5C%22%20string%20could%20be%20exposed%20as%20well%22%2C%20%22created_at%22%3A%20%222016-02-16T18%3A13%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-83%22%7D%2C%20%22Pull%2088a3862cd056ad0a595f2059bc5bda603cd4bdd0%20src/main/java/net/masterthought/cucumber/json/Match.java%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r53052008%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22else%20is%20useless%20here%20if%20you%20return%20value%20above%22%2C%20%22created_at%22%3A%20%222016-02-16T18%3A11%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-83%22%7D%2C%20%22Pull%2003eb05087e1926327d728453ecc5e9e73ce8ee6f%20src/test/resources/net/masterthought/cucumber/location_bug.json%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51053213%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22let%27s%20have%20two%20steps%3A%20one%20with%20new%20format%2C%20other%20with%20old%20one%20-%20this%20will%20eliminate%20noise%20of%20data%20that%20is%20not%20important%20in%20this%20test%22%2C%20%22created_at%22%3A%20%222016-01-27T21%3A31%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/resources/net/masterthought/cucumber/location_bug.json%3AL1-115%22%7D%2C%20%22Pull%2003eb05087e1926327d728453ecc5e9e73ce8ee6f%20src/main/java/net/masterthought/cucumber/json/Match.java%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51054481%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20worry%20if%20this%20is%20safe%20because%3A%5Cr%5Cn-%20name%20of%20the%20attribute%20%5C%22lines%5C%22%20means%20that%20it%20may%20be%20more%20%5C%22data%5C%22%20items%5Cr%5Cn-%20are%20you%20sure%20that%20%5C%22lines%5C%22%20and%20%5C%22data%5C%22%20are%20both%20mandatory%3F%5Cr%5Cn-%20if%20you%20have%20both%20line%20number%20%28from%20-%3E%20to%29%20this%20information%20is%20not%20compete%5Cr%5Cn-%20if%20you%20add%20line%20to%20the%20prefix%2C%20how%20would%20the%20%5C%22Steps%5C%22%20report%20look%20like%3F%20Lines%20determine%20the%20failure%20line%20of%20the%20method%20line%3F%5Cr%5Cn%5Cr%5CnSo%2C%20I%20would%20left%20file%20name%20only%20and%20consider%20what%20should%20be%20presented%20by%20%5C%22Steps%5C%22%20report%20page.%22%2C%20%22created_at%22%3A%20%222016-01-27T21%3A40%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27llll%20try%20to%20write%20it%20in%20a%20way%20to%20behave%20as%20same%20as%20location%27s%20%27to_s%27%20method%20from%20ruby%20%5Cr%5Cn%28https%3A//github.com/cucumber/cucumber-ruby-core/blob/master/spec/cucumber/core/ast/location_spec.rb%29%22%2C%20%22created_at%22%3A%20%222016-01-28T19%3A36%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Great%2C%20just%20mind%20that%20some%20json%20might%20not%20be%20fully%20valid%2C%20sometimes%20elements%20are%20optional%20and%20then%20we%20should%20handle%20as%20many%20exceptional%20cases%20as%20possible%20to%20avoid%20complains%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-01-28T20%3A06%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-24%22%7D%2C%20%22Pull%2003eb05087e1926327d728453ecc5e9e73ce8ee6f%20src/test/resources/net/masterthought/cucumber/location_bug.json%2095%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51055019%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20expect%20that%20different%20format%20may%20be%20also%20available%20in%20scenario%2C%20not%20only%20hook.%20Maybe%20it%27s%20worth%20to%20add%20extended%20format%20to%20scenario%20and%20validate%20it%20on%20html%20page%3F%20What%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222016-01-27T21%3A44%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20added%20that%20kind%20of%20location%20in%20scenario%2C%20and%20in%20test%2C%20but%20i%20don%27t%20see%20a%20point%20in%20checking%20if%20there%27s%20the%20same%20value%20in%20html.%22%2C%20%22created_at%22%3A%20%222016-01-28T21%3A20%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/resources/net/masterthought/cucumber/location_bug.json%3AL1-115%22%7D%2C%20%22Pull%2041fc4cf07e188c454a0b66034b0f9b940a45a3b6%20src/test/resources/net/masterthought/cucumber/location_formats.json%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51479348%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22as%20asked%20before%20-%20do%20you%20need%20this%20steps%20for%20test%3F%20if%20not%20then%20delete%20and%20leave%20only%20those%20data%20that%20you%20are%20going%20to%20validate%22%2C%20%22created_at%22%3A%20%222016-02-01T20%3A57%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22i%20left%20only%20steps%20needed%20to%20have%20full%20coverage.%22%2C%20%22created_at%22%3A%20%222016-02-01T22%3A08%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/resources/net/masterthought/cucumber/location_formats.json%3AL1-114%22%7D%2C%20%22Pull%2041fc4cf07e188c454a0b66034b0f9b940a45a3b6%20src/main/java/net/masterthought/cucumber/json/Match.java%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51478622%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22lack%20of%20spaces%20again%22%2C%20%22created_at%22%3A%20%222016-02-01T20%3A51%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-56%22%7D%2C%20%22Pull%2003eb05087e1926327d728453ecc5e9e73ce8ee6f%20src/main/java/net/masterthought/cucumber/json/Match.java%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51052843%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Does%20not%20look%20like%20null%20safe%20checking%2C%20isn%27t%3F%22%2C%20%22created_at%22%3A%20%222016-01-27T21%3A29%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%2C%20it%20will%20throw%20npe%2C%20if%20match%20doesnt%20have%20location.%20%5Cr%5CnWe%20could%20possible%20set%20it%20to%20empty%20string%2C%20but%20i%20don%27t%20how%20it%20would%20affect%20Step%20Page.%20%22%2C%20%22created_at%22%3A%20%222016-01-28T19%3A32%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%2C%20%7B%22body%22%3A%20%22NPE%20is%20evil%2C%20please%20make%20safe%20checking%20before%20extracting%20data%22%2C%20%22created_at%22%3A%20%222016-01-28T19%3A35%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22ok%2C%20now%20if%20location%20is%20null%20in%20feature%20report%20there%20will%20be%20%27After%27%20element%20without%20location%20and%20it%20isn%27t%20included%20in%20step%20statistics.%22%2C%20%22created_at%22%3A%20%222016-01-28T21%3A17%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-24%22%7D%2C%20%22Pull%2041fc4cf07e188c454a0b66034b0f9b940a45a3b6%20src/main/java/net/masterthought/cucumber/json/Match.java%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51478192%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22reformat%20the%20code%2C%20add%20spaces%22%2C%20%22created_at%22%3A%20%222016-02-01T20%3A48%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-56%22%7D%2C%20%22Pull%2003eb05087e1926327d728453ecc5e9e73ce8ee6f%20src/main/java/net/masterthought/cucumber/json/Match.java%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51053815%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22expose%20this%20into%20temporary%20variable%22%2C%20%22created_at%22%3A%20%222016-01-27T21%3A35%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-24%22%7D%2C%20%22Pull%2041fc4cf07e188c454a0b66034b0f9b940a45a3b6%20src/main/java/net/masterthought/cucumber/json/Match.java%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51478825%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20is%20builder%2C%20you%20can%20merge%20those%20three%20lines%20into%20one%22%2C%20%22created_at%22%3A%20%222016-02-01T20%3A53%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-56%22%7D%2C%20%22Pull%2003eb05087e1926327d728453ecc5e9e73ce8ee6f%20src/test/resources/net/masterthought/cucumber/location_bug.json%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51053293%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22rename%20plik%20to%20location_formats.json%22%2C%20%22created_at%22%3A%20%222016-01-27T21%3A32%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/resources/net/masterthought/cucumber/location_bug.json%3AL1-115%22%7D%2C%20%22Pull%2041fc4cf07e188c454a0b66034b0f9b940a45a3b6%20src/main/java/net/masterthought/cucumber/json/Match.java%2051%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51479005%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22use%20List%3Cint%3E%20or%20put%20here%20equals%20-%20otherwise%20it%20fails%22%2C%20%22created_at%22%3A%20%222016-02-01T20%3A54%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22the%20intention%20is%20to%20check%20if%20we%20can%20replace%20lines%20with%20a%20range%20%28f.e%201..10%20instead%20of%201%2C2%2C3%2C4%2C5%2C6%2C7%2C8%2C9%2C10%29%22%2C%20%22created_at%22%3A%20%222016-02-01T22%3A13%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-56%22%7D%2C%20%22Pull%2088a3862cd056ad0a595f2059bc5bda603cd4bdd0%20src/main/java/net/masterthought/cucumber/json/Match.java%2031%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r53051761%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22expose%20filePath%20and%20file%20to%20final%20static%20variable%22%2C%20%22created_at%22%3A%20%222016-02-16T18%3A09%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-83%22%7D%2C%20%22Pull%2003eb05087e1926327d728453ecc5e9e73ce8ee6f%20src/test/java/net/masterthought/cucumber/LocationTest.java%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r51054635%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22do%20you%20need%20this%20line%3F%20those%20values%20are%20default%20values%22%2C%20%22created_at%22%3A%20%222016-01-27T21%3A41%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22i%27ll%20remove%20it%22%2C%20%22created_at%22%3A%20%222016-01-28T19%3A37%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11270518%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tommywo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/java/net/masterthought/cucumber/LocationTest.java%3AL1-35%22%7D%2C%20%22Pull%20e5e7fa2efe539a8cee548e76b6e4be82a36a3eaf%20src/main/java/net/masterthought/cucumber/json/Match.java%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r52645840%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22maybe%20StringUtils.EMPTY%20%3F%22%2C%20%22created_at%22%3A%20%222016-02-11T18%3A38%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-53%22%7D%2C%20%22Pull%2088992c94486bf4fd2a4e2ab95249d5f8e4c8dd7b%20src/main/java/net/masterthought/cucumber/json/Match.java%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/316%23discussion_r53051883%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Codacy%20reported%20issue%20that%20complexity%20of%20this%20method%20is%20to%20big.%20Expose%20code%20to%20private%20methods%22%2C%20%22created_at%22%3A%20%222016-02-16T18%3A10%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Match.java%3AL1-83%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#issuecomment-175429133'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `89.56%`
> Merging **#316** into **master** will decrease coverage by **-0.05%** as of [`6c054d4`][3]
```diff
@@            master    #316   diff @@
======================================
Files           28      28
Stmts          799     805     +6
Branches        99     100     +1
Methods          0       0
======================================
+ Hit            716     721     +5
- Partial         25      26     +1
Missed          58      58
```
> Review entire [Coverage Diff][4] as of [`6c054d4`][3]
[1]: https://codecov.io/github/damianszczepanik/cucumber-reporting?ref=6c054d4bc8e1091e720594cd114ab068e7619586
[2]: https://codecov.io/github/damianszczepanik/cucumber-reporting/features/suggestions?ref=6c054d4bc8e1091e720594cd114ab068e7619586
[3]: https://codecov.io/github/damianszczepanik/cucumber-reporting/commit/6c054d4bc8e1091e720594cd114ab068e7619586
[4]: https://codecov.io/github/damianszczepanik/cucumber-reporting/compare/910f506c35a9d849f15b3855c68c7fe4ee2881c8...6c054d4bc8e1091e720594cd114ab068e7619586
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> @damianszczepanik can you recheck?
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> I've added comments, also you don't have default formatter that puts spaces between brackets and operators
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> @damianszczepanik can you recheck?
- <a href='https://github.com/hojbota'><img border=0 src='https://avatars.githubusercontent.com/u/12070051?v=3' height=16 width=16'></a> Hey guys, any ideea when this fixed will be released? I'm still facing https://github.com/damianszczepanik/cucumber-reporting-jenkins/issues/61
Thanks,
Sergiu
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> I believe the pr is ready to be merged.
Sergiu if you are in a hurry you can build the plugin yourself.
Here's commands for it.
```bash
git clone -b  location https://github.com/tommywo/cucumber-reporting.git
git clone https://github.com/jenkinsci/cucumber-reports-plugin.git
cd cucumber-reporting
mvn install
cd ../cucumber-reports-plugin
mvn versions:set -DartifactId=cucumber-reporting -DgroupId=net.masterthought -DoldVersion=1.3.0 -DnewVersion=1.3.0-SNAPSHOT
mvn package
```
- <a href='https://github.com/hojbota'><img border=0 src='https://avatars.githubusercontent.com/u/12070051?v=3' height=16 width=16'></a> Hi, thank you, I tried it and got this error:
java.lang.NullPointerException
at net.masterthought.cucumber.json.Match.getLocation(Match.java:24)
at net.masterthought.cucumber.json.Element.calculateAttachments(Element.java:174)
at net.masterthought.cucumber.json.Element.setMedaData(Element.java:149)
at net.masterthought.cucumber.json.Feature.setMetaData(Feature.java:141)
at net.masterthought.cucumber.ReportParser.setMetadata(ReportParser.java:51)
at net.masterthought.cucumber.ReportParser.parseJsonResults(ReportParser.java:39)
at net.masterthought.cucumber.ReportBuilder.generateReports(ReportBuilder.java:48)
at net.masterthought.jenkins.CucumberReportPublisher.perform(CucumberReportPublisher.java:134)
at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:782)
at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:723)
at hudson.model.Build$BuildExecution.post2(Build.java:185)
at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:668)
at hudson.model.Run.execute(Run.java:1763)
at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
at hudson.model.ResourceController.execute(ResourceController.java:98)
at hudson.model.Executor.run(Executor.java:410)
attached the json
Thank you,
Sergiu
[feature_report.json 2.zip](https://github.com/damianszczepanik/cucumber-reporting/files/126616/feature_report.json.2.zip)
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> @tommywo your code causes NPE, make it null safe
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> @damianszczepanik I made it null safe, added format from @hojbota json, and squashed commits..
- <a href='https://github.com/hojbota'><img border=0 src='https://avatars.githubusercontent.com/u/12070051?v=3' height=16 width=16'></a> Hi guys,
Any news on this? I would like to try it out.
Thanks,
Sergiu
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> @hojbota you can build the plugin again with same commands - it should work now, but it will not be merged until i improve code quality.
Note - fix for this issue was merged to cucumber-ruby master - https://github.com/cucumber/cucumber-ruby/pull/949
- <a href='https://github.com/hojbota'><img border=0 src='https://avatars.githubusercontent.com/u/12070051?v=3' height=16 width=16'></a> Just tried it, getting this error now:
com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT at line 1 column 679 path $[0].elements[0].before[0].match.location
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:221)
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:117)
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:217)
at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
at com.google.gson.internal.bind.ArrayTypeAdapter.read(ArrayTypeAdapter.java:72)
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:117)
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:217)
at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
at com.google.gson.internal.bind.ArrayTypeAdapter.read(ArrayTypeAdapter.java:72)
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:117)
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:217)
at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
at com.google.gson.internal.bind.ArrayTypeAdapter.read(ArrayTypeAdapter.java:72)
at com.google.gson.Gson.fromJson(Gson.java:861)
at com.google.gson.Gson.fromJson(Gson.java:799)
at net.masterthought.cucumber.ReportParser.parseJsonResults(ReportParser.java:35)
at net.masterthought.cucumber.ReportBuilder.generateReports(ReportBuilder.java:49)
at net.masterthought.jenkins.CucumberReportPublisher.perform(CucumberReportPublisher.java:134)
at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:782)
at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:723)
at hudson.model.Build$BuildExecution.post2(Build.java:185)
at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:668)
at hudson.model.Run.execute(Run.java:1763)
at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
at hudson.model.ResourceController.execute(ResourceController.java:98)
at hudson.model.Executor.run(Executor.java:410)
Caused by: java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT at line 1 column 679 path $[0].elements[0].before[0].match.location
at com.google.gson.stream.JsonReader.nextString(JsonReader.java:838)
at com.google.gson.internal.bind.TypeAdapters$16.read(TypeAdapters.java:422)
at com.google.gson.internal.bind.TypeAdapters$16.read(TypeAdapters.java:410)
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:117)
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:217)
... 26 more
Trying to generate report from following files. Make sure they are valid cucumber report files:
/Users/sergiuhojbota/.jenkins/jobs/e2e_test/builds/60/cucumber-html-reports/Yieldify-Testing/ruby/projects/yieldify-khaleesi-e2e/reports/feature_report.json
json report:
[feature_report.json.zip](https://github.com/damianszczepanik/cucumber-reporting/files/140606/feature_report.json.zip)
- <a href='https://github.com/hojbota'><img border=0 src='https://avatars.githubusercontent.com/u/12070051?v=3' height=16 width=16'></a> Reviewed 3 of 3 files at r1.
Review status: all files reviewed at latest revision, 5 unresolved discussions, some commit checks failed.
---
*Comments from the [review on Reviewable.io](https://reviewable.io:443/reviews/damianszczepanik/cucumber-reporting/316)*
<!-- Sent from Reviewable.io -->
- [x] <a href='#crh-comment-Pull 03eb05087e1926327d728453ecc5e9e73ce8ee6f src/main/java/net/masterthought/cucumber/json/Match.java 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51052843'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-24</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Does not look like null safe checking, isn't?
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> No, it will throw npe, if match doesnt have location.
We could possible set it to empty string, but i don't how it would affect Step Page.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> NPE is evil, please make safe checking before extracting data
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> ok, now if location is null in feature report there will be 'After' element without location and it isn't included in step statistics.
- [ ] <a href='#crh-comment-Pull 03eb05087e1926327d728453ecc5e9e73ce8ee6f src/test/resources/net/masterthought/cucumber/location_bug.json 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51053213'>File: src/test/resources/net/masterthought/cucumber/location_bug.json:L1-115</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> let's have two steps: one with new format, other with old one - this will eliminate noise of data that is not important in this test
- [ ] <a href='#crh-comment-Pull 03eb05087e1926327d728453ecc5e9e73ce8ee6f src/test/resources/net/masterthought/cucumber/location_bug.json 1'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51053293'>File: src/test/resources/net/masterthought/cucumber/location_bug.json:L1-115</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> rename plik to location_formats.json
- [ ] <a href='#crh-comment-Pull 03eb05087e1926327d728453ecc5e9e73ce8ee6f src/main/java/net/masterthought/cucumber/json/Match.java 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51053815'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-24</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> expose this into temporary variable
- [ ] <a href='#crh-comment-Pull 03eb05087e1926327d728453ecc5e9e73ce8ee6f src/main/java/net/masterthought/cucumber/json/Match.java 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51054481'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-24</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> I'm worry if this is safe because:
- name of the attribute "lines" means that it may be more "data" items
- are you sure that "lines" and "data" are both mandatory?
- if you have both line number (from -> to) this information is not compete
- if you add line to the prefix, how would the "Steps" report look like? Lines determine the failure line of the method line?
So, I would left file name only and consider what should be presented by "Steps" report page.
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> I'llll try to write it in a way to behave as same as location's 'to_s' method from ruby
(https://github.com/cucumber/cucumber-ruby-core/blob/master/spec/cucumber/core/ast/location_spec.rb)
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Great, just mind that some json might not be fully valid, sometimes elements are optional and then we should handle as many exceptional cases as possible to avoid complains :)
- [ ] <a href='#crh-comment-Pull 03eb05087e1926327d728453ecc5e9e73ce8ee6f src/test/java/net/masterthought/cucumber/LocationTest.java 22'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51054635'>File: src/test/java/net/masterthought/cucumber/LocationTest.java:L1-35</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> do you need this line? those values are default values
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> i'll remove it
- [ ] <a href='#crh-comment-Pull 03eb05087e1926327d728453ecc5e9e73ce8ee6f src/test/resources/net/masterthought/cucumber/location_bug.json 95'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51055019'>File: src/test/resources/net/masterthought/cucumber/location_bug.json:L1-115</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> I expect that different format may be also available in scenario, not only hook. Maybe it's worth to add extended format to scenario and validate it on html page? What do you think?
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> I've added that kind of location in scenario, and in test, but i don't see a point in checking if there's the same value in html.
- [ ] <a href='#crh-comment-Pull 41fc4cf07e188c454a0b66034b0f9b940a45a3b6 src/main/java/net/masterthought/cucumber/json/Match.java 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51478192'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-56</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> reformat the code, add spaces
- [ ] <a href='#crh-comment-Pull 41fc4cf07e188c454a0b66034b0f9b940a45a3b6 src/main/java/net/masterthought/cucumber/json/Match.java 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51478197'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-56</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> empty or null?
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> gson leaves location as null when this element is not found.
We have to return empty string, because of usage of .getLocation() without null checking in net/masterthought/cucumber/json/Element.java:174
- [ ] <a href='#crh-comment-Pull 41fc4cf07e188c454a0b66034b0f9b940a45a3b6 src/main/java/net/masterthought/cucumber/json/Match.java 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51478269'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-56</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> List<Integer> should be fine
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> if i change it to List i would have to change lineList.getFirst() and lineList.getLast() to
lineList.get(0) and lineList.get(lineList.size()-1)  which are less readable
- [ ] <a href='#crh-comment-Pull 41fc4cf07e188c454a0b66034b0f9b940a45a3b6 src/main/java/net/masterthought/cucumber/json/Match.java 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51478622'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-56</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> lack of spaces again
- [ ] <a href='#crh-comment-Pull 41fc4cf07e188c454a0b66034b0f9b940a45a3b6 src/main/java/net/masterthought/cucumber/json/Match.java 38'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51478825'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-56</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> this is builder, you can merge those three lines into one
- [ ] <a href='#crh-comment-Pull 41fc4cf07e188c454a0b66034b0f9b940a45a3b6 src/main/java/net/masterthought/cucumber/json/Match.java 51'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51479005'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-56</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> use List<int> or put here equals - otherwise it fails
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> the intention is to check if we can replace lines with a range (f.e 1..10 instead of 1,2,3,4,5,6,7,8,9,10)
- [ ] <a href='#crh-comment-Pull 41fc4cf07e188c454a0b66034b0f9b940a45a3b6 src/test/resources/net/masterthought/cucumber/location_formats.json 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r51479348'>File: src/test/resources/net/masterthought/cucumber/location_formats.json:L1-114</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> as asked before - do you need this steps for test? if not then delete and leave only those data that you are going to validate
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> i left only steps needed to have full coverage.
- [ ] <a href='#crh-comment-Pull e5e7fa2efe539a8cee548e76b6e4be82a36a3eaf src/main/java/net/masterthought/cucumber/json/Match.java 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r52645840'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-53</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> maybe StringUtils.EMPTY ?
- [ ] <a href='#crh-comment-Pull 88992c94486bf4fd2a4e2ab95249d5f8e4c8dd7b src/main/java/net/masterthought/cucumber/json/Match.java 65'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r52979692'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-83</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> ![Codacy](https://www.codacy.com/versioned/images/favicon.png) Issue found: [An empty statement (semicolon) not part of a loop](https://www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2048973241/issues/source?bid=3059308&fileBranchId=3097149#l63)
- <a href='https://github.com/tommywo'><img border=0 src='https://avatars.githubusercontent.com/u/11270518?v=3' height=16 width=16'></a> fixed
- [ ] <a href='#crh-comment-Pull 88a3862cd056ad0a595f2059bc5bda603cd4bdd0 src/main/java/net/masterthought/cucumber/json/Match.java 31'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r53051761'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-83</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> expose filePath and file to final static variable
- [ ] <a href='#crh-comment-Pull 88992c94486bf4fd2a4e2ab95249d5f8e4c8dd7b src/main/java/net/masterthought/cucumber/json/Match.java 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r53051883'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-83</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Codacy reported issue that complexity of this method is to big. Expose code to private methods
- [ ] <a href='#crh-comment-Pull 88a3862cd056ad0a595f2059bc5bda603cd4bdd0 src/main/java/net/masterthought/cucumber/json/Match.java 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r53052008'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-83</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> else is useless here if you return value above
- [ ] <a href='#crh-comment-Pull 88a3862cd056ad0a595f2059bc5bda603cd4bdd0 src/main/java/net/masterthought/cucumber/json/Match.java 47'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r53052333'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-83</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> "lines" string could be exposed as well
- [ ] <a href='#crh-comment-Pull 88a3862cd056ad0a595f2059bc5bda603cd4bdd0 src/test/java/net/masterthought/cucumber/LocationTest.java 48'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r53052752'>File: src/test/java/net/masterthought/cucumber/LocationTest.java:L1-64</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> This code `features.get(0).getElements()[0]` is repeated all the time, save in temp variable
- [ ] <a href='#crh-comment-Pull 88a3862cd056ad0a595f2059bc5bda603cd4bdd0 src/main/java/net/masterthought/cucumber/json/Match.java 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r53055027'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-83</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> ![Codacy](https://www.codacy.com/versioned/images/favicon.png) Issue found: [The method getLocation() has an NPath complexity of 298](https://www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2054722975/issues/source?bid=3059308&fileBranchId=3097149#l17)
- [ ] <a href='#crh-comment-Pull ec500cf5130298fc5253d88d011c90d564a05945 src/main/java/net/masterthought/cucumber/json/Match.java 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r55257960'>File: src/main/java/net/masterthought/cucumber/json/Match.java:L1-96</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> ![Codacy](https://www.codacy.com/assets/images/favicon.png) Issue found: [The method getLocation() has an NPath complexity of 298](https://www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2183564530/issues/source?bid=3059308&fileBranchId=3097149#l17)
- <a href='https://github.com/hojbota'><img border=0 src='https://avatars.githubusercontent.com/u/12070051?v=3' height=16 width=16'></a> Hi, I built the plugin again using these steps:
git clone -b  location https://github.com/tommywo/cucumber-reporting.git
git clone https://github.com/jenkinsci/cucumber-reports-plugin.git
cd cucumber-reporting
mvn install
cd ../cucumber-reports-plugin
mvn versions:set -DartifactId=cucumber-reporting
-DgroupId=net.masterthought -DoldVersion=1.3.0
-DnewVersion=1.3.0-SNAPSHOT
mvn package
And got the same error
Thanks,
Sergiu
On 7 March 2016 at 19:33, Damian Szczepanik <notifications@github.com>
wrote:
> In src/main/java/net/masterthought/cucumber/json/Match.java
> <https://github.com/damianszczepanik/cucumber-reporting/pull/316#discussion_r55257960>
> :
>
> >  public class Match {
> >
> >      // Start: attributes from JSON file report
> > -    private final String location = null;
> > +    private final JsonElement location = null;
> >      // End: attributes from JSON file report
> >
> >      public String getLocation() {
>
> [image: Codacy]
> <https://camo.githubusercontent.com/37ddd55708a38212f4e9de4e3eac98358fefe597/68747470733a2f2f7777772e636f646163792e636f6d2f6173736574732f696d616765732f66617669636f6e2e706e67>
> Issue found: The method getLocation() has an NPath complexity of 298
> <https://www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2183564530/issues/source?bid=3059308&fileBranchId=3097149#l17>
>
> —
> Reply to this email directly or view it on GitHub
> <https://github.com/damianszczepanik/cucumber-reporting/pull/316/files#r55257960>
> .
>


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/316?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/316?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/316'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>