### PR TITLE
Implement correct time sorting fix for features and tags overview pages

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/Feature.java
+++ b/src/main/java/net/masterthought/cucumber/json/Feature.java
@@ -125,8 +125,13 @@ public class Feature implements Reportable, Comparable<Feature> {
     }
 
     @Override
-    public String getDurations() {
-        return Util.formatDuration(totalDuration);
+    public long getDurations() {
+        return totalDuration;
+    }
+
+    @Override
+    public String getFormattedDurations() {
+        return Util.formatDuration(getDurations());
     }
 
     @Override

--- a/src/main/java/net/masterthought/cucumber/json/support/TagObject.java
+++ b/src/main/java/net/masterthought/cucumber/json/support/TagObject.java
@@ -87,8 +87,13 @@ public class TagObject implements Reportable, Comparable<TagObject> {
     }
 
     @Override
-    public String getDurations() {
-        return Util.formatDuration(totalDuration);
+    public long getDurations() {
+        return totalDuration;
+    }
+
+    @Override
+    public String getFormattedDurations() {
+        return Util.formatDuration(getDurations());
     }
 
     @Override

--- a/src/main/java/net/masterthought/cucumber/reports/OverviewReport.java
+++ b/src/main/java/net/masterthought/cucumber/reports/OverviewReport.java
@@ -78,8 +78,13 @@ public class OverviewReport implements Reportable {
     }
 
     @Override
-    public String getDurations() {
-        return Util.formatDuration(duration);
+    public long getDurations() {
+        return duration;
+    }
+
+    @Override
+    public String getFormattedDurations() {
+        return Util.formatDuration(getDurations());
     }
 
     public void incDurationBy(long duration) {

--- a/src/main/java/net/masterthought/cucumber/reports/Reportable.java
+++ b/src/main/java/net/masterthought/cucumber/reports/Reportable.java
@@ -45,8 +45,11 @@ public interface Reportable {
     /** Returns number of pending steps for this element. */
     int getPendingSteps();
 
+    /** Returns raw duration for this element. */
+    long getDurations();
+
     /** Returns formatted duration for this element. */
-    String getDurations();
+    String getFormattedDurations();
 
     /** Returns status for this element. */
     Status getStatus();

--- a/src/main/resources/templates/macros/report/reportTable.vm
+++ b/src/main/resources/templates/macros/report/reportTable.vm
@@ -19,7 +19,7 @@
           <td #if($reportable.getPendingSteps() != 0)   class="pending"   #end>$reportable.getPendingSteps()</td>
           <td #if($reportable.getUndefinedSteps() != 0) class="undefined" #end>$reportable.getUndefinedSteps()</td>
           <td #if($reportable.getMissingSteps() != 0)   class="missing"   #end>$reportable.getMissingSteps()</td>
-          <td class="duration">$reportable.getDurations()</td>
+          <td class="duration" data-value="$reportable.getDurations()">$reportable.getFormattedDurations()</td>
           <td class="$reportable.getStatus().getRawName()">$reportable.getStatus().getLabel()</td>
         </tr>
         </tbody>

--- a/src/main/resources/templates/macros/report/statsTable.vm
+++ b/src/main/resources/templates/macros/report/statsTable.vm
@@ -21,7 +21,7 @@
         <td #if($element.getPendingSteps() > 0)   class="pending"   #end>$element.getPendingSteps()</td>
         <td #if($element.getUndefinedSteps() > 0) class="undefined" #end>$element.getUndefinedSteps()</td>
         <td #if($element.getMissingSteps() > 0)   class="missing"   #end>$element.getMissingSteps()</td>
-        <td class="duration">$element.getDurations()</td>
+        <td class="duration" data-value="$element.getDurations()">$element.getFormattedDurations()</td>
         <td class="$element.getStatus().getRawName()">$element.getStatus().getLabel()</td>
       </tr>
     #end
@@ -43,7 +43,7 @@
       <td>$report_summary.getPendingSteps()</td>
       <td>$report_summary.getUndefinedSteps()</td>
       <td>$report_summary.getMissingSteps()</td>
-      <td class="duration">$report_summary.getDurations()</td>
+      <td class="duration">$report_summary.getFormattedDurations()</td>
       <td>Totals</td>
     </tr>
   </tfoot>

--- a/src/test/java/net/masterthought/cucumber/FeatureTest.java
+++ b/src/test/java/net/masterthought/cucumber/FeatureTest.java
@@ -124,8 +124,13 @@ public class FeatureTest {
     }
 
     @Test
-    public void shouldgetDurations() {
-        assertThat(passingFeature.getDurations(), StringContains.containsString("ms"));
+    public void shouldGetDuration() {
+        assertThat(passingFeature.getDurations(), is(112739000L));
+    }
+
+    @Test
+    public void shouldGetFormattedDurations() {
+        assertThat(passingFeature.getFormattedDurations(), StringContains.containsString("ms"));
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/ReportInformationTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportInformationTest.java
@@ -77,7 +77,7 @@ public class ReportInformationTest {
 
     @Test
     public void shouldReturnTotalDurationAsString() {
-        assertThat(reportResult.getFeatureReport().getDurations(), is("236 ms"));
+        assertThat(reportResult.getFeatureReport().getFormattedDurations(), is("236 ms"));
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/TagsTest.java
+++ b/src/test/java/net/masterthought/cucumber/TagsTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hamcrest.core.StringContains;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -100,5 +101,17 @@ public class TagsTest {
         Element secondElement = elements.get(1);
         assertThat(firstElement.getRawName(), is("scenario1 for tag2"));
         assertThat(secondElement.getRawName(), is("scenario2 for tag2"));
+    }
+
+    @Test
+    public void shouldGetDurations() {
+        TagObject tag = reportResult.getAllTags().get(0);
+        assertThat(tag.getDurations(), is(1106277L));
+    }
+
+    @Test
+    public void shouldGetFormattedDurations() {
+        TagObject tag = reportResult.getAllTags().get(0);
+        assertThat(tag.getFormattedDurations(), StringContains.containsString("ms"));
     }
 }

--- a/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageIntegrationTest.java
@@ -115,11 +115,13 @@ public class FeaturesOverviewPageIntegrationTest extends Page {
         firstRow.hasExactValues("1st feature", "1", "1", "0", "10", "7", "0", "0", "2", "1", "0", "1m 39s 343 ms",
                 "Passed");
         firstRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "passed");
+        firstRow.hasExactDataValues("", "", "", "", "", "", "", "", "", "", "", "99343602889", "");
         firstRow.getReportLink().hasLabelAndAddress("1st feature", "net-masterthought-example-s--ATM-local-feature.html");
 
         TableRowAssertion secondRow = bodyRows[1];
         secondRow.hasExactValues("Second feature", "1", "0", "1", "9", "4", "1", "3", "0", "0", "1", "002 ms", "Failed");
         secondRow.hasExactCSSClasses("tagname", "", "", "", "", "", "failed", "skipped", "", "", "missing", "duration", "failed");
+        secondRow.hasExactDataValues("", "", "", "", "", "", "", "", "", "", "", "2050000", "");
         secondRow.getReportLink().hasLabelAndAddress("Second feature", "net-masterthought-example-ATMK-feature.html");
     }
 

--- a/src/test/java/net/masterthought/cucumber/generators/TagsOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TagsOverviewPageIntegrationTest.java
@@ -112,16 +112,19 @@ public class TagsOverviewPageIntegrationTest extends Page {
         TableRowAssertion firstRow = bodyRows[0];
         firstRow.hasExactValues("@checkout", "2", "1", "1", "16", "8", "1", "3", "2", "1", "1", "231 ms", "Failed");
         firstRow.hasExactCSSClasses("tagname", "", "", "", "", "", "failed", "skipped", "pending", "undefined", "missing", "duration", "failed");
+        firstRow.hasExactDataValues("", "", "", "", "", "", "", "", "", "", "", "231054778", "");
         firstRow.getReportLink().hasLabelAndAddress("@checkout", "checkout.html");
 
         TableRowAssertion secondRow = bodyRows[1];
         secondRow.hasExactValues("@fast", "1", "1", "0", "7", "4", "0", "0", "2", "1", "0", "229 ms", "Passed");
         secondRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "passed");
+        secondRow.hasExactDataValues("", "", "", "", "", "", "", "", "", "", "", "229004778", "");
         secondRow.getReportLink().hasLabelAndAddress("@fast", "fast.html");
 
         TableRowAssertion lastRow = bodyRows[2];
         lastRow.hasExactValues("@featureTag", "1", "1", "0", "7", "4", "0", "0", "2", "1", "0", "229 ms", "Passed");
         lastRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "passed");
+        lastRow.hasExactDataValues("", "", "", "", "", "", "", "", "", "", "", "229004778", "");
         lastRow.getReportLink().hasLabelAndAddress("@featureTag", "featureTag.html");
     }
 

--- a/src/test/java/net/masterthought/cucumber/json/support/StepObjectTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/support/StepObjectTest.java
@@ -1,0 +1,26 @@
+package net.masterthought.cucumber.json.support;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Sam Park (midopa@github)
+ */
+public class StepObjectTest {
+
+    @Test
+    public void averageDurationsReturnsTime() {
+        // given
+        StepObject stepObj = new StepObject("Test step location");
+        stepObj.addDuration(100L, "passed");
+        stepObj.addDuration(200L, "failed");
+        stepObj.addDuration(300L, "undefined");
+
+        // when
+        long avgDuration = stepObj.getAverageDuration();
+
+        // then
+        assertEquals(avgDuration, (100L + 200L + 300L)/3);
+    }
+}


### PR DESCRIPTION
Implementing the rest of #401 

Added raw duration values to features and tags overview pages for correct sorting capability.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/414%23issuecomment-215167778%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/414%23discussion_r61305828%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/414%23issuecomment-215167778%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A60.61%25%2A%2A%5Cn%3E%20Merging%20%5B%23414%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20increase%20coverage%20by%20%2A%2A%2B0.45%25%2A%2A%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23414%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20680%20%20%20%20%20%20%20%20683%20%20%20%20%20%2B3%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%2087%20%20%20%20%20%20%20%20%2087%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20409%20%20%20%20%20%20%20%20414%20%20%20%20%20%2B5%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20%20%20249%20%20%20%20%20%20%20%20247%20%20%20%20%20-2%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%2022%20%20%20%20%20%20%20%20%2022%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn1.%20File%20%60...port/StepObject.java%60%20%28not%20in%20diff%29%20was%20modified.%20%5Bmore%5D%28https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/commit/3a65c4e9a66ad9d858fda689578b69a5263b7d27/changes%3Fsrc%3Dpr%237372632F6D61696E2F6A6176612F6E65742F6D617374657274686F756768742F637563756D6265722F6A736F6E2F737570706F72742F537465704F626A6563742E6A617661%29%20%5Cn%20%20-%20Misses%20%60-1%60%20%5Cn%20%20-%20Partials%20%600%60%20%5Cn%20%20-%20Hits%20%60%2B1%60%5Cn%5Cn%5B%21%5BSunburst%5D%28https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/414/graphs/sunburst.svg%3Fsrc%3Dpr%26size%3D200%29%5D%5Bcc-pull%5D%5Cn%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%203a65c4e%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/414%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-04-27T17%3A44%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%203a65c4e9a66ad9d858fda689578b69a5263b7d27%20src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageIntegrationTest.java%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/414%23discussion_r61305828%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22since%20this%20work%20only%20for%20duration%20that%20would%20be%20better%20to%20use%20hasValidDuration%20and%20check%20value%20and%20data%20at%20once%20-%20skipping%20other%20empty%20items%22%2C%20%22created_at%22%3A%20%222016-04-27T17%3A57%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageIntegrationTest.java%3AL115-128%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/414#issuecomment-215167778'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **60.61%**
> Merging [#414][cc-pull] into [master][cc-base-branch] will increase coverage by **+0.45%**
```diff
@@             master       #414   diff @@
==========================================
Files            29         29
Lines           680        683     +3
Methods           0          0
Messages          0          0
Branches         87         87
==========================================
+ Hits            409        414     +5
+ Misses          249        247     -2
Partials         22         22
```
1. File `...port/StepObject.java` (not in diff) was modified. [more](https://codecov.io/gh/damianszczepanik/cucumber-reporting/commit/3a65c4e9a66ad9d858fda689578b69a5263b7d27/changes?src=pr#7372632F6D61696E2F6A6176612F6E65742F6D617374657274686F756768742F637563756D6265722F6A736F6E2F737570706F72742F537465704F626A6563742E6A617661)
- Misses `-1`
- Partials `0`
- Hits `+1`
[![Sunburst](https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/414/graphs/sunburst.svg?src=pr&size=200)][cc-pull]
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by 3a65c4e
[cc-base-branch]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master?src=pr
[cc-pull]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/414?src=pr
- [ ] <a href='#crh-comment-Pull 3a65c4e9a66ad9d858fda689578b69a5263b7d27 src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageIntegrationTest.java 10'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/414#discussion_r61305828'>File: src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageIntegrationTest.java:L115-128</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> since this work only for duration that would be better to use hasValidDuration and check value and data at once - skipping other empty items


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/414?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/414?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/414'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>