### PR TITLE
Move backgrounds next to scenarios for visual coupling

### DIFF
--- a/src/main/resources/css/reporting.css
+++ b/src/main/resources/css/reporting.css
@@ -49,8 +49,19 @@ a:hover {
     padding-left: 3px;
 }
 
+/* background elements will be moved closer to their respective scenarios.
+so don't want to indent again. keeps background and scenario visually coupled */
+.element.background {
+    margin-top: 0;
+    padding-left: 0;
+}
+
+.element.background:hover {
+    box-shadow: none;
+}
+
 /* left line along each section */
-.element:hover, .steps:hover, .hooks-after:hover, .hooks-before:hover {
+.element:hover, .steps:hover, .hooks:hover {
     box-shadow: -3px 0px black;
 }
 

--- a/src/main/resources/templates/head.html
+++ b/src/main/resources/templates/head.html
@@ -24,5 +24,12 @@ $(document).ready(function() {
         // use a stable sort
         sortStable: true
     });
+
+    // reshuffle background results so they are visually coupled with their
+    // respective scenarios
+    $('.background').each(function(idx, el) {
+        el = $(el);
+        el.insertAfter(el.find('+ .scenario .tags'));
+    });
 });
 </script>

--- a/src/main/resources/templates/macros/report/elements.vm
+++ b/src/main/resources/templates/macros/report/elements.vm
@@ -1,7 +1,7 @@
 #macro(includeElements, $elements, $linkToFeature)
 
 #foreach($element in $elements)
-  <div class="element">
+  <div class="element $element.getKeyword().toLowerCase()">
     #if ($linkToFeature)
       <div class="indention">
         <a href="$element.getFeature().getReportFileName()">View Feature</a> <i>$element.getFeature().getName()</i>


