### PR TITLE
Use bootstrap collapse function for message/embed content

### DIFF
--- a/src/main/resources/css/reporting.css
+++ b/src/main/resources/css/reporting.css
@@ -21,14 +21,6 @@ a:hover {
     font-style: italic;
 }
 
-.hidden {
-    display: none;
-}
-
-.visible {
-    display: block;
-}
-
 .keyword {
     font-weight: bold;
 }

--- a/src/main/resources/templates/macros/report/embeddings.vm
+++ b/src/main/resources/templates/macros/report/embeddings.vm
@@ -51,8 +51,11 @@
 #macro(includeExpandableEmbedding, $embedding, $type, $content, $index)
   #set($index = $index + 1)
   <div class="embedding indention">
-    <a onclick="attachment=document.getElementById('embedding_$embedding.hashCode()'); attachment.className = (attachment.className == 'hidden' ? 'visible' : 'hidden'); return false" href="#">
-      Attachment $index ($type)</a>
-    <div id="embedding_$embedding.hashCode()" class="hidden"><span class="embedding-box">$content</span></div>
+    <div data-toggle="collapse" data-target="#embedding_$embedding.hashCode()" class="collapsable-control">
+      <a>Attachment $index ($type)</a>
+    </div>
+    <div id="embedding_$embedding.hashCode()" class="collapse collapsable-detail">
+      <span class="embedding-box">$content</span>
+    </div>
   </div>
 #end

--- a/src/main/resources/templates/macros/report/message.vm
+++ b/src/main/resources/templates/macros/report/message.vm
@@ -3,8 +3,12 @@
 #if ($message)
   <div class="inner-level">
     <div class="message indention">
-      <a onclick="message=document.getElementById('$message.hashCode()'); message.className = (message.className == 'hidden' ? 'visible' : 'hidden'); return false" href="#">$messageName</a>
-      <div id="$message.hashCode()" class="hidden"><pre>$message</pre></div>
+      <div data-toggle="collapse" class="collapsable-control" data-target="#msg-$message.hashCode()">
+          <a>$messageName</a>
+      </div>
+      <div id="msg-$message.hashCode()" class="collapse collapsable-details">
+        <pre>$message</pre>
+      </div>
     </div>
   </div>
 #end


### PR DESCRIPTION
Was using custom JS to expand and collapse. Since bootstrap's collapse
was used recently for feature/scenario/step/hook collapsing, do the same
so the code is more consistent.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/424%23issuecomment-216073078%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/424%23discussion_r61711718%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/424%23issuecomment-216124483%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/424%23issuecomment-216744634%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/424%23issuecomment-218573019%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/424%23issuecomment-218573423%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/424%23issuecomment-216073078%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A69.47%25%2A%2A%5Cn%3E%20Merging%20%5B%23424%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20not%20change%20coverage%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23424%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20655%20%20%20%20%20%20%20%20655%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%2084%20%20%20%20%20%20%20%20%2084%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%20%20%20455%20%20%20%20%20%20%20%20455%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20200%20%20%20%20%20%20%20%20200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5Beb6b1c0...009e1a1%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/compare/eb6b1c0cd0d2038f5affba063b614047f234a467...009e1a1f8bf193cef27e2e46bf241460c776e1eb%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/424%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-05-01T21%3A13%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Makes%20sure%20that%20embeddings%20are%20expandable%20and%20users%20instantly%20knows%20it.%20Also%20squash%20both%20commits%20into%20one%22%2C%20%22created_at%22%3A%20%222016-05-02T07%3A41%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22FYI%20Codecov%20is%20reporting%20the%20wrong%20metrics%22%2C%20%22created_at%22%3A%20%222016-05-04T05%3A11%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40midopa%20%20any%20plan%20for%20this%20PR%3F%22%2C%20%22created_at%22%3A%20%222016-05-11T20%3A02%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20else%20needs%20to%20be%20done%3F%20I%27ve%20updated%20the%20UI.%20The%20code%20coverage%20metrics%20are%20wrong.%22%2C%20%22created_at%22%3A%20%222016-05-11T20%3A03%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201dd13d335bfb82b68ae3301409a4c0bfdb517d93%20src/main/resources/templates/macros/report/embeddings.vm%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/424%23discussion_r61711718%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ok%2C%20but%20by%20this%20change%20there%20is%20no%20clear%20UX%20that%20this%20div%20is%20expanded%5Cr%5Cn%5Cr%5Cnpreviously%20the%20label%20was%20presented%20as%20link%20so%20user%20knows%20that%20this%20is%20clickable%2C%20steps/hooks/elements%20has%20sign%20that%20indicates%20that%20div%20is%20already%20opened%20or%20can%20be%20opened%5Cr%5Cn%5Cr%5Cnnow%20you%20need%20to%20mouse%20over%20to%20see%20that%20this%20element%20is%20expandable%22%2C%20%22created_at%22%3A%20%222016-05-02T07%3A41%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/resources/templates/macros/report/embeddings.vm%3AL51-62%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/424#issuecomment-216073078'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **69.47%**
> Merging [#424][cc-pull] into [master][cc-base-branch] will not change coverage
```diff
@@             master       #424   diff @@
==========================================
Files            29         29
Lines           655        655
Methods           0          0
Messages          0          0
Branches         84         84
==========================================
Hits            455        455
Misses          200        200
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [eb6b1c0...009e1a1][cc-compare]
[cc-base-branch]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/compare/eb6b1c0cd0d2038f5affba063b614047f234a467...009e1a1f8bf193cef27e2e46bf241460c776e1eb
[cc-pull]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/424?src=pr
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Makes sure that embeddings are expandable and users instantly knows it. Also squash both commits into one
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> FYI Codecov is reporting the wrong metrics
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> @midopa  any plan for this PR?
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> What else needs to be done? I've updated the UI. The code coverage metrics are wrong.
- [x] <a href='#crh-comment-Pull 1dd13d335bfb82b68ae3301409a4c0bfdb517d93 src/main/resources/templates/macros/report/embeddings.vm 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/424#discussion_r61711718'>File: src/main/resources/templates/macros/report/embeddings.vm:L51-62</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> ok, but by this change there is no clear UX that this div is expanded
previously the label was presented as link so user knows that this is clickable, steps/hooks/elements has sign that indicates that div is already opened or can be opened
now you need to mouse over to see that this element is expandable


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/424?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/424?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/424'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>