### PR TITLE
Make background/scenario expand/collapse smoothly

### DIFF
--- a/src/main/resources/templates/macros/report/elements.vm
+++ b/src/main/resources/templates/macros/report/elements.vm
@@ -15,7 +15,7 @@
     </span>
     <div class="description indention">$element.getDescription()</div>
 
-    <span id="element-$element.hashCode()" class="collapse collapsable-details #if(!$element.getElementStatus().isPassed()) in #end">
+    <div id="element-$element.hashCode()" class="collapse collapsable-details #if(!$element.getElementStatus().isPassed()) in #end">
       #includeHooks("Before", $element.getBefore(), $element.getBeforeStatus())
 
       <div class="steps inner-level">
@@ -49,7 +49,7 @@
       </div>
 
       #includeHooks("After", $element.getAfter(), $element.getAfterStatus())
-    <span>
+    </div>
   </div>
 #end
 


### PR DESCRIPTION
Smoothly expand and collapse backgrounds and scenarios. They weren't expanding smoothly because they were contained in a span, instead of a div like the steps.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/430?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/430'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>