### PR TITLE
Add hover effect to stats and steps table rows

### DIFF
--- a/src/main/resources/css/reporting.css
+++ b/src/main/resources/css/reporting.css
@@ -161,6 +161,10 @@ table#tablesorter thead tr th {
     cursor: pointer;
 }
 
+tr:hover {
+    transition: background-color 0.3s;
+}
+
 .collapsable-control {
     cursor: pointer;
 }

--- a/src/main/resources/templates/generators/stepsOverview.vm
+++ b/src/main/resources/templates/generators/stepsOverview.vm
@@ -20,7 +20,7 @@
       #if($all_steps.isEmpty())
         <p>You have no features in your cucumber report</p>
       #else
-        <table id="tablesorter" class="stats-table">
+        <table id="tablesorter" class="stats-table table-hover">
 
           <thead>
             <tr class="header">

--- a/src/main/resources/templates/macros/report/statsTable.vm
+++ b/src/main/resources/templates/macros/report/statsTable.vm
@@ -1,6 +1,6 @@
 #macro(includeStatsTable, $table_key, $parallel, $elements, $report_summary)
 
-<table id="tablesorter" class="stats-table">
+<table id="tablesorter" class="stats-table table-hover">
   #includeReportHeader($table_key, $parallel)
 
   <tbody>


### PR DESCRIPTION
Makes it easier to see what the user is current hovering cursor over. Helpful when the table is very long. This is not applied to the report table, since it's basically just one row.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/429?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/429'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>