### PR TITLE
Displaying docstring in the report with <br> instead of \n

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/DocString.java
+++ b/src/main/java/net/masterthought/cucumber/json/DocString.java
@@ -17,4 +17,8 @@ public class DocString {
     public String getValue() {
         return value;
     }
+
+    public String getValueWithBreakingSpace() {
+        return value!=null?value.replaceAll("(\r\n|\r|\n|\n\r)", "<br/>"):value;
+    }
 }

--- a/src/main/java/net/masterthought/cucumber/json/DocString.java
+++ b/src/main/java/net/masterthought/cucumber/json/DocString.java
@@ -18,7 +18,4 @@ public class DocString {
         return value;
     }
 
-    public String getValueWithBreakingSpace() {
-        return value!=null?value.replaceAll("(\r\n|\r|\n|\n\r)", "<br/>"):value;
-    }
 }

--- a/src/main/java/net/masterthought/cucumber/json/Step.java
+++ b/src/main/java/net/masterthought/cucumber/json/Step.java
@@ -63,6 +63,9 @@ public class Step implements ResultsWithMatch {
     public boolean hasRows() {
         return ArrayUtils.isNotEmpty(rows);
     }
+    public boolean hasDocString() {
+        return doc_string!=null;
+    }
 
     @Override
     public Status getStatus() {

--- a/src/main/java/net/masterthought/cucumber/json/Step.java
+++ b/src/main/java/net/masterthought/cucumber/json/Step.java
@@ -63,8 +63,9 @@ public class Step implements ResultsWithMatch {
     public boolean hasRows() {
         return ArrayUtils.isNotEmpty(rows);
     }
+
     public boolean hasDocString() {
-        return doc_string!=null;
+        return doc_string != null && StringUtils.isNotEmpty(doc_string.getValue());
     }
 
     @Override
@@ -98,8 +99,7 @@ public class Step implements ResultsWithMatch {
                 while (iterator.hasNext()) {
                     list.add(elementToString(iterator.next()));
                 }
-            }
-            else            {
+            } else {
                 list.add(elementToString(element));
             }
         }

--- a/src/main/resources/css/reporting.css
+++ b/src/main/resources/css/reporting.css
@@ -154,7 +154,7 @@ table.step-arguments {
     margin-top: 3px;
 }
 
-table.step-docstring {
+.step-docstring {
     margin-bottom: 5px;
     margin-left: 25px;
     margin-top: 3px;

--- a/src/main/resources/css/reporting.css
+++ b/src/main/resources/css/reporting.css
@@ -154,6 +154,12 @@ table.step-arguments {
     margin-top: 3px;
 }
 
+table.step-docstring {
+    margin-bottom: 5px;
+    margin-left: 25px;
+    margin-top: 3px;
+}
+
 table.step-arguments th, table.step-arguments td {
     border: 1px solid gray;
     padding: 3px;

--- a/src/main/resources/css/reporting.css
+++ b/src/main/resources/css/reporting.css
@@ -154,7 +154,7 @@ table.step-arguments {
     margin-top: 3px;
 }
 
-.step-docstring {
+.docstring {
     margin-bottom: 5px;
     margin-left: 25px;
     margin-top: 3px;

--- a/src/main/resources/templates/macros/report/elements.vm
+++ b/src/main/resources/templates/macros/report/elements.vm
@@ -42,9 +42,9 @@
               #end
 
               #if ($step.hasDocString())
-                <table class="step-docstring">
+                <table class="docstring">
                   <tr>
-                    <td>$step.getDocString().getValueWithBreakingSpace()</td>
+                    <td>$step.getDocString().getValue()</td>
                   </tr>
                 </table>
               #end

--- a/src/main/resources/templates/macros/report/elements.vm
+++ b/src/main/resources/templates/macros/report/elements.vm
@@ -41,6 +41,14 @@
                 </table>
               #end
 
+              #if ($step.hasDocString())
+                <table class="step-docstring">
+                  <tr>
+                    <td>$step.getDocString().getValueWithBreakingSpace()</td>
+                  </tr>
+                </table>
+              #end
+
               #includeMessage("Output", $step.getOutput())
               #includeEmbeddings($step.getEmbeddings())
             </div>

--- a/src/test/java/net/masterthought/cucumber/DocStringTest.java
+++ b/src/test/java/net/masterthought/cucumber/DocStringTest.java
@@ -37,4 +37,10 @@ public class DocStringTest {
                          + "O X O\n"
                          + "_ O X");
     }
+
+    @Test
+    public void shouldFormatDocStringWithBreakingSpace() {
+        assertThat(step.getDocString().getValueWithBreakingSpace())
+                .isEqualTo("X _ X<br/>O X O<br/>_ O X");
+    }
 }

--- a/src/test/java/net/masterthought/cucumber/DocStringTest.java
+++ b/src/test/java/net/masterthought/cucumber/DocStringTest.java
@@ -38,9 +38,4 @@ public class DocStringTest {
                          + "_ O X");
     }
 
-    @Test
-    public void shouldFormatDocStringWithBreakingSpace() {
-        assertThat(step.getDocString().getValueWithBreakingSpace())
-                .isEqualTo("X _ X<br/>O X O<br/>_ O X");
-    }
 }

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java
@@ -221,7 +221,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
             assertThat(rowElement.getCellsValues()).isEqualTo(row.getCells());
         }
 
-        TableAssertion docStringTable = stepElement.getDocStringTable();
+        TableAssertion docStringTable = stepElement.getDocString();
 
         TableRowAssertion rowDocStringElement = docStringTable.getBodyRows()[0];
 

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java
@@ -220,6 +220,12 @@ public class FeatureReportPageIntegrationTest extends PageTest {
 
             assertThat(rowElement.getCellsValues()).isEqualTo(row.getCells());
         }
+
+        TableAssertion docStringTable = stepElement.getDocStringTable();
+
+        TableRowAssertion rowDocStringElement = docStringTable.getBodyRows()[0];
+
+        assertThat(rowDocStringElement.getCellsValues()[0]).isEqualTo(step.getDocString().getValue());
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/StepAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/StepAssertion.java
@@ -13,8 +13,8 @@ public class StepAssertion extends ReportAssertion {
         return oneByClass("step-arguments", TableAssertion.class);
     }
 
-    public TableAssertion getDocStringTable() {
-        return oneByClass("step-docstring", TableAssertion.class);
+    public TableAssertion getDocString() {
+        return oneByClass("docstring", TableAssertion.class);
     }
 
     public EmbeddingAssertion[] getEmbedding() {

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/StepAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/StepAssertion.java
@@ -13,6 +13,10 @@ public class StepAssertion extends ReportAssertion {
         return oneByClass("step-arguments", TableAssertion.class);
     }
 
+    public TableAssertion getDocStringTable() {
+        return oneByClass("step-docstring", TableAssertion.class);
+    }
+
     public EmbeddingAssertion[] getEmbedding() {
         return oneByClass("embeddings", WebAssertion.class).allByClass("embedding", EmbeddingAssertion.class);
     }

--- a/src/test/resources/json/sample.json
+++ b/src/test/resources/json/sample.json
@@ -77,7 +77,12 @@
                                 ],
                                 "line":6
                             }
-                        ]
+                        ],
+                        "doc_string": {
+                            "content_type": "",
+                            "line": 7,
+                            "value": "Hello Doc String"
+                        }
                     },
                     {
                         "result":{


### PR DESCRIPTION
Currently cucumber-reporting doesn't seem to display docstring.

Here's a implementation proposition.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23issuecomment-222973238%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65361873%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23issuecomment-223023154%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23issuecomment-223023955%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65403376%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65405148%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65405285%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65405470%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65405559%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65490462%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65491128%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65491207%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65491967%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23issuecomment-223212148%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65583590%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65584771%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23issuecomment-222973238%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A87.65%25%2A%2A%5Cn%3E%20Merging%20%5B%23457%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20increase%20coverage%20by%20%2A%2A%3C.01%25%2A%2A%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23457%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20670%20%20%20%20%20%20%20%20672%20%20%20%20%20%2B2%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%2085%20%20%20%20%20%20%20%20%2087%20%20%20%20%20%2B2%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20587%20%20%20%20%20%20%20%20589%20%20%20%20%20%2B2%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20%2083%20%20%20%20%20%20%20%20%2083%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5B44ceefb...7c55be3%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/compare/44ceefb94b008960085cc43065034b65c81f3e9a...7c55be3be0e0da28c786100b613a2039b6e6d0dd%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/457%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-06-01T12%3A09%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40oltruong%2C%20I%20think%20I%20just%20got%20a%20duplicated%20PR%20%23458.%20%3A-D%22%2C%20%22created_at%22%3A%20%222016-06-01T15%3A08%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5112670%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fayndee%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40fayndee%20%3Asmile%3A%20We%20agree%20on%20the%20need%20to%20have%20doc%20string%20as%20well%21%5Cr%5Cn%5Cr%5CnGreat%20tool%20by%20the%20way%20%40damianszczepanik%20%20%21%22%2C%20%22created_at%22%3A%20%222016-06-01T15%3A10%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/666942%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/oltruong%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20committed%20changes%20following%20your%20remarks%20%40damianszczepanik%20%22%2C%20%22created_at%22%3A%20%222016-06-02T07%3A04%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/666942%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/oltruong%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%205e1a9d74718d61acac1518c7ff5908d1a9cff052%20src/main/resources/css/reporting.css%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65405285%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22just%20.docstring%20%3F%22%2C%20%22created_at%22%3A%20%222016-06-01T17%3A25%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK.%20I%20wanted%20it%20to%20be%20consistent%20with%20%60table.step-arguments%60%22%2C%20%22created_at%22%3A%20%222016-06-02T06%3A44%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/666942%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/oltruong%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/resources/css/reporting.css%3AL154-166%22%7D%2C%20%22Pull%205e1a9d74718d61acac1518c7ff5908d1a9cff052%20src/main/resources/templates/macros/report/elements.vm%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65405470%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22getValueWithBreakingSpace%28%29%20not%20needed%20as%20reported%20above%22%2C%20%22created_at%22%3A%20%222016-06-01T17%3A26%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/resources/templates/macros/report/elements.vm%3AL41-55%22%7D%2C%20%22Pull%205e1a9d74718d61acac1518c7ff5908d1a9cff052%20src/main/java/net/masterthought/cucumber/json/DocString.java%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65405148%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20you%20want%20to%20display%20it%20as%20html%20code%20then%20convert%20it%20before%20passing%20to%20the%20report.%20Report%20displays%20data%20%27as%20it%20is%27%20and%20no%20conversion%20is%20applied%5Cr%5Cn%5Cr%5Cnthis%20is%20because%20if%20someday%20I%20will%20decide%20to%20display%20this%20in%20PRE%20block%20then%20such%20conversion%20won%27t%20be%20compatible%5Cr%5Cn%5Cr%5Cneven%20worse%20-%20if%20someone%20adds%20html%20code%20into%20this%20doc_string%20then%20the%20expected%20outcome%20would%20be%20different%20then%20generated%22%2C%20%22created_at%22%3A%20%222016-06-01T17%3A24%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Makes%20sense.%20I%20still%20think%20that%20we%20should%20convert%20carriage%20returns%20with%20%3Cbr/%3E%20but%20that%20can%20be%20done%20before%20calling%20the%20reporting%20tool.%22%2C%20%22created_at%22%3A%20%222016-06-02T06%3A54%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/666942%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/oltruong%22%7D%7D%2C%20%7B%22body%22%3A%20%22don%27t%20manipulate%20data%20-%20you%20can%20format%20how%20they%20are%20not%20displayed%20but%20don%27t%20change%22%2C%20%22created_at%22%3A%20%222016-06-02T17%3A40%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/DocString.java%3AL17-25%22%7D%2C%20%22Pull%205e1a9d74718d61acac1518c7ff5908d1a9cff052%20src/test/java/net/masterthought/cucumber/generators/integrations/helpers/StepAssertion.java%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65405559%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22getDocString%28%29%20%3F%22%2C%20%22created_at%22%3A%20%222016-06-01T17%3A27%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%20why%20not.%20I%20wanted%20it%20to%20be%20consistent%20with%20getArgumentsTable.%22%2C%20%22created_at%22%3A%20%222016-06-02T06%3A44%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/666942%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/oltruong%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/java/net/masterthought/cucumber/generators/integrations/helpers/StepAssertion.java%3AL13-23%22%7D%2C%20%22Pull%205e1a9d74718d61acac1518c7ff5908d1a9cff052%20src/main/java/net/masterthought/cucumber/json/Step.java%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65403376%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ArrayUtils.isNotEmpty%28doc_string%29%5Cr%5Cn%5Cr%5Cnso%20empty%20string%20is%20treated%20as%20no%20doc_string%22%2C%20%22created_at%22%3A%20%222016-06-01T17%3A13%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60doc_string%60%20is%20not%20an%20array%20so%20%60ArrayUtils.isNotEmpty%60%20would%20not%20work.%5Cr%5Cn%5Cr%5CnHow%20about%3A%20%20%60doc_string%20%21%3D%20null%20%26%26%20StringUtils.isNotEmpty%28doc_string.getValue%28%29%29%60%20%3F%22%2C%20%22created_at%22%3A%20%222016-06-02T06%3A37%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/666942%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/oltruong%22%7D%7D%2C%20%7B%22body%22%3A%20%22maybe%5Cr%5Cndoc_string%20%21%3D%20null%20%26%26%20%21doc_string.isEmpty%28%29%22%2C%20%22created_at%22%3A%20%222016-06-02T17%3A32%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/json/Step.java%3AL63-72%22%7D%2C%20%22Pull%207c55be3be0e0da28c786100b613a2039b6e6d0dd%20src/main/resources/css/reporting.css%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/457%23discussion_r65361873%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%21%5BCodacy%5D%28https%3A//www.codacy.com/assets/images/favicon.png%29%20Issue%20found%3A%20%5BElement%20%28table.step-docstring%29%20is%20overqualified%2C%20just%20use%20.step-docstring%20without%20element%20name.%5D%28https%3A//www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2669731470/issues/source%3Fbid%3D3059308%26fileBranchId%3D3332252%23l157%29%22%2C%20%22created_at%22%3A%20%222016-06-01T13%3A44%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/resources/css/reporting.css%3AL154-166%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/457#issuecomment-222973238'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **87.65%**
> Merging [#457][cc-pull] into [master][cc-base-branch] will increase coverage by **<.01%**
```diff
@@             master       #457   diff @@
==========================================
Files            29         29
Lines           670        672     +2
Methods           0          0
Messages          0          0
Branches         85         87     +2
==========================================
+ Hits            587        589     +2
Misses           83         83
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [44ceefb...7c55be3][cc-compare]
[cc-base-branch]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/compare/44ceefb94b008960085cc43065034b65c81f3e9a...7c55be3be0e0da28c786100b613a2039b6e6d0dd
[cc-pull]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/457?src=pr
- <a href='https://github.com/fayndee'><img border=0 src='https://avatars.githubusercontent.com/u/5112670?v=3' height=16 width=16'></a> @oltruong, I think I just got a duplicated PR #458. :-D
- <a href='https://github.com/oltruong'><img border=0 src='https://avatars.githubusercontent.com/u/666942?v=3' height=16 width=16'></a> @fayndee :smile: We agree on the need to have doc string as well!
Great tool by the way @damianszczepanik  !
- <a href='https://github.com/oltruong'><img border=0 src='https://avatars.githubusercontent.com/u/666942?v=3' height=16 width=16'></a> I've committed changes following your remarks @damianszczepanik
- [x] <a href='#crh-comment-Pull 7c55be3be0e0da28c786100b613a2039b6e6d0dd src/main/resources/css/reporting.css 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/457#discussion_r65361873'>File: src/main/resources/css/reporting.css:L154-166</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> ![Codacy](https://www.codacy.com/assets/images/favicon.png) Issue found: [Element (table.step-docstring) is overqualified, just use .step-docstring without element name.](https://www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2669731470/issues/source?bid=3059308&fileBranchId=3332252#l157)
- [ ] <a href='#crh-comment-Pull 5e1a9d74718d61acac1518c7ff5908d1a9cff052 src/main/java/net/masterthought/cucumber/json/Step.java 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/457#discussion_r65403376'>File: src/main/java/net/masterthought/cucumber/json/Step.java:L63-72</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> ArrayUtils.isNotEmpty(doc_string)
so empty string is treated as no doc_string
- <a href='https://github.com/oltruong'><img border=0 src='https://avatars.githubusercontent.com/u/666942?v=3' height=16 width=16'></a> `doc_string` is not an array so `ArrayUtils.isNotEmpty` would not work.
How about:  `doc_string != null && StringUtils.isNotEmpty(doc_string.getValue())` ?
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> maybe
doc_string != null && !doc_string.isEmpty()
- [ ] <a href='#crh-comment-Pull 5e1a9d74718d61acac1518c7ff5908d1a9cff052 src/main/java/net/masterthought/cucumber/json/DocString.java 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/457#discussion_r65405148'>File: src/main/java/net/masterthought/cucumber/json/DocString.java:L17-25</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> If you want to display it as html code then convert it before passing to the report. Report displays data 'as it is' and no conversion is applied
this is because if someday I will decide to display this in PRE block then such conversion won't be compatible
even worse - if someone adds html code into this doc_string then the expected outcome would be different then generated
- <a href='https://github.com/oltruong'><img border=0 src='https://avatars.githubusercontent.com/u/666942?v=3' height=16 width=16'></a> Makes sense. I still think that we should convert carriage returns with <br/> but that can be done before calling the reporting tool.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> don't manipulate data - you can format how they are not displayed but don't change
- [ ] <a href='#crh-comment-Pull 5e1a9d74718d61acac1518c7ff5908d1a9cff052 src/main/resources/css/reporting.css 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/457#discussion_r65405285'>File: src/main/resources/css/reporting.css:L154-166</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> just .docstring ?
- <a href='https://github.com/oltruong'><img border=0 src='https://avatars.githubusercontent.com/u/666942?v=3' height=16 width=16'></a> OK. I wanted it to be consistent with `table.step-arguments`
- [ ] <a href='#crh-comment-Pull 5e1a9d74718d61acac1518c7ff5908d1a9cff052 src/main/resources/templates/macros/report/elements.vm 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/457#discussion_r65405470'>File: src/main/resources/templates/macros/report/elements.vm:L41-55</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> getValueWithBreakingSpace() not needed as reported above
- [x] <a href='#crh-comment-Pull 5e1a9d74718d61acac1518c7ff5908d1a9cff052 src/test/java/net/masterthought/cucumber/generators/integrations/helpers/StepAssertion.java 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/457#discussion_r65405559'>File: src/test/java/net/masterthought/cucumber/generators/integrations/helpers/StepAssertion.java:L13-23</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> getDocString() ?
- <a href='https://github.com/oltruong'><img border=0 src='https://avatars.githubusercontent.com/u/666942?v=3' height=16 width=16'></a> OK why not. I wanted it to be consistent with getArgumentsTable.


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/457?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/457?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/457'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>