### PR TITLE
Test enhancement

### DIFF
--- a/src/test/java/net/masterthought/cucumber/ReportGenerator.java
+++ b/src/test/java/net/masterthought/cucumber/ReportGenerator.java
@@ -17,8 +17,8 @@ public abstract class ReportGenerator {
 
     private final static String JSON_DIRECTORY = "json/";
 
-    protected static final String SAMPLE_JOSN = "sample.json";
-    protected static final String SIMPLE_JOSN = "simple.json";
+    protected static final String SAMPLE_JSON = "sample.json";
+    protected static final String SIMPLE_JSON = "simple.json";
     protected static final String EMPTY_JSON = "empty.json";
     protected static final String INVALID_JSON = "invalid.json";
     protected static final String INVALID_REPORT_JSON = "invalid-report.json";

--- a/src/test/java/net/masterthought/cucumber/ReportParserTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportParserTest.java
@@ -24,7 +24,7 @@ public class ReportParserTest extends ReportGenerator {
     public void parseJsonResultsParsesAllFeatureFiles() throws IOException {
 
         // given
-        setUpWithJson(SAMPLE_JOSN, SIMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON, SIMPLE_JSON);
 
         // when
         List<Feature> features = new ReportParser(configuration).parseJsonResults(jsonReports);
@@ -37,7 +37,7 @@ public class ReportParserTest extends ReportGenerator {
     public void parseJsonResultsSkipsInvalidJSONFiles() throws IOException {
 
         // given
-        setUpWithJson(INVALID_JSON, SIMPLE_JOSN);
+        setUpWithJson(INVALID_JSON, SIMPLE_JSON);
 
         // when
         List<Feature> features = new ReportParser(configuration).parseJsonResults(jsonReports);
@@ -63,7 +63,7 @@ public class ReportParserTest extends ReportGenerator {
     public void parseJsonResultsSkipsInvalidReportFiles() throws IOException {
 
         // given
-        setUpWithJson(INVALID_REPORT_JSON, SIMPLE_JOSN);
+        setUpWithJson(INVALID_REPORT_JSON, SIMPLE_JSON);
 
         // when
         List<Feature> features = new ReportParser(configuration).parseJsonResults(jsonReports);

--- a/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
@@ -19,7 +19,7 @@ public class AbstractPageTest extends PageTest {
 
     @Before
     public void setUp() {
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/ErrorPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/ErrorPageTest.java
@@ -17,7 +17,7 @@ public class ErrorPageTest extends PageTest {
 
     @Before
     public void setUp() {
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageTest.java
@@ -17,7 +17,7 @@ public class FeatureReportPageTest extends PageTest {
 
     @Before
     public void setUp() {
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageTest.java
@@ -17,7 +17,7 @@ public class FeaturesOverviewPageTest extends PageTest {
 
     @Before
     public void setUp() {
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/StepsOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/StepsOverviewPageTest.java
@@ -18,7 +18,7 @@ public class StepsOverviewPageTest extends PageTest {
 
     @Before
     public void setUp() {
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/TagReportPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TagReportPageTest.java
@@ -17,7 +17,7 @@ public class TagReportPageTest extends PageTest {
 
     @Before
     public void setUp() {
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/TagsOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TagsOverviewPageTest.java
@@ -17,7 +17,7 @@ public class TagsOverviewPageTest extends PageTest {
 
     @Before
     public void setUp() {
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/ErrorPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/ErrorPageIntegrationTest.java
@@ -20,7 +20,7 @@ public class ErrorPageIntegrationTest extends PageTest {
     public void generatePage_generatesTitle() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new ErrorPage(reportResult, configuration, cause, jsonReports);
         final String titleValue = String.format("Cucumber-JVM Html Reports  - Error Page");
 
@@ -38,7 +38,7 @@ public class ErrorPageIntegrationTest extends PageTest {
     public void generatePage_generatesLead() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         configuration.setBuildNumber("12");
         page = new ErrorPage(reportResult, configuration, cause, jsonReports);
 
@@ -58,7 +58,7 @@ public class ErrorPageIntegrationTest extends PageTest {
     public void generatePage_generatesErrorMessage() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new ErrorPage(reportResult, configuration, cause, jsonReports);
 
         // when

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java
@@ -33,7 +33,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     public void generatePage_generatesTitle() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         final Feature feature = features.get(0);
         page = new FeatureReportPage(reportResult, configuration, feature);
         final String titleValue = String.format("Cucumber-JVM Html Reports  - Feature: %s", feature.getName());
@@ -52,7 +52,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     public void generatePage_generatesStatsTableBody() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         configuration.setStatusFlags(true, false, false, true);
         final Feature feature = features.get(0);
         page = new FeatureReportPage(reportResult, configuration, feature);
@@ -72,7 +72,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     public void generatePage_generatesFeatureDetails() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         final Feature feature = features.get(0);
         page = new FeatureReportPage(reportResult, configuration, feature);
 
@@ -99,7 +99,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     public void generatePage_generatesScenarioDetails() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         final Feature feature = features.get(0);
         page = new FeatureReportPage(reportResult, configuration, feature);
 
@@ -133,7 +133,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     public void generatePage_generatesHooks() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         final Feature feature = features.get(1);
         page = new FeatureReportPage(reportResult, configuration, feature);
 
@@ -166,7 +166,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     public void generatePage_generatesSteps() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         final Feature feature = features.get(1);
         page = new FeatureReportPage(reportResult, configuration, feature);
 
@@ -199,7 +199,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     public void generatePage_generatesArguments() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         final Feature feature = features.get(0);
         page = new FeatureReportPage(reportResult, configuration, feature);
 
@@ -220,13 +220,19 @@ public class FeatureReportPageIntegrationTest extends PageTest {
 
             assertThat(rowElement.getCellsValues()).isEqualTo(row.getCells());
         }
+
+        TableAssertion docStringTable = stepElement.getDocStringTable();
+
+        TableRowAssertion rowDocStringElement = docStringTable.getBodyRows()[0];
+
+        assertThat(rowDocStringElement.getCellsValues()[0]).isEqualTo(step.getDocString().getValue());
     }
 
     @Test
     public void generatePage_generatesEmbedding() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         final Feature feature = features.get(1);
         page = new FeatureReportPage(reportResult, configuration, feature);
 

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FeaturesOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FeaturesOverviewPageIntegrationTest.java
@@ -20,7 +20,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesTitle() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         configuration.setRunWithJenkins(true);
         configuration.setBuildNumber("1");
         page = new FeaturesOverviewPage(reportResult, configuration);
@@ -41,7 +41,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesLead() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new FeaturesOverviewPage(reportResult, configuration);
 
         // when
@@ -59,7 +59,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesCharts() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new FeaturesOverviewPage(reportResult, configuration);
 
         // when
@@ -75,7 +75,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesStatsTableHeader() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new FeaturesOverviewPage(reportResult, configuration);
 
         // when
@@ -99,7 +99,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesStatsTableBody() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         configuration.setStatusFlags(true, false, false, true);
         page = new FeaturesOverviewPage(reportResult, configuration);
 
@@ -129,7 +129,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesStatsTableFooter() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         configuration.setStatusFlags(true, false, false, true);
         page = new FeaturesOverviewPage(reportResult, configuration);
 

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/PageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/PageIntegrationTest.java
@@ -30,7 +30,7 @@ public class PageIntegrationTest extends PageTest {
     public void generatePage_onDefaultConfiguration_generatesDefaultItemsInNaviBarfor() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new FeaturesOverviewPage(reportResult, configuration);
 
         // when
@@ -53,7 +53,7 @@ public class PageIntegrationTest extends PageTest {
     public void generatePage_onJenkinsConfiguration_generatesAllItemsInNaviBarfor() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         configuration.setRunWithJenkins(true);
         configuration.setBuildNumber("123");
 
@@ -83,7 +83,7 @@ public class PageIntegrationTest extends PageTest {
     public void generatePage_onDefaultConfiguration_generatesSummaryTable() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new StepsOverviewPage(reportResult, configuration);
 
         // when
@@ -104,7 +104,7 @@ public class PageIntegrationTest extends PageTest {
     public void generatePage_onJenkinsConfiguration_generatesSummaryTableWithBuildNumber() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         configuration.setRunWithJenkins(true);
         configuration.setBuildNumber("123");
 
@@ -129,7 +129,7 @@ public class PageIntegrationTest extends PageTest {
     public void generatePage_generatesFooter() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new TagReportPage(reportResult, configuration, reportResult.getAllTags().get(0));
 
         // when

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/PageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/PageIntegrationTest.java
@@ -14,6 +14,8 @@ import net.masterthought.cucumber.generators.integrations.helpers.NavigationAsse
 import net.masterthought.cucumber.generators.integrations.helpers.NavigationItemAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.TableRowAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.WebAssertion;
+import org.junit.Before;
+import java.util.Locale;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/PageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/PageIntegrationTest.java
@@ -20,6 +20,10 @@ import net.masterthought.cucumber.generators.integrations.helpers.WebAssertion;
  */
 public class PageIntegrationTest extends PageTest {
 
+    @Before
+    public void prepare() {
+        Locale.setDefault(Locale.UK);
+    }
     @Test
     public void generatePage_onDefaultConfiguration_generatesDefaultItemsInNaviBarfor() {
 

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/StepsOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/StepsOverviewPageIntegrationTest.java
@@ -19,7 +19,7 @@ public class StepsOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesTitle() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         configuration.setRunWithJenkins(true);
         configuration.setBuildNumber("333");
         page = new StepsOverviewPage(reportResult, configuration);
@@ -40,7 +40,7 @@ public class StepsOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesLead() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new StepsOverviewPage(reportResult, configuration);
 
         // when
@@ -60,7 +60,7 @@ public class StepsOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesStatsTableHeader() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new StepsOverviewPage(reportResult, configuration);
 
         // when
@@ -80,7 +80,7 @@ public class StepsOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesStatsTableBody() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new StepsOverviewPage(reportResult, configuration);
 
         // when
@@ -106,7 +106,7 @@ public class StepsOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesStatsTableFooter() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         configuration.setStatusFlags(true, false, false, true);
         page = new StepsOverviewPage(reportResult, configuration);
 

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/TagReportPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/TagReportPageIntegrationTest.java
@@ -21,7 +21,7 @@ public class TagReportPageIntegrationTest extends PageTest {
     public void generatePage_generatesTitle() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         final TagObject tag = tags.get(0);
         page = new TagReportPage(reportResult, configuration, tag);
         final String titleValue = String.format("Cucumber-JVM Html Reports  - Tag: %s", tag.getName());
@@ -40,7 +40,7 @@ public class TagReportPageIntegrationTest extends PageTest {
     public void generatePage_generatesStatsTableBody() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         configuration.setStatusFlags(true, false, false, true);
         final TagObject tag = tags.get(0);
         page = new TagReportPage(reportResult, configuration, tag);
@@ -60,7 +60,7 @@ public class TagReportPageIntegrationTest extends PageTest {
     public void generatePage_generatesTagsList() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         final TagObject tag = tags.get(0);
         page = new TagReportPage(reportResult, configuration, tag);
 
@@ -78,7 +78,7 @@ public class TagReportPageIntegrationTest extends PageTest {
     public void generatePage_generatesSampleStep() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         final TagObject tag = tags.get(1);
         page = new TagReportPage(reportResult, configuration, tag);
 

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/TagsOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/TagsOverviewPageIntegrationTest.java
@@ -20,7 +20,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesTitle() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new TagsOverviewPage(reportResult, configuration);
         final String titleValue = String.format("Cucumber-JVM Html Reports  - Tags Overview",
                 configuration.getBuildNumber());
@@ -39,7 +39,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesLead() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new TagsOverviewPage(reportResult, configuration);
 
         // when
@@ -57,7 +57,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesCharts() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new TagsOverviewPage(reportResult, configuration);
 
         // when
@@ -73,7 +73,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesStatsTableHeader() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         page = new TagsOverviewPage(reportResult, configuration);
 
         // when
@@ -97,7 +97,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesStatsTableBody() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         configuration.setStatusFlags(true, false, false, true);
         page = new TagsOverviewPage(reportResult, configuration);
 
@@ -133,7 +133,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesStatsTableFooter() {
 
         // given
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
         configuration.setStatusFlags(true, false, false, true);
         page = new TagsOverviewPage(reportResult, configuration);
 

--- a/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
@@ -14,7 +14,7 @@ public class EmbeddingTest extends PageTest {
 
     @Before
     public void setUp() {
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/json/ResultTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/ResultTest.java
@@ -15,7 +15,7 @@ public class ResultTest extends PageTest {
 
     @Before
     public void setUp() {
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/json/RowTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/RowTest.java
@@ -14,7 +14,7 @@ public class RowTest extends PageTest {
 
     @Before
     public void setUp() {
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/json/TagTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/TagTest.java
@@ -14,7 +14,7 @@ public class TagTest extends PageTest {
 
     @Before
     public void setUp() {
-        setUpWithJson(SAMPLE_JOSN);
+        setUpWithJson(SAMPLE_JSON);
     }
 
     @Test


### PR DESCRIPTION
typo fix and adding locale to a test to not depend on default locale (tests currently fail with FR locale).
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/455?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/455'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>