### PR DESCRIPTION
This makes it clearer that a background was executed for a specific
scenario. Otherwise, it appears like the backgrounds kind of executed on
their own.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/426%23issuecomment-216074428%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/426%23issuecomment-216123106%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/426%23issuecomment-216433624%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/426%23issuecomment-216463819%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/426%23issuecomment-216744499%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/426%23issuecomment-216749895%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/426%23issuecomment-216750589%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/426%23issuecomment-216074428%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A69.47%25%2A%2A%5Cn%3E%20Merging%20%5B%23426%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20not%20change%20coverage%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23426%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20655%20%20%20%20%20%20%20%20655%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%2084%20%20%20%20%20%20%20%20%2084%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%20%20%20455%20%20%20%20%20%20%20%20455%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20200%20%20%20%20%20%20%20%20200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5Beb6b1c0...a57b4e8%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/compare/eb6b1c0cd0d2038f5affba063b614047f234a467...a57b4e8f84fee0144fcd93933739420d6119c17d%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/426%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-05-01T21%3A38%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22One%20remark%3A%20now%20background%20and%20scenario%20have%20one%20common%20box-shaddow%20%28displayed%20on%20hover%29%20-%20can%20you%20update%20CSS%20so%20there%20are%20two%20separates%20shadows%3F%22%2C%20%22created_at%22%3A%20%222016-05-02T07%3A30%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Short%20answer%2C%20yes%2C%20but%20not%20without%20a%20bit%20more%20tinkering.%5Cr%5Cn%5Cr%5CnI%20assume%20the%20visual%20order%20we%20want%20is%3A%5Cr%5Cn-%20Tags%5Cr%5Cn-%20Background%5Cr%5Cn-%20Scenario%5Cr%5Cn%5Cr%5CnThe%20first%20approach%20I%20used%20was%20to%20move%20the%20background%20div%20into%20the%20scenario%20div%2C%20after%20the%20tags%20div.%20And%20then%20disabled%20some%20CSS%20for%20the%20backgrounds.%5Cr%5Cn%5Cr%5CnTo%20get%20separate%20box-shadows%20for%20both%20background%20and%20scenarios%20while%20staying%20true%20to%20the%20above%20requirements%2C%20we%20need%20to%20move%20the%20tags%20list%20outside%20of%20the%20scenario%20div%20and%20move%20the%20background%20div%20to%20after%20the%20tags%20list.%20And%20then%20some%20updates%20to%20the%20CSS.%5Cr%5Cn%5Cr%5CnThis%20works%2C%20but%20breaks%20the%20tests.%20TagAssertion%20wants%20the%20tag%20lists%20to%20be%20children%20to%20the%20feature/scenario%20element.%20Since%20features%20still%20have%20their%20tag%20list%20inside%20the%20features%20div.%20So%20to%20keep%20the%20tests%20simple%2C%20we%20need%20to%20update%20the%20way%20features%20are%20rendered%20as%20well.%20This%20is%20easy.%20Just%20wanted%20to%20give%20you%20context%20to%20what%20kind%20of%20change%20you%27re%20about%20to%20see.%22%2C%20%22created_at%22%3A%20%222016-05-03T04%3A39%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22True%2C%20not%20sure%20if%20worth.%20This%20is%20some%20jvm-cucumber%20concept%20to%20have%20the%20same%20item%20for%20Scenario%20and%20Background%20and%20from%20time%20to%20time%20it%20causes%20such%20problems%20%3A%28%22%2C%20%22created_at%22%3A%20%222016-05-03T08%3A07%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah.%20As%20much%20as%20I%27d%20like%20this%20change%2C%20I%27d%20rather%20not%20go%20through%20the%20effort%20to%20update%20the%20tests%20because%20of%20the%20Background%20%3D%3D%20Scenario%20design%20from%20Cucumber.%20I%27m%20fine%20if%20you%20want%20to%20decline%20this%20PR.%22%2C%20%22created_at%22%3A%20%222016-05-04T05%3A11%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22Feel%20free%20to%20decide%22%2C%20%22created_at%22%3A%20%222016-05-04T05%3A38%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Do%20you%20feel%20separate%20box%20shadows%20for%20backgrounds%20is%20a%20blocker%20for%20merge%3F%20If%20so%2C%20then%20we%20can%20close%20this%20because%20it%27s%20extra%20effort%20I%20don%27t%20want%20to%20spend%20at%20the%20moment.%22%2C%20%22created_at%22%3A%20%222016-05-04T05%3A46%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/426#issuecomment-216074428'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **69.47%**
> Merging [#426][cc-pull] into [master][cc-base-branch] will not change coverage
```diff
@@             master       #426   diff @@
==========================================
Files            29         29
Lines           655        655
Methods           0          0
Messages          0          0
Branches         84         84
==========================================
Hits            455        455
Misses          200        200
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [eb6b1c0...a57b4e8][cc-compare]
[cc-base-branch]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/compare/eb6b1c0cd0d2038f5affba063b614047f234a467...a57b4e8f84fee0144fcd93933739420d6119c17d
[cc-pull]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/426?src=pr
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> One remark: now background and scenario have one common box-shaddow (displayed on hover) - can you update CSS so there are two separates shadows?
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Short answer, yes, but not without a bit more tinkering.
I assume the visual order we want is:
- Tags
- Background
- Scenario
The first approach I used was to move the background div into the scenario div, after the tags div. And then disabled some CSS for the backgrounds.
To get separate box-shadows for both background and scenarios while staying true to the above requirements, we need to move the tags list outside of the scenario div and move the background div to after the tags list. And then some updates to the CSS.
This works, but breaks the tests. TagAssertion wants the tag lists to be children to the feature/scenario element. Since features still have their tag list inside the features div. So to keep the tests simple, we need to update the way features are rendered as well. This is easy. Just wanted to give you context to what kind of change you're about to see.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> True, not sure if worth. This is some jvm-cucumber concept to have the same item for Scenario and Background and from time to time it causes such problems :(
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Yeah. As much as I'd like this change, I'd rather not go through the effort to update the tests because of the Background == Scenario design from Cucumber. I'm fine if you want to decline this PR.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Feel free to decide
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Do you feel separate box shadows for backgrounds is a blocker for merge? If so, then we can close this because it's extra effort I don't want to spend at the moment.


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/426?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/426?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/426'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>