### PR TITLE
Tweaks to report HTML

### DIFF
--- a/src/main/resources/css/reporting.css
+++ b/src/main/resources/css/reporting.css
@@ -21,14 +21,6 @@ a:hover {
     font-style: italic;
 }
 
-.hidden {
-    display: none;
-}
-
-.visible {
-    display: block;
-}
-
 .keyword {
     font-weight: bold;
 }
@@ -38,7 +30,7 @@ a:hover {
 }
 
 .inner-level {
-    margin-bottom: 10px;
+    margin-bottom: 5px;
     margin-top: 5px;
     margin-left: 20px;
     padding-left: 1px;
@@ -47,6 +39,14 @@ a:hover {
 .element {
     margin-top: 15px;
     padding-left: 3px;
+}
+
+/* background elements will be moved closer to their respective scenarios.
+so don't want to indent again. keeps background and scenario visually coupled */
+.element.background {
+    margin-top: 0;
+    padding-left: 0;
+    box-shadow: none !important;
 }
 
 .element:hover, .steps:hover, .hooks:hover {
@@ -77,6 +77,11 @@ a:hover {
     background-color: #f5f5f5;
     border: 1px solid #ccc;
     border-radius: 4px
+}
+
+.embedding img {
+    max-width: 100%;
+    max-height: 100%;
 }
 
 /* names of those classes must be the same as name of the statuses (to lower case) in Status class  */
@@ -111,9 +116,7 @@ a:hover {
 
 table.stats-table {
     background-color: white;
-    color: black;
     margin-bottom: 20px;
-    width: 100%;
 }
 
 table.stats-table th, table.stats-table td {
@@ -157,8 +160,20 @@ table.step-arguments th, table.step-arguments td {
     text-align: left;
 }
 
-table#tablesorter thead tr th {
+table#tablesorter thead tr:not(.dont-sort) th {
     cursor: pointer;
+}
+
+.tablesorter-headerUnSorted .tablesorter-icon:after {
+    content: '\f0dc';
+}
+
+.tablesorter-headerDesc .tablesorter-icon:after {
+    content: "\f0dd";
+}
+
+.tablesorter-headerAsc .tablesorter-icon:after {
+    content: "\f0de";
 }
 
 .collapsable-control {
@@ -172,13 +187,6 @@ table#tablesorter thead tr th {
 .collapsed .chevron:after {
     content: "\f054";
 }
-
-.footer {
-    font-size: smaller;
-    text-align: center;
-    margin-top: 30px;
-}
-
 
 
 /* Custom Bootstrap CSS overloading. */
@@ -206,4 +214,8 @@ table#tablesorter thead tr th {
 pre {
     margin-left: 10px;
     margin-right: 10px;
+}
+
+* {
+    transition: all 0.3s;
 }

--- a/src/main/resources/templates/footer.html
+++ b/src/main/resources/templates/footer.html
@@ -1,8 +1,10 @@
-<nav class="navbar navbar-default" id="footer">
+<nav class="navbar navbar-default navbar-bottom" id="footer">
   <div class="container-fluid">
-    <p class="navbar-text navbar-right">
-      <a class="navbar-link" href="https://github.com/jenkinsci/cucumber-reports-plugin">Jenkins Plugin</a> |
-      <a class="navbar-link" href="https://github.com/damianszczepanik/cucumber-reporting">Cucumber-JVM Reports</a>
-    </p>
+    <div class="collapse navbar-collapse">
+        <p class="navbar-text navbar-right">
+          <a class="navbar-link" href="https://github.com/jenkinsci/cucumber-reports-plugin">Jenkins Plugin</a> |
+          <a class="navbar-link" href="https://github.com/damianszczepanik/cucumber-reporting">Cucumber-JVM Reports</a>
+        </p>
+    </div>
   </div>
 </nav>

--- a/src/main/resources/templates/generators/featuresOverview.vm
+++ b/src/main/resources/templates/generators/featuresOverview.vm
@@ -6,6 +6,8 @@
 
   <script type="text/javascript">
   $(function () {
+    var anim_time_ms = 300;
+
     $('#steps_chart').highcharts({
         chart: {
             type: 'pie',
@@ -13,7 +15,8 @@
                 enabled: true,
                 alpha: 45,
                 beta: 0
-            }
+            },
+            animation: {duration: anim_time_ms}
         },
         title: {
             text: 'Steps',
@@ -43,6 +46,9 @@
                         color: 'indigo'
                     }
                 }
+            },
+            series: {
+                animation: {duration: anim_time_ms}
             }
         },
         series: [{
@@ -91,7 +97,8 @@
             options3d: {
                 enabled: true,
                 alpha: 45
-            }
+            },
+            animation: {duration: anim_time_ms}
         },
         title: {
             text: 'Scenarios',
@@ -122,6 +129,9 @@
                         color: 'indigo'
                     }
                 }
+            },
+            series: {
+                animation: {duration: anim_time_ms}
             }
         },
         series: [{
@@ -148,6 +158,7 @@
         chart: {
             type: 'pie',
             plotShadow: false,
+            animation: {duration: anim_time_ms}
         },
         title: {
             text: 'Features',
@@ -177,6 +188,9 @@
                 startAngle: -90,
                 endAngle: 90,
                 center: ['50%', '75%']
+            },
+            series: {
+                animation: {duration: anim_time_ms}
             }
         },
         series: [{

--- a/src/main/resources/templates/generators/stepsOverview.vm
+++ b/src/main/resources/templates/generators/stepsOverview.vm
@@ -20,7 +20,7 @@
       #if($all_steps.isEmpty())
         <p>You have no features in your cucumber report</p>
       #else
-        <table id="tablesorter" class="stats-table">
+        <table id="tablesorter" class="table table-hover table-striped table-bordered stats-table">
 
           <thead>
             <tr class="header">

--- a/src/main/resources/templates/generators/tagsOverview.vm
+++ b/src/main/resources/templates/generators/tagsOverview.vm
@@ -6,6 +6,7 @@
 
   <script type="text/javascript">
     jQuery(document).ready(function() {
+        var anim_time_ms = 300;
 
         var chartData = $chart_data,
             chartCategory = $chart_categories,
@@ -59,7 +60,8 @@
                     alpha: 10,
                     beta: 25,
                     depth: 70
-                }
+                },
+                animation: {duration: anim_time_ms}
             },
             title: {
                 text: 'Tags',
@@ -98,6 +100,9 @@
             plotOptions: {
                 column: {
                     stacking: 'percent'
+                },
+                series: {
+                    animation: {duration: anim_time_ms}
                 }
             },
             series: formattedData

--- a/src/main/resources/templates/head.html
+++ b/src/main/resources/templates/head.html
@@ -17,7 +17,25 @@ $(document).ready(function() {
     // if present, it'll sort by that instead
     // otherwise, it'll sort by the text content of the table cell
     $("#tablesorter").tablesorter({
-        textAttribute: 'data-value'
+        textAttribute: 'data-value',
+        // this allows us to add an up/down chevron using css when a column is
+        // sorted
+        headerTemplate: '{content} {icon}',
+        // ignores the first row of the header, the 'scenario', 'steps', since
+        // sorting those doesn't make sense
+        selectorHeaders: '> thead tr:not(.dont-sort) th',
+        // use a stable sort
+        sortStable: true
     });
+
+    // reshuffle background results so they are visually coupled with their
+    // respective scenarios
+    $('.background').each(function(idx, el) {
+        el = $(el);
+        el.insertAfter(el.find('+ .scenario .tags'));
+    });
+
+    // adds sorting chevrons to table header rows that can sort
+    $('.tablesorter-icon').addClass('fa').addClass('fa-fw');
 });
 </script>

--- a/src/main/resources/templates/macros/report/elements.vm
+++ b/src/main/resources/templates/macros/report/elements.vm
@@ -1,7 +1,7 @@
 #macro(includeElements, $elements, $linkToFeature)
 
 #foreach($element in $elements)
-  <div class="element">
+  <div class="element $element.getKeyword().toLowerCase()">
     #if ($linkToFeature)
       <div class="indention">
         <a href="$element.getFeature().getReportFileName()">View Feature</a> <i>$element.getFeature().getName()</i>
@@ -10,46 +10,38 @@
 
     #includeTags($element.getTags())
 
-    <span data-toggle="collapse" class="#if ($element.getElementStatus().isPassed()) collapsed #end collapsable-control" data-target="#element-$element.hashCode()">
+    <span data-toggle="collapse" class="#if ($element.getElementStatus().isPassed()) collapsed #end collapsable-control" data-target="#steps-$element.getSteps().hashCode()">
       #includeBrief($element.getKeyword(), $element.getElementStatus(), $element.getName(), true)
     </span>
     <div class="description indention">$element.getDescription()</div>
 
-    <span id="element-$element.hashCode()" class="collapse collapsable-details #if(!$element.getElementStatus().isPassed()) in #end">
-      #includeHooks("Before", $element.getBefore(), $element.getBeforeStatus())
+      <div id="steps-$element.getSteps().hashCode()" class="steps inner-level collapse collapsable-details #if(!$element.getElementStatus().isPassed()) in #end">
+        #includeHooks("Before", $element.getBefore(), $element.getBeforeStatus())
 
-      <div class="steps inner-level">
-        <div data-toggle="collapse" class="#if ($element.getElementStatus().isPassed()) collapsed #end collapsable-control" data-target="#steps-$element.getSteps().hashCode()">
-          #includeBrief("Steps", $element.getStepsStatus(), "", true)
-        </div>
+        #foreach($step in $element.getSteps())
+          <div class="step">
+            #includeBrief($step.getKeyword(), $step.getStatus(), $step.getName(), false, $step.getResult())
+            #includeMessage("Error message", $step.getErrorMessage())
 
-        <div id="steps-$element.getSteps().hashCode()" class="inner-level collapse collapsable-details #if (!$element.getElementStatus().isPassed()) in #end">
-          #foreach($step in $element.getSteps())
-            <div class="step">
-              #includeBrief($step.getKeyword(), $step.getStatus(), $step.getName(), false, $step.getResult())
-              #includeMessage("Error message", $step.getErrorMessage())
+            #if ($step.hasRows())
+              <table class="step-arguments">
+                #foreach($row in $step.getRows())
+                  <tr>
+                    #foreach($cell in $row.getCells())
+                      <td>$cell</td>
+                    #end
+                  </tr>
+                #end
+              </table>
+            #end
 
-              #if ($step.hasRows())
-                <table class="step-arguments">
-                  #foreach($row in $step.getRows())
-                    <tr>
-                      #foreach($cell in $row.getCells())
-                        <td>$cell</td>
-                      #end
-                    </tr>
-                  #end
-                </table>
-              #end
+            #includeMessage("Output", $step.getOutput())
+            #includeEmbeddings($step.getEmbeddings())
+          </div>
+        #end
 
-              #includeMessage("Output", $step.getOutput())
-              #includeEmbeddings($step.getEmbeddings())
-            </div>
-          #end
-        </div>
+        #includeHooks("After", $element.getAfter(), $element.getAfterStatus())
       </div>
-
-      #includeHooks("After", $element.getAfter(), $element.getAfterStatus())
-    <span>
   </div>
 #end
 

--- a/src/main/resources/templates/macros/report/embeddings.vm
+++ b/src/main/resources/templates/macros/report/embeddings.vm
@@ -1,6 +1,6 @@
 #macro(includeEmbeddings, $embeddings)
 
-#if ($embeddings)
+#if ($embeddings.size() > 0)
   <div class="embeddings inner-level">
   #foreach($embedding in $embeddings)
     #if ($embedding.getMimeType() == "image/png")
@@ -51,8 +51,11 @@
 #macro(includeExpandableEmbedding, $embedding, $type, $content, $index)
   #set($index = $index + 1)
   <div class="embedding indention">
-    <a onclick="attachment=document.getElementById('embedding_$embedding.hashCode()'); attachment.className = (attachment.className == 'hidden' ? 'visible' : 'hidden'); return false" href="#">
-      Attachment $index ($type)</a>
-    <div id="embedding_$embedding.hashCode()" class="hidden"><span class="embedding-box">$content</span></div>
+    <div data-toggle="collapse" data-target="#embedding_$embedding.hashCode()" class="collapsable-control">
+      Attachment $index ($type)
+    </div>
+    <div id="embedding_$embedding.hashCode()" class="collapse collapsable-detail">
+      <span class="embedding-box">$content</span>
+    </div>
   </div>
 #end

--- a/src/main/resources/templates/macros/report/hooks.vm
+++ b/src/main/resources/templates/macros/report/hooks.vm
@@ -1,29 +1,21 @@
 #macro(includeHooks, $keyword, $hooks, $status)
 
 #if($hooks.size() > 0)
-  <div class="inner-level hooks-$keyword.toLowerCase()">
-    <div data-toggle="collapse" class="#if($status.isPassed()) collapsed #end collapsable-control" data-target="#$keyword.toLowerCase()-$hooks.hashCode()">
-      #includeBrief("Hooks", $status, "", true)
-    </div>
+  #foreach($hook in $hooks)
+    <div class="hook $keyword.toLowerCase()">
+      <div class="brief $hook.getStatus().getRawName()">
+        <span class="keyword indention">$keyword</span>
+        #if ($hook.getMatch())
+          <span class="location name">$hook.getMatch().getLocation()</span>
+        #end
+        #includeDuration($hook.getResult())
+      </div>
 
-    <div id="$keyword.toLowerCase()-$hooks.hashCode()" class="inner-level collapse collapsable-details #if (!$status.isPassed()) in #end">
-      #foreach($hook in $hooks)
-        <div class="hook">
-          <div class="brief $hook.getStatus().getRawName()">
-            <span class="keyword indention">$keyword</span>
-            #if ($hook.getMatch())
-              <span class="location name">$hook.getMatch().getLocation()</span>
-            #end
-            #includeDuration($hook.getResult())
-          </div>
-
-          #if ($hook.getResult())
-            #includeMessage("Error message", $hook.getResult().getErrorMessage())
-          #end
-        </div>
+      #if ($hook.getResult())
+        #includeMessage("Error message", $hook.getResult().getErrorMessage())
       #end
     </div>
-  </div>
+  #end
 #end
 
 #end

--- a/src/main/resources/templates/macros/report/message.vm
+++ b/src/main/resources/templates/macros/report/message.vm
@@ -3,8 +3,12 @@
 #if ($message)
   <div class="inner-level">
     <div class="message indention">
-      <a onclick="message=document.getElementById('$message.hashCode()'); message.className = (message.className == 'hidden' ? 'visible' : 'hidden'); return false" href="#">$messageName</a>
-      <div id="$message.hashCode()" class="hidden"><pre>$message</pre></div>
+      <span data-toggle="collapse" class='collapsable-control' data-target='#msg-$message.hashCode()'>
+        <div>
+          $messageName
+        </div>
+      </span>
+      <div id="msg-$message.hashCode()" class="collapse collapsable-details"><pre>$message</pre></div>
     </div>
   </div>
 #end

--- a/src/main/resources/templates/macros/report/reportHeader.vm
+++ b/src/main/resources/templates/macros/report/reportHeader.vm
@@ -1,6 +1,6 @@
 #macro(includeReportHeader, $table_key, $parallel)
 <thead>
-  <tr class="header">
+  <tr class="header dont-sort">
     #if($parallel)
       <th></th>
     #end

--- a/src/main/resources/templates/macros/report/reportTable.vm
+++ b/src/main/resources/templates/macros/report/reportTable.vm
@@ -1,8 +1,8 @@
 #macro(includeReportTable, $table_key, $reportable, $parallel)
-<div class="container-fluid" id="summary">
+<div class="container" id="summary">
   <div class="row">
-    <div class="col-md-10 col-md-offset-1">
-      <table class="stats-table">
+    <div class="col-md-5 col-md-offset-1">
+      <table class="table stats-table table-bordered">
 
         #includeReportHeader($table_key, $parallel)
 

--- a/src/main/resources/templates/macros/report/statsTable.vm
+++ b/src/main/resources/templates/macros/report/statsTable.vm
@@ -1,6 +1,6 @@
 #macro(includeStatsTable, $table_key, $parallel, $elements, $report_summary)
 
-<table id="tablesorter" class="stats-table">
+<table id="tablesorter" class="table stats-table table-hover table-bordered">
   #includeReportHeader($table_key, $parallel)
 
   <tbody>

--- a/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageIntegrationTest.java
@@ -1,27 +1,11 @@
 package net.masterthought.cucumber.generators;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import net.masterthought.cucumber.generators.helpers.*;
+import net.masterthought.cucumber.json.*;
+import org.junit.Assert;
 import org.junit.Test;
 
-import net.masterthought.cucumber.generators.helpers.BriefAssertion;
-import net.masterthought.cucumber.generators.helpers.DocumentAssertion;
-import net.masterthought.cucumber.generators.helpers.ElementAssertion;
-import net.masterthought.cucumber.generators.helpers.EmbeddingAssertion;
-import net.masterthought.cucumber.generators.helpers.FeatureAssertion;
-import net.masterthought.cucumber.generators.helpers.HookAssertion;
-import net.masterthought.cucumber.generators.helpers.HooksAssertion;
-import net.masterthought.cucumber.generators.helpers.StepAssertion;
-import net.masterthought.cucumber.generators.helpers.StepsAssertion;
-import net.masterthought.cucumber.generators.helpers.TableAssertion;
-import net.masterthought.cucumber.generators.helpers.TableRowAssertion;
-import net.masterthought.cucumber.generators.helpers.TagAssertion;
-import net.masterthought.cucumber.json.Element;
-import net.masterthought.cucumber.json.Embedding;
-import net.masterthought.cucumber.json.Feature;
-import net.masterthought.cucumber.json.Hook;
-import net.masterthought.cucumber.json.Row;
-import net.masterthought.cucumber.json.Step;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -146,11 +130,11 @@ public class FeatureReportPageIntegrationTest extends Page {
 
         Element element = feature.getElements()[0];
 
-        HooksAssertion beforeHooks = secondElement.getBefore();
-        HookAssertion[] before = beforeHooks.getHooks();
-        assertThat(before).hasSize(element.getBefore().length);
-        validateHook(before, element.getBefore(), "Before");
-        BriefAssertion beforeBrief = beforeHooks.getBrief();
+        HooksAssertion[] beforeHooks = secondElement.getBefores();
+        Assert.assertEquals(beforeHooks.length, element.getBefore().length);
+        assertThat(beforeHooks).hasSize(element.getBefore().length);
+        validateHook(beforeHooks[0].getHooks(), element.getBefore(), "Before");
+        BriefAssertion beforeBrief = beforeHooks[1].getBrief();
         beforeBrief.hasStatus(element.getBeforeStatus());
 
         HooksAssertion afterHooks = secondElement.getAfter();
@@ -178,8 +162,9 @@ public class FeatureReportPageIntegrationTest extends Page {
         ElementAssertion secondElement = document.getFeature().getElements()[0];
         Element element = feature.getElements()[0];
 
+        secondElement.getBrief().hasStatus(element.getStepsStatus());
+
         StepsAssertion stepsSection = secondElement.getSteps();
-        stepsSection.getBrief().hasStatus(element.getStepsStatus());
         StepAssertion[] steps = stepsSection.getSteps();
         assertThat(steps).hasSameSizeAs(element.getSteps());
 

--- a/src/test/java/net/masterthought/cucumber/generators/helpers/ElementAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/helpers/ElementAssertion.java
@@ -15,12 +15,12 @@ public class ElementAssertion extends ReportAssertion {
         return super.getCollapseControl(BriefAssertion.class).getBrief();
     }
 
-    public HooksAssertion getBefore() {
-        return oneByClass("hooks-before", HooksAssertion.class);
+    public HooksAssertion[] getBefores() {
+        return allByClass("before", HooksAssertion.class);
     }
 
     public HooksAssertion getAfter() {
-        return oneByClass("hooks-after", HooksAssertion.class);
+        return oneByClass("after", HooksAssertion.class);
     }
 
     public StepsAssertion getSteps() {

--- a/src/test/java/net/masterthought/cucumber/generators/helpers/HooksAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/helpers/HooksAssertion.java
@@ -7,7 +7,7 @@ public class HooksAssertion extends ReportAssertion {
 
     @Override
     public BriefAssertion getBrief() {
-        return super.getCollapseControl(BriefAssertion.class).getBrief();
+        return super.getBrief();
     }
 
     public HookAssertion[] getHooks() {

--- a/src/test/java/net/masterthought/cucumber/generators/helpers/StepsAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/helpers/StepsAssertion.java
@@ -7,7 +7,7 @@ public class StepsAssertion extends ReportAssertion {
 
     @Override
     public BriefAssertion getBrief() {
-        return super.getCollapseControl(BriefAssertion.class).getBrief();
+        return super.getBrief();
     }
 
     public StepAssertion[] getSteps() {


### PR DESCRIPTION
- Put Before, Steps, and After elements all on the same level, under Scenarios. Results are easier to read and navigate.
- Shift Background results closer to their Scenarios so they're visually coupled
- Make embedded images fit into page width
- Use Lumen 
- Disabled sorting on first header row. Didn't make sense to have this.
- Added icons to sortable header row
- Stable sorting is now used. Ensures each sort looks consistent
- Fix: Don't add embedded content when it doesn't exist
- Sped up animations for highcharts
- Steps summary has striped table rows to make it easier to view
- Most tables have row-hover effects applied
- Used same bootstrap collapse function on messages
- Minor fix to footer so it fits browser width
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/422%23issuecomment-216024434%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/422%23issuecomment-216031350%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/422%23discussion_r61685186%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/422%23issuecomment-216024434%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A69.47%25%2A%2A%5Cn%3E%20Merging%20%5B%23422%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20not%20change%20coverage%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23422%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20655%20%20%20%20%20%20%20%20655%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%2084%20%20%20%20%20%20%20%20%2084%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%20%20%20455%20%20%20%20%20%20%20%20455%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20200%20%20%20%20%20%20%20%20200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5Beb6b1c0...4c69ba5%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/compare/eb6b1c0cd0d2038f5affba063b614047f234a467...4c69ba55bdce2d8cad9b4459a33877d57e1efc99%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/422%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-05-01T08%3A01%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nice%20tweak%2C%20my%20comments%20below%3A%5Cr%5Cn%5Cr%5Cn-%20Put%20Before%2C%20Steps%2C%20and%20After%20elements%20all%20on%20the%20same%20level%2C%20under%20Scenarios.%20Results%20are%20easier%20to%20read%20and%20navigate.%5Cr%5Cn%3E%20This%20has%20been%20changed%20recently%20%28but%20not%20released%29%20according%20to%20%23415%20so%20now%20hooks%20are%20expandable%20%28and%20collapsed%20for%20passing%20items%29%20and%20right%20now%20you%20reverted%20this%20change.%20Please%20keep%20old%20version%20which%20also%20added%20space%20between%20hooks%20and%20steps%20-%20currently%20there%20is%20no%20visual%20space%20before/after%20steps%5Cr%5Cn%5Cr%5Cn-%20Shift%20Background%20results%20closer%20to%20their%20Scenarios%20so%20they%27re%20visually%20coupled%5Cr%5Cn%3E%20Nice%2C%20would%20be%20nice%20to%20have%20some%20space%20between%20%60%60Background%60%60%20and%20%60%60Scenario%60%60%20section%20but%20that%20might%20be%20a%20part%20for%20next%20improvements%5Cr%5Cn%5Cr%5Cn-%20Make%20embedded%20images%20fit%20into%20page%20width%5Cr%5Cn%3E%20Embedded%20are%20collapsed%20by%20default%20so%20there%20is%20no%20need%20to%20make%20them%20page-width.%20When%20the%20screenshot%20is%20wider%20than%20page%2C%20then%20horizontal%20scroll%20appears.%20Keep%20the%20previous%20solution.%20Also%20because%20of%20the%20%23380%5Cr%5Cn%5Cr%5Cn-%20Use%20Lumen%5Cr%5Cn%3E%20Can%20you%20provide%20more%20details%20about%20it%3F%5Cr%5Cn%5Cr%5Cn-%20Disabled%20sorting%20on%20first%20header%20row.%20Didn%27t%20make%20sense%20to%20have%20this.%5Cr%5Cn%3E%20Right%5Cr%5Cn%5Cr%5Cn-%20Added%20icons%20to%20sortable%20header%20row%5Cr%5Cn%3E%20But%20now%20the%20width%20of%20the%20cells%20are%20bigger%20so%20the%20first%20cell%20is%20narrower%20and%20most%20of%20the%20features%20are%20not%20presented%20in%20single%20line%20so%20the%20while%20table%20is%20bigger%20than%20it%20should%20be.%20I%20prefer%20to%20have%20different%20cursor%20that%20tells%20user%20that%20sorting%20is%20supported%20and%20to%20have%20ugly%20table%20at%20all%5Cr%5Cn%5Cr%5Cn-%20Stable%20sorting%20is%20now%20used.%20Ensures%20each%20sort%20looks%20consistent%5Cr%5Cn%3E%20What%20do%20you%20mean%3F%5Cr%5Cn%5Cr%5Cn-%20Fix%3A%20Don%27t%20add%20embedded%20content%20when%20it%20doesn%27t%20exist%5Cr%5Cn%3E%20When%20this%20case%20happens%3F%20Maybe%20it%20is%20worth%20to%20display%20information%20about%20missing%20embedded%20than%20hiding%20such%20information%20in%20report%3F%5Cr%5Cn%5Cr%5Cn-%20Sped%20up%20animations%20for%20highcharts%5Cr%5Cn%3E%20I%20preferred%20the%20old%20one%20%3A%28%5Cr%5Cn%5Cr%5Cn-%20Steps%20summary%20has%20striped%20table%20rows%20to%20make%20it%20easier%20to%20view%5Cr%5Cn%3E%20I%20disagree%5Cr%5Cn%5Cr%5Cn-%20Most%20tables%20have%20row-hover%20effects%20applied%5Cr%5Cn%3E%20What%20do%20you%20mean%3F%5Cr%5Cn%5Cr%5Cn-%20Used%20same%20bootstrap%20collapse%20function%20on%20messages%5Cr%5Cn%3E%20Nice%21%5Cr%5Cn%5Cr%5Cn-%20Minor%20fix%20to%20footer%20so%20it%20fits%20browser%20width%5Cr%5Cn%3E%20I%20see%20regression%20on%20smaller%20screens%20-%20bar%20is%20not%20displayed%5Cr%5Cn%5Cr%5Cn%5Cr%5CnAlso%20I%20would%20be%20happy%20if%20you%20can%20split%20this%20huge%20PR%20into%20a%20few%20that%20are%20smaller%20and%20easier%20to%20review%22%2C%20%22created_at%22%3A%20%222016-05-01T09%3A48%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f03921ca198a83989b99e09e9254f949993926be%20src/main/resources/css/reporting.css%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/422%23discussion_r61685186%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%21%5BCodacy%5D%28https%3A//www.codacy.com/assets/images/favicon.png%29%20Issue%20found%3A%20%5BUse%20of%20%21important%5D%28https%3A//www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2496596343/issues/source%3Fbid%3D3059308%26fileBranchId%3D3269761%23l49%29%22%2C%20%22created_at%22%3A%20%222016-05-01T10%3A53%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/resources/css/reporting.css%3AL41-55%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/422#issuecomment-216024434'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **69.47%**
> Merging [#422][cc-pull] into [master][cc-base-branch] will not change coverage
```diff
@@             master       #422   diff @@
==========================================
Files            29         29
Lines           655        655
Methods           0          0
Messages          0          0
Branches         84         84
==========================================
Hits            455        455
Misses          200        200
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [eb6b1c0...4c69ba5][cc-compare]
[cc-base-branch]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/compare/eb6b1c0cd0d2038f5affba063b614047f234a467...4c69ba55bdce2d8cad9b4459a33877d57e1efc99
[cc-pull]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/422?src=pr
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Nice tweak, my comments below:
- Put Before, Steps, and After elements all on the same level, under Scenarios. Results are easier to read and navigate.
> This has been changed recently (but not released) according to #415 so now hooks are expandable (and collapsed for passing items) and right now you reverted this change. Please keep old version which also added space between hooks and steps - currently there is no visual space before/after steps
- Shift Background results closer to their Scenarios so they're visually coupled
> Nice, would be nice to have some space between ``Background`` and ``Scenario`` section but that might be a part for next improvements
- Make embedded images fit into page width
> Embedded are collapsed by default so there is no need to make them page-width. When the screenshot is wider than page, then horizontal scroll appears. Keep the previous solution. Also because of the #380
- Use Lumen
> Can you provide more details about it?
- Disabled sorting on first header row. Didn't make sense to have this.
> Right
- Added icons to sortable header row
> But now the width of the cells are bigger so the first cell is narrower and most of the features are not presented in single line so the while table is bigger than it should be. I prefer to have different cursor that tells user that sorting is supported and to have ugly table at all
- Stable sorting is now used. Ensures each sort looks consistent
> What do you mean?
- Fix: Don't add embedded content when it doesn't exist
> When this case happens? Maybe it is worth to display information about missing embedded than hiding such information in report?
- Sped up animations for highcharts
> I preferred the old one :(
- Steps summary has striped table rows to make it easier to view
> I disagree
- Most tables have row-hover effects applied
> What do you mean?
- Used same bootstrap collapse function on messages
> Nice!
- Minor fix to footer so it fits browser width
> I see regression on smaller screens - bar is not displayed
Also I would be happy if you can split this huge PR into a few that are smaller and easier to review
- [ ] <a href='#crh-comment-Pull f03921ca198a83989b99e09e9254f949993926be src/main/resources/css/reporting.css 33'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/422#discussion_r61685186'>File: src/main/resources/css/reporting.css:L41-55</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> ![Codacy](https://www.codacy.com/assets/images/favicon.png) Issue found: [Use of !important](https://www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2496596343/issues/source?bid=3059308&fileBranchId=3269761#l49)


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/422?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/422?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/422'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>