### PR TITLE
Don't add embedded HTML if there's no embedded content

### DIFF
--- a/src/main/resources/templates/macros/report/embeddings.vm
+++ b/src/main/resources/templates/macros/report/embeddings.vm
@@ -1,6 +1,6 @@
 #macro(includeEmbeddings, $embeddings)
 
-#if ($embeddings)
+#if (!$embeddings.isEmpty())
   <div class="embeddings inner-level">
   #foreach($embedding in $embeddings)
     #if ($embedding.getMimeType() == "image/png")


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/427%23issuecomment-216075260%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/427%23discussion_r61710598%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/427%23issuecomment-216744094%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/427%23issuecomment-216750054%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/427%23issuecomment-216075260%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A69.47%25%2A%2A%5Cn%3E%20Merging%20%5B%23427%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20not%20change%20coverage%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23427%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20655%20%20%20%20%20%20%20%20655%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%2084%20%20%20%20%20%20%20%20%2084%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%20%20%20455%20%20%20%20%20%20%20%20455%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20200%20%20%20%20%20%20%20%20200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5Beb6b1c0...952310b%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/compare/eb6b1c0cd0d2038f5affba063b614047f234a467...952310bccd28dee1b0f8cf3acda02ad02d2e3e32%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/427%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-05-01T21%3A54%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22FYI%20Codecov%20is%20reporting%20the%20wrong%20coverage%20metrics.%22%2C%20%22created_at%22%3A%20%222016-05-04T05%3A10%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20improves%20UI%22%2C%20%22created_at%22%3A%20%222016-05-04T05%3A40%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20952310bccd28dee1b0f8cf3acda02ad02d2e3e32%20src/main/resources/templates/macros/report/embeddings.vm%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/427%23discussion_r61710598%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22in%20that%20case%20I%20wonder%20if%20second%20condition%20is%20not%20enough%3F%20Also%20maybe%20%60%60%21%24embeddings.isEmpty%28%29%60%60%22%2C%20%22created_at%22%3A%20%222016-05-02T07%3A32%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/resources/templates/macros/report/embeddings.vm%3AL1-7%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/427#issuecomment-216075260'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **69.47%**
> Merging [#427][cc-pull] into [master][cc-base-branch] will not change coverage
```diff
@@             master       #427   diff @@
==========================================
Files            29         29
Lines           655        655
Methods           0          0
Messages          0          0
Branches         84         84
==========================================
Hits            455        455
Misses          200        200
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [eb6b1c0...952310b][cc-compare]
[cc-base-branch]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/compare/eb6b1c0cd0d2038f5affba063b614047f234a467...952310bccd28dee1b0f8cf3acda02ad02d2e3e32
[cc-pull]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/427?src=pr
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> FYI Codecov is reporting the wrong coverage metrics.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> This improves UI
- [x] <a href='#crh-comment-Pull 952310bccd28dee1b0f8cf3acda02ad02d2e3e32 src/main/resources/templates/macros/report/embeddings.vm 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/427#discussion_r61710598'>File: src/main/resources/templates/macros/report/embeddings.vm:L1-7</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> in that case I wonder if second condition is not enough? Also maybe ``!$embeddings.isEmpty()``


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/427?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/427?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/427'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>