### PR TITLE
Correctly sort columns with durations

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/support/StepObject.java
+++ b/src/main/java/net/masterthought/cucumber/json/support/StepObject.java
@@ -45,8 +45,12 @@ public class StepObject implements Comparable<StepObject> {
         return Util.formatDuration(totalDuration);
     }
 
+    public long getAverageDuration() {
+        return totalDuration / totalOccurrences;
+    }
+
     public String getAverageFormattedDuration() {
-        return Util.formatDuration(totalDuration / totalOccurrences);
+        return Util.formatDuration(getAverageDuration());
     }
 
     public int getTotalOccurrences() {

--- a/src/main/resources/templates/generators/stepsOverview.vm
+++ b/src/main/resources/templates/generators/stepsOverview.vm
@@ -37,8 +37,8 @@
               <tr>
                 <td class="location">$step.getLocation()</td>
                 <td>$step.getTotalOccurrences()</td>
-                <td class="duration">$step.getTotalFormattedDuration()</td>
-                <td class="duration">$step.getAverageFormattedDuration()</td>
+                <td class="duration" data-value="$step.getDurations()">$step.getTotalFormattedDuration()</td>
+                <td class="duration" data-value="$step.getAverageDuration()">$step.getAverageFormattedDuration()</td>
                 <td class="$step.getStatus().getRawName()">$step.getPercentageResult()</td>
               </tr>
             #end

--- a/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageIntegrationTest.java
@@ -59,7 +59,7 @@ public class FeatureReportPageIntegrationTest extends Page {
         DocumentAssertion document = documentFrom(page.getWebPage());
         TableRowAssertion odyRow = document.getSummary().getTableStats().getBodyRow();
 
-        odyRow.hasExactValues(feature.getName(), "1", "1", "0", "10", "7", "0", "0", "2", "1", "0", "343 ms", "Passed");
+        odyRow.hasExactValues(feature.getName(), "1", "1", "0", "10", "7", "0", "0", "2", "1", "0", "1m 39s 343 ms", "Passed");
         odyRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "passed");
     }
 

