### PR TITLE
Roll up first non-passing status for scenarios

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/Element.java
+++ b/src/main/java/net/masterthought/cucumber/json/Element.java
@@ -163,11 +163,14 @@ public class Element {
     }
 
     private Status calculateStepsStatus() {
-        StatusCounter statusCounter = new StatusCounter();
+        // if all the steps passed, then the steps as a whole passed
+        // otherwise, the status of the first non-passing step will roll up to
+        // the 'steps' status
         for (Step step : steps) {
-            statusCounter.incrementFor(step.getStatus());
+            if (step.getStatus() != Status.PASSED)
+                return step.getStatus();
         }
-        return statusCounter.getFinalStatus();
+        return Status.PASSED;
     }
 
     /**
@@ -196,6 +199,14 @@ public class Element {
 
         if (configuration.failsIfMissing() && statusCounter.getValueFor(Status.MISSING) > 0) {
             return Status.FAILED;
+        }
+
+        // return the result of the first unsucessful step. this will help expose
+        // a scenario's status when looking at reports that might collapse passed tests
+        for (Step step : steps) {
+            if (step.getStatus() != Status.PASSED) {
+                return step.getStatus();
+            }
         }
 
         return Status.PASSED;

--- a/src/test/java/net/masterthought/cucumber/ScenarioTest.java
+++ b/src/test/java/net/masterthought/cucumber/ScenarioTest.java
@@ -1,21 +1,20 @@
 package net.masterthought.cucumber;
 
-import static net.masterthought.cucumber.FileReaderUtil.getAbsolutePathFromResource;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.Is.isA;
-import static org.junit.Assert.assertThat;
+import net.masterthought.cucumber.json.Element;
+import net.masterthought.cucumber.json.Feature;
+import net.masterthought.cucumber.json.Step;
+import net.masterthought.cucumber.json.support.Status;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
-
-import net.masterthought.cucumber.json.Element;
-import net.masterthought.cucumber.json.Feature;
-import net.masterthought.cucumber.json.Step;
-import net.masterthought.cucumber.json.support.Status;
+import static net.masterthought.cucumber.FileReaderUtil.getAbsolutePathFromResource;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.Is.isA;
+import static org.junit.Assert.assertThat;
 
 public class ScenarioTest {
 
@@ -59,8 +58,8 @@ public class ScenarioTest {
         setUpJsonReports(false, false, false, false);
         assertThat(passingElement.getElementStatus(), is(Status.PASSED));
         assertThat(failingElement.getElementStatus(), is(Status.FAILED));
-        assertThat(undefinedElement.getElementStatus(), is(Status.PASSED));
-        assertThat(skippedElement.getElementStatus(), is(Status.PASSED));
+        assertThat(undefinedElement.getElementStatus(), is(Status.UNDEFINED));
+        assertThat(skippedElement.getElementStatus(), is(Status.SKIPPED));
     }
 
     @Test
@@ -78,7 +77,7 @@ public class ScenarioTest {
 
         assertThat(passingElement.getElementStatus(), is(Status.PASSED));
         assertThat(failingElement.getElementStatus(), is(Status.FAILED));
-        assertThat(undefinedElement.getElementStatus(), is(Status.PASSED));
+        assertThat(undefinedElement.getElementStatus(), is(Status.UNDEFINED));
         assertThat(skippedElement.getElementStatus(), is(Status.FAILED));
     }
 
@@ -89,7 +88,7 @@ public class ScenarioTest {
         assertThat(passingElement.getElementStatus(), is(Status.PASSED));
         assertThat(failingElement.getElementStatus(), is(Status.FAILED));
         assertThat(undefinedElement.getElementStatus(), is(Status.FAILED));
-        assertThat(skippedElement.getElementStatus(), is(Status.PASSED));
+        assertThat(skippedElement.getElementStatus(), is(Status.SKIPPED));
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageIntegrationTest.java
@@ -61,10 +61,10 @@ public class FeatureReportPageIntegrationTest extends Page {
 
         // then
         DocumentAssertion document = documentFrom(page.getWebPage());
-        TableRowAssertion odyRow = document.getSummary().getTableStats().getBodyRow();
+        TableRowAssertion bodyRow = document.getSummary().getTableStats().getBodyRow();
 
-        odyRow.hasExactValues(feature.getName(), "1", "1", "0", "10", "7", "0", "0", "2", "1", "0", "1m 39s 343 ms", "Passed");
-        odyRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "passed");
+        bodyRow.hasExactValues(feature.getName(), "1", "0", "0", "10", "7", "0", "0", "2", "1", "0", "1m 39s 343 ms", "Failed");
+        bodyRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "failed");
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageIntegrationTest.java
@@ -1,14 +1,9 @@
 package net.masterthought.cucumber.generators;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import net.masterthought.cucumber.generators.helpers.*;
 import org.junit.Test;
 
-import net.masterthought.cucumber.generators.helpers.DocumentAssertion;
-import net.masterthought.cucumber.generators.helpers.LeadAssertion;
-import net.masterthought.cucumber.generators.helpers.SummaryAssertion;
-import net.masterthought.cucumber.generators.helpers.TableRowAssertion;
-import net.masterthought.cucumber.generators.helpers.WebAssertion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -112,9 +107,9 @@ public class FeaturesOverviewPageIntegrationTest extends Page {
         assertThat(bodyRows).hasSize(2);
 
         TableRowAssertion firstRow = bodyRows[0];
-        firstRow.hasExactValues("1st feature", "1", "1", "0", "10", "7", "0", "0", "2", "1", "0", "1m 39s 343 ms",
-                "Passed");
-        firstRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "passed");
+        firstRow.hasExactValues("1st feature", "1", "0", "0", "10", "7", "0", "0", "2", "1", "0", "1m 39s 343 ms",
+                "Failed");
+        firstRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "failed");
         firstRow.hasExactDataValues("", "", "", "", "", "", "", "", "", "", "", "99343602889", "");
         firstRow.getReportLink().hasLabelAndAddress("1st feature", "net-masterthought-example-s--ATM-local-feature.html");
 
@@ -140,7 +135,7 @@ public class FeaturesOverviewPageIntegrationTest extends Page {
         DocumentAssertion document = documentFrom(page.getWebPage());
         TableRowAssertion footerCells = document.getSummary().getTableStats().getFooterRow();
 
-        footerCells.hasExactValues("2", "2", "1", "1", "19", "11", "1", "3", "2", "1", "1", "1m 39s 345 ms", "Totals");
+        footerCells.hasExactValues("2", "2", "0", "1", "19", "11", "1", "3", "2", "1", "1", "1m 39s 345 ms", "Totals");
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/TagReportPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TagReportPageIntegrationTest.java
@@ -1,15 +1,14 @@
 package net.masterthought.cucumber.generators;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.Test;
-
 import net.masterthought.cucumber.generators.helpers.BriefAssertion;
 import net.masterthought.cucumber.generators.helpers.DocumentAssertion;
 import net.masterthought.cucumber.generators.helpers.ElementAssertion;
 import net.masterthought.cucumber.generators.helpers.TableRowAssertion;
 import net.masterthought.cucumber.json.Step;
 import net.masterthought.cucumber.json.support.TagObject;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -51,7 +50,7 @@ public class TagReportPageIntegrationTest extends Page {
         DocumentAssertion document = documentFrom(page.getWebPage());
         TableRowAssertion bodyRow = document.getSummary().getTableStats().getBodyRow();
 
-        bodyRow.hasExactValues(tag.getName(), "2", "1", "1", "16", "8", "1", "3", "2", "1", "1", "231 ms", "Failed");
+        bodyRow.hasExactValues(tag.getName(), "2", "0", "1", "16", "8", "1", "3", "2", "1", "1", "231 ms", "Failed");
         bodyRow.hasExactCSSClasses("tagname", "", "", "", "", "", "failed", "skipped", "pending", "undefined", "missing", "duration", "failed");
     }
 

--- a/src/test/java/net/masterthought/cucumber/generators/TagsOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TagsOverviewPageIntegrationTest.java
@@ -1,14 +1,9 @@
 package net.masterthought.cucumber.generators;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import net.masterthought.cucumber.generators.helpers.*;
 import org.junit.Test;
 
-import net.masterthought.cucumber.generators.helpers.DocumentAssertion;
-import net.masterthought.cucumber.generators.helpers.LeadAssertion;
-import net.masterthought.cucumber.generators.helpers.SummaryAssertion;
-import net.masterthought.cucumber.generators.helpers.TableRowAssertion;
-import net.masterthought.cucumber.generators.helpers.WebAssertion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -110,20 +105,20 @@ public class TagsOverviewPageIntegrationTest extends Page {
         assertThat(bodyRows).hasSize(3);
 
         TableRowAssertion firstRow = bodyRows[0];
-        firstRow.hasExactValues("@checkout", "2", "1", "1", "16", "8", "1", "3", "2", "1", "1", "231 ms", "Failed");
+        firstRow.hasExactValues("@checkout", "2", "0", "1", "16", "8", "1", "3", "2", "1", "1", "231 ms", "Failed");
         firstRow.hasExactCSSClasses("tagname", "", "", "", "", "", "failed", "skipped", "pending", "undefined", "missing", "duration", "failed");
         firstRow.hasExactDataValues("", "", "", "", "", "", "", "", "", "", "", "231054778", "");
         firstRow.getReportLink().hasLabelAndAddress("@checkout", "checkout.html");
 
         TableRowAssertion secondRow = bodyRows[1];
-        secondRow.hasExactValues("@fast", "1", "1", "0", "7", "4", "0", "0", "2", "1", "0", "229 ms", "Passed");
-        secondRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "passed");
+        secondRow.hasExactValues("@fast", "1", "0", "0", "7", "4", "0", "0", "2", "1", "0", "229 ms", "Failed");
+        secondRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "failed");
         secondRow.hasExactDataValues("", "", "", "", "", "", "", "", "", "", "", "229004778", "");
         secondRow.getReportLink().hasLabelAndAddress("@fast", "fast.html");
 
         TableRowAssertion lastRow = bodyRows[2];
-        lastRow.hasExactValues("@featureTag", "1", "1", "0", "7", "4", "0", "0", "2", "1", "0", "229 ms", "Passed");
-        lastRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "passed");
+        lastRow.hasExactValues("@featureTag", "1", "0", "0", "7", "4", "0", "0", "2", "1", "0", "229 ms", "Failed");
+        lastRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "failed");
         lastRow.hasExactDataValues("", "", "", "", "", "", "", "", "", "", "", "229004778", "");
         lastRow.getReportLink().hasLabelAndAddress("@featureTag", "featureTag.html");
     }
@@ -142,7 +137,7 @@ public class TagsOverviewPageIntegrationTest extends Page {
         // then
         DocumentAssertion document = documentFrom(page.getWebPage());
         TableRowAssertion footerCells = document.getSummary().getTableStats().getFooterRow();
-        footerCells.hasExactValues("3", "4", "3", "1", "30", "16", "1", "3", "6", "3", "1", "689 ms", "Totals");
+        footerCells.hasExactValues("3", "4", "0", "2", "30", "16", "1", "3", "6", "3", "1", "689 ms", "Totals");
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/json/ElementTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/ElementTest.java
@@ -23,6 +23,9 @@ public class ElementTest {
     // a simple element json that we'll tweak for our tests
     private static final String TEMPLATE_JSON = "json/element/template.json";
 
+    // the status we're testing for this run
+    private final Status step_status;
+
     @Parameterized.Parameters
     public static Collection<Status[]> data() {
         Collection<Status[]> params = new ArrayList<>();
@@ -34,9 +37,6 @@ public class ElementTest {
         params.add(new Status[] {Status.UNDEFINED});
         return params;
     }
-
-    // the status we're testing for this run
-    private final Status step_status;
 
     public ElementTest(Status step_status) {
         this.step_status = step_status;

--- a/src/test/java/net/masterthought/cucumber/json/ElementTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/ElementTest.java
@@ -1,0 +1,120 @@
+package net.masterthought.cucumber.json;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.masterthought.cucumber.Configuration;
+import net.masterthought.cucumber.FileReaderUtil;
+import net.masterthought.cucumber.json.support.Status;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class ElementTest {
+    // a simple element json that we'll tweak for our tests
+    private static final String TEMPLATE_JSON = "json/element/template.json";
+
+    @Parameterized.Parameters
+    public static Collection<Status[]> data() {
+        Collection<Status[]> params = new ArrayList<>();
+        params.add(new Status[] {Status.PASSED});
+        params.add(new Status[] {Status.FAILED});
+        params.add(new Status[] {Status.SKIPPED});
+        params.add(new Status[] {Status.MISSING});
+        params.add(new Status[] {Status.PENDING});
+        params.add(new Status[] {Status.UNDEFINED});
+        return params;
+    }
+
+    // the status we're testing for this run
+    private final Status step_status;
+
+    public ElementTest(Status step_status) {
+        this.step_status = step_status;
+    }
+
+    // reads in the template json file to an element
+    // sets the status of the middle step in the json to the given status
+    private static Element read_json_set_step(Status status) throws FileNotFoundException {
+        String path = FileReaderUtil.getAbsolutePathFromResource(TEMPLATE_JSON);
+        FileReader f = new FileReader(path);
+        Gson gson = new Gson();
+
+        // read in as json and tweak the last step's status
+        JsonObject json = gson.fromJson(f, JsonElement.class).getAsJsonObject();
+        JsonArray steps = json.getAsJsonArray("steps");
+
+        // change the middle step
+        JsonObject mid_step = steps.get(1).getAsJsonObject().getAsJsonObject("result");
+        mid_step.remove("status");
+        mid_step.addProperty("status", status.getRawName());
+
+        // setup the last step based on the middle step
+        // if passed, then the rest should be rest for the purpose of our test
+        // else, the last step should be skipped
+        JsonObject last_step = steps.get(2).getAsJsonObject().getAsJsonObject("result");
+        last_step.remove("status");
+        last_step.addProperty("status", (status == Status.PASSED ? Status.PASSED : Status.SKIPPED).getRawName());
+
+        // now read it back into gson to parse as an element
+        return gson.fromJson(json, Element.class);
+    }
+
+    // given a test result,
+    // the steps group status should rollup the status of the first non-passing step
+    @Test
+    public void steps_status_no_fail_flags() throws Throwable {
+        Element el = read_json_set_step(step_status);
+
+        // setup default config, no fail flags
+        el.setMedaData(null, new Configuration(new File(""), ""));
+
+        Assert.assertEquals(step_status, el.getStepsStatus());
+    }
+
+    // given a config with fail flags set for the status we're testing,
+    // an element's status should be passed if all steps passed
+    // or failed if any step's status matches the fail flag
+    @Test
+    public void element_status_fail_flags() throws Throwable {
+        Element el = read_json_set_step(step_status);
+
+        // setup config to have fail flags for the status we're testing
+        Configuration cfg = new Configuration(new File(""), "");
+        cfg.setStatusFlags(
+            step_status == Status.SKIPPED,
+            step_status == Status.PENDING,
+            step_status == Status.UNDEFINED,
+            step_status == Status.MISSING
+        );
+        el.setMedaData(null, cfg);
+
+        // if fail flags are set, any non-passing status will be fails
+        Status expect = step_status == Status.PASSED ? Status.PASSED : Status.FAILED;
+
+        Assert.assertEquals(expect, el.getElementStatus());
+    }
+
+    // given a default config (no fail flags),
+    // an element's status should rollup the status of the first non-passing step
+    @Test
+    public void element_status_no_fail_flags() throws Throwable {
+        Element el = read_json_set_step(step_status);
+
+        // setup default config, no fail flags
+        Configuration cfg = new Configuration(new File(""), "");
+        el.setMedaData(null, cfg);
+
+        Assert.assertEquals(step_status, el.getElementStatus());
+    }
+
+}

--- a/src/test/resources/json/element/template.json
+++ b/src/test/resources/json/element/template.json
@@ -1,0 +1,46 @@
+{
+    "id": "asdasd",
+    "type": "scenario",
+    "keyword": "Scenario",
+    "name": "Element rolls up statuses",
+    "description": "Test element status roll up",
+    "line": 1,
+    "steps": [
+        {
+            "result": {
+                "duration": 1000000,
+                "status": "passed"
+            },
+            "name": "the first step",
+            "keyword": "Given ",
+            "line": 10,
+            "match": {
+                "location": "Somewhere.first()"
+            }
+        },
+        {
+            "result": {
+                "duration": 2000000,
+                "status": "passed"
+            },
+            "name": "the second step",
+            "keyword": "And ",
+            "line": 11,
+            "match": {
+                "location": "Somewhere.second()"
+            }
+        },
+        {
+            "result": {
+                "duration": 3000000,
+                "status": "passed"
+            },
+            "name": "the third step",
+            "keyword": "And ",
+            "line": 12,
+            "match": {
+                "location": "Somewhere.third()"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
If a scenario had a pending or missing step, then it seems wrong to report it as "passed". It can mask problems. So this change will set the status of a scenario to the first non-passing status of its steps. So the first pending, missing, etc status will be propagated to the reports.

Fail config flags still work and take precedence. The logic to use the last-non-passing status happens afterward.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/428%23discussion_r61700201%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/428%23issuecomment-216104636%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/428%23issuecomment-216128205%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/428%23issuecomment-216342261%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/428%23issuecomment-216359704%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/428%23discussion_r61803155%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/428%23discussion_r61803221%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/428%23issuecomment-216104636%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A70.06%25%2A%2A%5Cn%3E%20Merging%20%5B%23428%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20increase%20coverage%20by%20%2A%2A%2B0.59%25%2A%2A%5Cn%5Cn1.%20File%20%60...er/json/Element.java%60%20was%20modified.%20%5Bmore%5D%28https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/commit/3a207d5be3870d1ab1f80ed997e4f0de80ccfdb6/changes%3Fsrc%3Dpr%237372632F6D61696E2F6A6176612F6E65742F6D617374657274686F756768742F637563756D6265722F6A736F6E2F456C656D656E742E6A617661%29%20%5Cn%20%20-%20Misses%20%60-2%60%20%5Cn%20%20-%20Partials%20%600%60%20%5Cn%20%20-%20Hits%20%60%2B2%60%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23428%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20655%20%20%20%20%20%20%20%20658%20%20%20%20%20%2B3%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%2084%20%20%20%20%20%20%20%20%2087%20%20%20%20%20%2B3%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20455%20%20%20%20%20%20%20%20461%20%20%20%20%20%2B6%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%20%20%20%20200%20%20%20%20%20%20%20%20197%20%20%20%20%20-3%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5Beb6b1c0...3a207d5%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/compare/eb6b1c0cd0d2038f5affba063b614047f234a467...3a207d5be3870d1ab1f80ed997e4f0de80ccfdb6%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/428%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-05-02T04%3A48%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22Scenario%20that%20have%20unresolved/undefined/missing%20steps%20might%20be%20marked%20as%20passed%20and%20this%20is%20valid%20if%20you%20set%20it%20up%20in%20Configuration%20class%20or%20via%20Jenkins.%20Thus%20this%20is%20not%20a%20bug.%5Cr%5Cn%5Cr%5CnPlease%20check%20again%22%2C%20%22created_at%22%3A%20%222016-05-02T08%3A04%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22There%20are%20only%20options%20to%20mark%20a%20scenario/step%20as%20failed%20if%20it%27s%20pending/etc.%20Nothing%20that%20says%20%5C%22pass%20if%20pending/etc%5C%22.%20That%20is%20only%20implied.%5Cr%5Cn%5Cr%5CnThe%20fail-flags%20functionality%20still%20works.%20However%2C%20this%20changes%20the%20implied%20and%20default%20behavior%20of%20making%20pending/etc%20%3D%3E%20passed%20to%20pending/etc%20%3D%3E%20actual.%5Cr%5Cn%5Cr%5CnI%20think%20this%20is%20a%20better%20change%20and%20makes%20the%20report%20more%20useful.%5Cr%5Cn%5Cr%5CnIf%20the%20user%20really%20wants%20to%20hide%20problems%20in%20their%20test%20reports%20%28which%20sounds%20like%20a%20bad%20idea%20to%20me%29%2C%20then%20it%20should%20be%20more%20configuration%20flags.%22%2C%20%22created_at%22%3A%20%222016-05-02T19%3A49%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22Basically%20if%20you%20take%20a%20look%20at%20readme/example%20you%20will%20find%20how%20to%20make%20build%20failed/passed%20when%20undefined/pending%20steps%20are%20reported%22%2C%20%22created_at%22%3A%20%222016-05-02T20%3A52%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%203a207d5be3870d1ab1f80ed997e4f0de80ccfdb6%20src/main/java/net/masterthought/cucumber/json/Element.java%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/428%23discussion_r61803155%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22so%20if%20you%20have%20steps%20with%20statuses%20PASSED%2C%20UNDEFINED%2C%20MISSING%20then%20it%20returns%20UNDEFINED%20but%20for%20PASSED%2C%20MISSING%2C%20UNDEFINED%20it%20returns%20MISSING%20so%20I%20believe%20it%20is%20not%20good%20idea%20when%20the%20final%20status%20depends%20of%20the%20order%22%2C%20%22created_at%22%3A%20%222016-05-02T20%3A58%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Element.java%3AL163-177%22%7D%2C%20%22Pull%203a207d5be3870d1ab1f80ed997e4f0de80ccfdb6%20src/main/java/net/masterthought/cucumber/json/Element.java%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/428%23discussion_r61803221%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22duplicated%20code%22%2C%20%22created_at%22%3A%20%222016-05-02T20%3A58%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Element.java%3AL201-215%22%7D%2C%20%22Pull%2045377f6edd4790f912be4a711cf0b16a4986cb5d%20src/test/java/net/masterthought/cucumber/json/ElementTest.java%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/428%23discussion_r61700201%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%21%5BCodacy%5D%28https%3A//www.codacy.com/assets/images/favicon.png%29%20Issue%20found%3A%20%5BFields%20should%20be%20declared%20at%20the%20top%20of%20the%20class%2C%20before%20any%20method%20declarations%2C%20constructors%2C%20initializers%20or%20inner%20classes.%5D%28https%3A//www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2497471963/issues/source%3Fbid%3D3059308%26fileBranchId%3D3270310%23l39%29%22%2C%20%22created_at%22%3A%20%222016-05-02T03%3A33%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/java/net/masterthought/cucumber/json/ElementTest.java%3AL1-121%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 45377f6edd4790f912be4a711cf0b16a4986cb5d src/test/java/net/masterthought/cucumber/json/ElementTest.java 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/428#discussion_r61700201'>File: src/test/java/net/masterthought/cucumber/json/ElementTest.java:L1-121</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> ![Codacy](https://www.codacy.com/assets/images/favicon.png) Issue found: [Fields should be declared at the top of the class, before any method declarations, constructors, initializers or inner classes.](https://www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2497471963/issues/source?bid=3059308&fileBranchId=3270310#l39)
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/428#issuecomment-216104636'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **70.06%**
> Merging [#428][cc-pull] into [master][cc-base-branch] will increase coverage by **+0.59%**
1. File `...er/json/Element.java` was modified. [more](https://codecov.io/gh/damianszczepanik/cucumber-reporting/commit/3a207d5be3870d1ab1f80ed997e4f0de80ccfdb6/changes?src=pr#7372632F6D61696E2F6A6176612F6E65742F6D617374657274686F756768742F637563756D6265722F6A736F6E2F456C656D656E742E6A617661)
- Misses `-2`
- Partials `0`
- Hits `+2`
```diff
@@             master       #428   diff @@
==========================================
Files            29         29
Lines           655        658     +3
Methods           0          0
Messages          0          0
Branches         84         87     +3
==========================================
+ Hits            455        461     +6
+ Misses          200        197     -3
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [eb6b1c0...3a207d5][cc-compare]
[cc-base-branch]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/compare/eb6b1c0cd0d2038f5affba063b614047f234a467...3a207d5be3870d1ab1f80ed997e4f0de80ccfdb6
[cc-pull]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/428?src=pr
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Scenario that have unresolved/undefined/missing steps might be marked as passed and this is valid if you set it up in Configuration class or via Jenkins. Thus this is not a bug.
Please check again
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> There are only options to mark a scenario/step as failed if it's pending/etc. Nothing that says "pass if pending/etc". That is only implied.
The fail-flags functionality still works. However, this changes the implied and default behavior of making pending/etc => passed to pending/etc => actual.
I think this is a better change and makes the report more useful.
If the user really wants to hide problems in their test reports (which sounds like a bad idea to me), then it should be more configuration flags.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Basically if you take a look at readme/example you will find how to make build failed/passed when undefined/pending steps are reported
- [ ] <a href='#crh-comment-Pull 3a207d5be3870d1ab1f80ed997e4f0de80ccfdb6 src/main/java/net/masterthought/cucumber/json/Element.java 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/428#discussion_r61803155'>File: src/main/java/net/masterthought/cucumber/json/Element.java:L163-177</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> so if you have steps with statuses PASSED, UNDEFINED, MISSING then it returns UNDEFINED but for PASSED, MISSING, UNDEFINED it returns MISSING so I believe it is not good idea when the final status depends of the order
- [ ] <a href='#crh-comment-Pull 3a207d5be3870d1ab1f80ed997e4f0de80ccfdb6 src/main/java/net/masterthought/cucumber/json/Element.java 29'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/428#discussion_r61803221'>File: src/main/java/net/masterthought/cucumber/json/Element.java:L201-215</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> duplicated code


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/428?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/428?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/428'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>