### PR TITLE
Prevent top row headers from sorting

### DIFF
--- a/src/main/resources/css/reporting.css
+++ b/src/main/resources/css/reporting.css
@@ -157,7 +157,7 @@ table.step-arguments th, table.step-arguments td {
     text-align: left;
 }
 
-table#tablesorter thead tr th {
+table#tablesorter thead tr:not(.dont-sort) th {
     cursor: pointer;
 }
 

--- a/src/main/resources/templates/head.html
+++ b/src/main/resources/templates/head.html
@@ -17,7 +17,10 @@ $(document).ready(function() {
     // if present, it'll sort by that instead
     // otherwise, it'll sort by the text content of the table cell
     $("#tablesorter").tablesorter({
-        textAttribute: 'data-value'
+        textAttribute: 'data-value',
+        // ignores the first row of the header, the 'scenario', 'steps', since
+        // sorting those doesn't make sense
+        selectorHeaders: '> thead tr:not(.dont-sort) th',
     });
 });
 </script>

--- a/src/main/resources/templates/macros/report/reportHeader.vm
+++ b/src/main/resources/templates/macros/report/reportHeader.vm
@@ -1,6 +1,6 @@
 #macro(includeReportHeader, $table_key, $parallel)
 <thead>
-  <tr class="header">
+  <tr class="header dont-sort">
     #if($parallel)
       <th></th>
     #end


### PR DESCRIPTION
Sorting the "Scenario" and "Steps" column groups doesn't make sense
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/423?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/423'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>