--- a/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageIntegrationTest.java
@@ -112,7 +112,7 @@ public class FeaturesOverviewPageIntegrationTest extends Page {
         assertThat(bodyRows).hasSize(2);
 
         TableRowAssertion firstRow = bodyRows[0];
-        firstRow.hasExactValues("1st feature", "1", "1", "0", "10", "7", "0", "0", "2", "1", "0", "343 ms",
+        firstRow.hasExactValues("1st feature", "1", "1", "0", "10", "7", "0", "0", "2", "1", "0", "1m 39s 343 ms",
                 "Passed");
         firstRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "passed");
         firstRow.getReportLink().hasLabelAndAddress("1st feature", "net-masterthought-example-s--ATM-local-feature.html");
@@ -138,7 +138,7 @@ public class FeaturesOverviewPageIntegrationTest extends Page {
         DocumentAssertion document = documentFrom(page.getWebPage());
         TableRowAssertion footerCells = document.getSummary().getTableStats().getFooterRow();
 
-        footerCells.hasExactValues("2", "2", "1", "1", "19", "11", "1", "3", "2", "1", "1", "345 ms", "Totals");
+        footerCells.hasExactValues("2", "2", "1", "1", "19", "11", "1", "3", "2", "1", "1", "1m 39s 345 ms", "Totals");
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/StepsOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/StepsOverviewPageIntegrationTest.java
@@ -92,9 +92,13 @@ public class StepsOverviewPageIntegrationTest extends Page {
         assertThat(bodyRows).hasSameSizeAs(steps);
 
         TableRowAssertion firstRow = bodyRows[1];
-        firstRow.hasExactValues("ATMScenario.I_have_a_new_credit_card()", "1", "107 ms", "107 ms", "100.00%");
+        firstRow.hasExactValues("ATMScenario.I_have_a_new_credit_card()", "1", "1m 39s 107 ms", "1m 39s 107 ms", "100.00%");
         firstRow.hasExactCSSClasses("location", "", "duration", "duration", "passed");
+        firstRow.hasExactDataValues("", "", "99107447000", "99107447000", "");
 
+        // also verify the average durations is written to data-values correctly
+        TableRowAssertion secondRow = bodyRows[2];
+        secondRow.hasExactDataValues("", "", "90000000", "45000000", "");
     }
 
     @Test
@@ -112,7 +116,7 @@ public class StepsOverviewPageIntegrationTest extends Page {
         DocumentAssertion document = documentFrom(page.getWebPage());
         TableRowAssertion footerCells = document.getSummary().getTableStats().getFooterRow();
 
-        footerCells.hasExactValues("15", "22", "482 ms", "021 ms", "Totals");
+        footerCells.hasExactValues("15", "22", "1m 39s 482 ms", "04s 521 ms", "Totals");
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/helpers/TableRowAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/helpers/TableRowAssertion.java
@@ -24,10 +24,8 @@ public class TableRowAssertion extends ReportAssertion {
     }
 
     /**
-     * Validates if element of passed array is equal (as a text) to passed values (reference).
+     * Validates the row cells' text match the given passed values.
      * 
-     * @param array
-     *            elements that will be compared
      * @param values
      *            reference element to compare with
      */
@@ -41,6 +39,12 @@ public class TableRowAssertion extends ReportAssertion {
         }
     }
 
+    /**
+     * Validates the row cells' class names contain the given values.
+     *
+     * @param classes
+     *            reference element to compare with
+     */
     public void hasExactCSSClasses(String... classes) {
         WebAssertion[] array = allBySelector("td,th", WebAssertion.class);
 
@@ -51,6 +55,26 @@ public class TableRowAssertion extends ReportAssertion {
                 assertThat(array[i].classNames()).describedAs("Unexpected CSC class on index %d", i).isEmpty();
             } else {
                 assertThat(array[i].classNames()).describedAs("Missing CSC class on index %d", i).contains(classes[i]);
+            }
+        }
+    }
+
+    /**
+     * Validates the row cells' data-value attribute values match the given values.
+     *
+     * @param values
+     *            reference element to compare with
+     */
+    public void hasExactDataValues(String... values) {
+        WebAssertion[] array = allBySelector("td,th", WebAssertion.class);
+
+        assertThat(array.length).isEqualTo(values.length);
+
+        for (int i = 0; i < values.length; i++) {
+            if (StringUtils.isEmpty(values[i])) {
+                assertThat(array[i].attr("data-value")).describedAs("Unexpected data-value on index %d", i).isEmpty();
+            } else {
+                assertThat(array[i].attr("data-value")).describedAs("Missing data-value on index %d", i).isEqualTo(values[i]);
             }
         }
     }

--- a/src/test/resources/json/sample.json
+++ b/src/test/resources/json/sample.json
@@ -20,7 +20,7 @@
                 "steps":[
                     {
                         "result":{
-                            "duration":107447000,
+                            "duration":99107447000,
                             "status":"passed"
                         },
                         "name":"I have a new credit card",


### PR DESCRIPTION
If the duration is > 1 second, then the time formatting can confuse tablesorter's sorting. So instead, we add the unformatted time values as a data attribute. tablesorter will automatically detect and pickup these values and use them to sort.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/413%23issuecomment-214944697%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/413%23issuecomment-214971946%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/413%23issuecomment-214983238%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/413%23issuecomment-214944697%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A59.09%25%2A%2A%5Cn%3E%20Merging%20%5B%23413%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20increase%20coverage%20by%20%2A%2A-1.13%25%2A%2A%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23413%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20679%20%20%20%20%20%20%20%20660%20%20%20%20-19%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%2087%20%20%20%20%20%20%20%20%2087%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn-%20Hits%20%20%20%20%20%20%20%20%20%20409%20%20%20%20%20%20%20%20390%20%20%20%20-19%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20248%20%20%20%20%20%20%20%20248%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%2022%20%20%20%20%20%20%20%20%2022%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn1.%203%20files%20%28not%20in%20diff%29%20in%20%60...sterthought/cucumber%60%20were%20modified.%20%5Bmore%5D%28https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/commit/b019336d33e6ec207c942c6c0b21803052b06e0a/changes%3Fsrc%3Dpr%237372632F6D61696E2F6A6176612F6E65742F6D617374657274686F756768742F637563756D626572%29%20%5Cn%20%20-%20Misses%20%60-1%60%20%5Cn%20%20-%20Hits%20%60-19%60%5Cn%5Cn%5B%21%5BSunburst%5D%28https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/413/graphs/sunburst.svg%3Fsize%3D200%26src%3Dpr%29%5D%5Bcc-pull%5D%5Cn%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20b019336%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/413%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-04-27T02%3A05%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Is%20there%20a%20subset%20of%20tests%20being%20run%20for%20the%20coverage%20reports%3F%20When%20I%20run%20the%20full%20test%20suite%20and%20measure%20coverage%2C%20it%27s%20much%20higher%20and%20the%20delta%20between%20master%20smaller.%22%2C%20%22created_at%22%3A%20%222016-04-27T05%3A16%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22Integration%20tests%20are%20not%20counted%22%2C%20%22created_at%22%3A%20%222016-04-27T06%3A29%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/413#issuecomment-214944697'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **59.09%**
> Merging [#413][cc-pull] into [master][cc-base-branch] will increase coverage by **-1.13%**
```diff
@@           master       #413   diff @@
========================================
Files          29         29
Lines         679        660    -19
Methods         0          0
Branches       87         87
========================================
- Hits          409        390    -19
Misses        248        248
Partials       22         22
```
1. 3 files (not in diff) in `...sterthought/cucumber` were modified. [more](https://codecov.io/gh/damianszczepanik/cucumber-reporting/commit/b019336d33e6ec207c942c6c0b21803052b06e0a/changes?src=pr#7372632F6D61696E2F6A6176612F6E65742F6D617374657274686F756768742F637563756D626572)
- Misses `-1`
- Hits `-19`
[![Sunburst](https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/413/graphs/sunburst.svg?size=200&src=pr)][cc-pull]
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by b019336
[cc-base-branch]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master?src=pr
[cc-pull]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/413?src=pr
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Is there a subset of tests being run for the coverage reports? When I run the full test suite and measure coverage, it's much higher and the delta between master smaller.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Integration tests are not counted


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/413?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/413?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/413'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>