### PR TITLE
Add support for step doc string.

### DIFF
--- a/src/main/resources/templates/headers.vm
+++ b/src/main/resources/templates/headers.vm
@@ -19,3 +19,4 @@
 #parse("/templates/macros/report/duration.vm")
 #parse("/templates/macros/report/message.vm")
 #parse("/templates/macros/report/output.vm")
+#parse("/templates/macros/report/docstring.vm")

--- a/src/main/resources/templates/macros/report/docstring.vm
+++ b/src/main/resources/templates/macros/report/docstring.vm
@@ -1,0 +1,16 @@
+#macro(includeDocString, $docString)
+
+#if ($docString)
+  <div class="inner-level">
+    <div class="docstring indention">
+      <div data-toggle="collapse" class="collapsable-control" data-target="#msg-$docString.hashCode()">
+          <a>Doc string</a>
+      </div>
+      <div id="msg-$docString.hashCode()" class="collapse collapsable-details">
+        <pre>$docString.getValue()</pre>
+      </div>
+    </div>
+  </div>
+#end
+
+#end

--- a/src/main/resources/templates/macros/report/steps.vm
+++ b/src/main/resources/templates/macros/report/steps.vm
@@ -23,6 +23,7 @@
           </table>
         #end
 
+        #includeDocString($step.getDocString())
         #includeOutput($step.getOutput())
         #includeEmbeddings($step.getEmbeddings())
       </div>

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java
@@ -68,7 +68,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
         DocumentAssertion document = documentFrom(page.getWebPage());
         TableRowAssertion odyRow = document.getSummary().getTableStats().getBodyRow();
 
-        odyRow.hasExactValues(feature.getName(), "1", "1", "0", "10", "7", "0", "0", "2", "1", "0", "1m 39s 343ms", "Passed");
+        odyRow.hasExactValues(feature.getName(), "1", "1", "0", "11", "8", "0", "0", "2", "1", "0", "1m 39s 353ms", "Passed");
         odyRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "passed");
     }
 
@@ -251,7 +251,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
         // then
         DocumentAssertion document = documentFrom(page.getWebPage());
 
-        StepAssertion stepElement = document.getFeature().getElements()[0].getStepsSection().getSteps()[1];
+        StepAssertion stepElement = document.getFeature().getElements()[0].getStepsSection().getSteps()[2];
         TableAssertion argTable = stepElement.getArgumentsTable();
 
         Step step = feature.getElements()[0].getSteps()[1];
@@ -262,6 +262,26 @@ public class FeatureReportPageIntegrationTest extends PageTest {
 
             assertThat(rowElement.getCellsValues()).isEqualTo(row.getCells());
         }
+    }
+
+    @Test
+    public void generatePage_generatesDocString() {
+
+        // given
+        setUpWithJson(SAMPLE_JSON);
+        final Feature feature = features.get(0);
+        page = new FeatureReportPage(reportResult, configuration, feature);
+
+        // when
+        page.generatePage();
+
+        // then
+        DocumentAssertion document = documentFrom(page.getWebPage());
+
+        StepAssertion stepElement = document.getFeature().getElements()[0].getStepsSection().getSteps()[1];
+        Step step = feature.getElements()[0].getSteps()[1];
+
+        stepElement.getDocString().hasDocString(step.getDocString());
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FeaturesOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FeaturesOverviewPageIntegrationTest.java
@@ -113,9 +113,9 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
         assertThat(bodyRows).hasSize(2);
 
         TableRowAssertion firstRow = bodyRows[0];
-        firstRow.hasExactValues("1st feature", "1", "1", "0", "10", "7", "0", "0", "2", "1", "0", "1m 39s 343ms", "Passed");
+        firstRow.hasExactValues("1st feature", "1", "1", "0", "11", "8", "0", "0", "2", "1", "0", "1m 39s 353ms", "Passed");
         firstRow.hasExactCSSClasses("tagname", "", "", "", "", "", "", "", "pending", "undefined", "", "duration", "passed");
-        firstRow.hasExactDataValues("", "", "", "", "", "", "", "", "", "", "", "99343602889", "");
+        firstRow.hasExactDataValues("", "", "", "", "", "", "", "", "", "", "", "99353122889", "");
         firstRow.getReportLink().hasLabelAndAddress("1st feature", "net-masterthought-example-s--ATM-local-feature.html");
 
         TableRowAssertion secondRow = bodyRows[1];
@@ -140,7 +140,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
         DocumentAssertion document = documentFrom(page.getWebPage());
         TableRowAssertion footerCells = document.getSummary().getTableStats().getFooterRow();
 
-        footerCells.hasExactValues("2", "2", "1", "1", "19", "11", "1", "3", "2", "1", "1", "1m 39s 345ms", "Totals");
+        footerCells.hasExactValues("2", "2", "1", "1", "20", "12", "1", "3", "2", "1", "1", "1m 39s 355ms", "Totals");
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/StepsOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/StepsOverviewPageIntegrationTest.java
@@ -98,7 +98,7 @@ public class StepsOverviewPageIntegrationTest extends PageTest {
         firstRow.hasExactDataValues("", "", "99107447000", "99107447000", "");
 
         // also verify the average durations is written to data-values correctly
-        TableRowAssertion secondRow = bodyRows[2];
+        TableRowAssertion secondRow = bodyRows[3];
         secondRow.hasExactDataValues("", "", "90000000", "45000000", "");
     }
 
@@ -117,7 +117,7 @@ public class StepsOverviewPageIntegrationTest extends PageTest {
         DocumentAssertion document = documentFrom(page.getWebPage());
         TableRowAssertion footerCells = document.getSummary().getTableStats().getFooterRow();
 
-        footerCells.hasExactValues("15", "22", "1m 39s 482ms", "4s 521ms", "Totals");
+        footerCells.hasExactValues("16", "23", "1m 39s 492ms", "4s 325ms", "Totals");
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/DocStringAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/DocStringAssertion.java
@@ -1,0 +1,16 @@
+package net.masterthought.cucumber.generators.integrations.helpers;
+
+import net.masterthought.cucumber.json.DocString;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Fang Yuan (fayndee@github)
+ */
+public class DocStringAssertion extends ReportAssertion {
+
+    public void hasDocString(DocString docString) {
+        assertThat(docString).isNotNull();
+        assertThat(oneBySelector("pre", WebAssertion.class).text()).isEqualTo(docString.getValue());
+    }
+}

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/StepAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/StepAssertion.java
@@ -20,4 +20,8 @@ public class StepAssertion extends ReportAssertion {
     public OutputAssertion getOutput() {
         return oneByClass("outputs", OutputAssertion.class);
     }
+
+    public DocStringAssertion getDocString() {
+        return oneByClass("docstring", DocStringAssertion.class);
+    }
 }

--- a/src/test/java/net/masterthought/cucumber/json/ResultTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/ResultTest.java
@@ -35,7 +35,7 @@ public class ResultTest extends PageTest {
     public void getDuration_ReturnsDuration() {
 
         // give
-        Result result = features.get(0).getElements()[0].getSteps()[2].getResult();
+        Result result = features.get(0).getElements()[0].getSteps()[3].getResult();
 
         // when
         long duration = result.getDuration();
@@ -48,7 +48,7 @@ public class ResultTest extends PageTest {
     public void getFormattedDuration_ReturnsDurationAsString() {
 
         // give
-        Result result = features.get(0).getElements()[0].getSteps()[1].getResult();
+        Result result = features.get(0).getElements()[0].getSteps()[2].getResult();
 
         // when
         String duration = result.getFormatedDuration();

--- a/src/test/java/net/masterthought/cucumber/json/RowTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/RowTest.java
@@ -21,7 +21,7 @@ public class RowTest extends PageTest {
     public void getCells_ReturnsCells() {
 
         // give
-        Row[] rows = features.get(0).getElements()[0].getSteps()[1].getRows();
+        Row[] rows = features.get(0).getElements()[0].getSteps()[2].getRows();
 
         // when
         String[] cells = rows[0].getCells();

--- a/src/test/java/net/masterthought/cucumber/json/support/TagObjectTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/support/TagObjectTest.java
@@ -139,8 +139,8 @@ public class TagObjectTest extends PageTest {
         }
 
         // then
-        assertThat(tag.getDurations()).isEqualTo(99343602889L);
-        assertThat(tag.getFormattedDurations()).isEqualTo("1m 39s 343ms");
+        assertThat(tag.getDurations()).isEqualTo(99353122889L);
+        assertThat(tag.getFormattedDurations()).isEqualTo("1m 39s 353ms");
     }
 
     @Test
@@ -156,7 +156,7 @@ public class TagObjectTest extends PageTest {
         }
 
         // then
-        assertThat(tag.getSteps()).isEqualTo(10);
+        assertThat(tag.getSteps()).isEqualTo(11);
     }
 
     @Test
@@ -172,7 +172,7 @@ public class TagObjectTest extends PageTest {
         }
 
         // then
-        assertThat(tag.getNumberOfStatus(Status.PASSED)).isEqualTo(7);
+        assertThat(tag.getNumberOfStatus(Status.PASSED)).isEqualTo(8);
         assertThat(tag.getNumberOfStatus(Status.FAILED)).isEqualTo(0);
         assertThat(tag.getNumberOfStatus(Status.PENDING)).isEqualTo(2);
         assertThat(tag.getNumberOfStatus(Status.MISSING)).isEqualTo(0);

--- a/src/test/resources/json/sample.json
+++ b/src/test/resources/json/sample.json
@@ -32,12 +32,29 @@
                     },
                     {
                         "result":{
+                            "duration":9520000,
+                            "status":"passed"
+                        },
+                        "name":"My credit card is described as follow:",
+                        "keyword":"And ",
+                        "line":9,
+                        "match":{
+                            "location":"ATMScenario.My_credit_card_is_described_as_follow"
+                        },
+                        "doc_string": {
+                            "content_type": "",
+                            "line": 10,
+                            "value": "{\n\"issuer\": {\n\"name\": \"Real Bank Inc.\",\n\"isn:\": \"RB55800093842N\"\n},\n\"card_number\": \"4896 0215 8478 6325\",\n\"holder\": \"A guy\"\n}"
+                        }
+                    },
+                    {
+                        "result":{
                             "duration":7040000,
                             "status":"passed"
                         },
                         "name":"I confirm my pin number",
                         "keyword":"When ",
-                        "line":9,
+                        "line":18,
                         "match":{
                             "location":"ATMScenario.I_confirm_my_pin_number()"
                         },
@@ -86,7 +103,7 @@
                         },
                         "name":"the card should be activated",
                         "keyword":"Then ",
-                        "line":10,
+                        "line":19,
                         "match":{
                             "location":"ATMScenario.the_card_should_be_activated()"
                         }
@@ -99,7 +116,7 @@
                 "tags":[
                     {
                         "name":"@fast",
-                        "line":12
+                        "line":21
                     },
                     {
                         "name":"@featureTag",
@@ -107,13 +124,13 @@
                     },
                     {
                         "name":"@checkout",
-                        "line":12
+                        "line":21
                     }
                 ],
                 "description":"Account holder withdraws cash",
                 "name":"Account has \u0027sufficient funds\u0027",
                 "keyword":"Scenario Outline",
-                "line":24,
+                "line":33,
                 "steps":[
                     {
                         "result":{
@@ -122,7 +139,7 @@
                         },
                         "name":"the account balance is 100",
                         "keyword":"Given ",
-                        "line":14,
+                        "line":23,
                         "match":{
                             "arguments":[
                                 {
@@ -140,7 +157,7 @@
                         },
                         "name":"the card is valid",
                         "keyword":"And ",
-                        "line":15,
+                        "line":24,
                         "match":{
                             "location":"ATMScenario.createCreditCard()"
                         }
@@ -152,7 +169,7 @@
                         },
                         "name":"the machine contains 100",
                         "keyword":"And ",
-                        "line":16,
+                        "line":25,
                         "match":{
                             "arguments":[
                                 {
@@ -173,7 +190,7 @@
                         },
                         "name":"the Account Holder requests 10",
                         "keyword":"When ",
-                        "line":17,
+                        "line":26,
                         "match":{
                             "arguments":[
                                 {
@@ -194,7 +211,7 @@
                         },
                         "name":"the ATM should dispense 10",
                         "keyword":"Then ",
-                        "line":18,
+                        "line":27,
                         "match":{
                             "arguments":[
                                 {
@@ -215,7 +232,7 @@
                         },
                         "name":"the account balance should be 90",
                         "keyword":"And ",
-                        "line":19,
+                        "line":28,
                         "match":{
                             "arguments":[
                                 {
@@ -236,7 +253,7 @@
                         },
                         "name":"the card should be returned",
                         "keyword":"And ",
-                        "line":20,
+                        "line":29,
                         "match":{
                             "location":"ATMScenario.cardShouldBeReturned()"
                         }


### PR DESCRIPTION
In the current version (2.3.0), if user defined some doc strings in their scenario steps, then they are simply ignored by the generator, thus not visible in the report.

It would be nice to have them show up in the report as well. For instance:
![screenshot from 2016-06-01 17 02 21](https://cloud.githubusercontent.com/assets/5112670/15714225/022c8928-281a-11e6-93d9-5d03d307ca88.png)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23issuecomment-223031362%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r65406569%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r65406877%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r65407167%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r65407580%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r65407889%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r65498523%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r65498701%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23issuecomment-225615387%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23issuecomment-225632717%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r66823888%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r66823994%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23issuecomment-225635945%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23issuecomment-225877738%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23issuecomment-225966157%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23issuecomment-226143092%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23issuecomment-223031362%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A87.61%25%2A%2A%5Cn%3E%20Merging%20%5B%23458%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20not%20change%20coverage%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23458%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%2029%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20670%20%20%20%20%20%20%20%20670%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%2085%20%20%20%20%20%20%20%20%2085%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%20%20%20587%20%20%20%20%20%20%20%20587%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20%2083%20%20%20%20%20%20%20%20%2083%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5B44ceefb...527b353%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/compare/44ceefb94b008960085cc43065034b65c81f3e9a...527b3535edf058c0518cb30fd8b7da5962fd6de9%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/458%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-06-01T15%3A33%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40damianszczepanik%20any%20chance%20to%20accept%20one%20of%20two%20PRs%20to%20enable%20docstring%20in%20reports%3F%22%2C%20%22created_at%22%3A%20%222016-06-13T15%3A25%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5112670%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fayndee%22%7D%7D%2C%20%7B%22body%22%3A%20%22Please%20resolve%20conflicts%20and%20add%20expandable%20like%20other%20message%20or%20output.%20Today%20I%27m%20going%20to%20release%20next%20version.%20%22%2C%20%22created_at%22%3A%20%222016-06-13T16%3A22%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%20for%20the%20delay%20-%20I%20believe%20change%20is%20almost%20ready%20to%20be%20merged%20and%20release.%20Add%20expandable%20for%20now%20and%20further%20improvements%20when%20needed%21%22%2C%20%22created_at%22%3A%20%222016-06-13T16%3A34%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40damianszczepanik%2C%20conflicts%20resolved%2C%20expandable%20added.%22%2C%20%22created_at%22%3A%20%222016-06-14T13%3A17%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5112670%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fayndee%22%7D%7D%2C%20%7B%22body%22%3A%20%22One%20more%3A%20squash%20commits%20into%20one%22%2C%20%22created_at%22%3A%20%222016-06-14T18%3A06%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22now%20it%27s%20good%20to%20go%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-06-15T10%3A01%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5112670%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fayndee%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ee1b6ee9445cb38a81b6b873a2f0ec437d8cb490%20src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java%2025%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r66823994%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22SAMPLE_JSON%20-%20typo%20already%20fixed%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-06-13T16%3A31%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java%3AL223-249%22%7D%2C%20%22Pull%20ee1b6ee9445cb38a81b6b873a2f0ec437d8cb490%20src/main/resources/templates/macros/report/elements.vm%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r66823888%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20you%20can%20simple%20reuse%20or%20copy%20this%20https%3A//github.com/damianszczepanik/cucumber-reporting/blob/master/src/main/resources/templates/macros/report/steps.vm%23L26%20so%20expandable%20will%20be%20quite%20simple%20to%20add%22%2C%20%22created_at%22%3A%20%222016-06-13T16%3A30%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/resources/templates/macros/report/elements.vm%3AL41-51%22%7D%2C%20%22Pull%20527b3535edf058c0518cb30fd8b7da5962fd6de9%20src/test/resources/json/sample.json%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r65407889%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22and%20the%20content_type%20is%20empty%3F%20can%20you%20check%20with%20the%20report%20you%20have%20in%20your%20report%3F%20shouldn%27t%20be%20set%20to%20something%20similar%20to%20embedding%3F%22%2C%20%22created_at%22%3A%20%222016-06-01T17%3A40%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20content_type%20is%20an%20user%20specified%20value%2C%20for%20instance%3A%5Cr%5Cn%5C%22%5C%22%5C%22json%5Cr%5Cn%7B%5C%22field%5C%22%3A%20%5C%22value%5C%22%7D%5Cr%5Cn%5C%22%5C%22%5C%22%5Cr%5Cn%5Cr%5CnHere%20I%20just%20left%20it%20out%20for%20simplicity%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-06-02T08%3A01%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5112670%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fayndee%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/resources/json/sample.json%3AL32-61%22%7D%2C%20%22Pull%20527b3535edf058c0518cb30fd8b7da5962fd6de9%20src/test/resources/json/sample.json%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r65407167%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22nice%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-06-01T17%3A36%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/resources/json/sample.json%3AL32-61%22%7D%2C%20%22Pull%20527b3535edf058c0518cb30fd8b7da5962fd6de9%20src/main/resources/templates/macros/report/elements.vm%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r65406569%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20elseif%3F%20I%20guess%20rows%20and%20docstring%20can%20exist%20together%20so%20there%20should%20be%20simple%20if%2C%20not%20elseif%22%2C%20%22created_at%22%3A%20%222016-06-01T17%3A33%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22can%20you%20make%20this%20expandable%3F%20I%20guess%20that%20would%20be%20nice%20to%20make%20this%20hidden/invisible%20if%20the%20docstring%20is%20very%20long%22%2C%20%22created_at%22%3A%20%222016-06-01T17%3A39%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Good%20to%20know%20that%2C%20I%20was%20thinking%20Doc%20String%20and%20Rows%20are%20mutually%20exclusive%2C%20maybe%20because%20I%27ve%20never%20thought%20to%20use%20it%20in%20that%20way%20%3A%29%5Cr%5Cn%5Cr%5CnFor%20the%20expandable%2C%20I%27ve%20also%20thought%20about.%20Just%20like%20the%20rows%2C%20if%20it%27s%20actually%20too%20long%2C%20then%20it%20definitely%20makes%20sense.%20Otherwise%20it%20would%20also%20be%20a%20pain%20to%20manually%20expand%20it%20for%20every%20small%20piece%20of%20thing...%22%2C%20%22created_at%22%3A%20%222016-06-02T07%3A59%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5112670%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/fayndee%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/resources/templates/macros/report/elements.vm%3AL39-47%22%7D%2C%20%22Pull%20527b3535edf058c0518cb30fd8b7da5962fd6de9%20src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/458%23discussion_r65406877%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22maybe%20pass%20DocString%20type%2C%20not%20pure%20string%20into%20the%20hasDocString%28%29%22%2C%20%22created_at%22%3A%20%222016-06-01T17%3A35%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java%3AL223-249%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/458#issuecomment-223031362'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **87.61%**
> Merging [#458][cc-pull] into [master][cc-base-branch] will not change coverage
```diff
@@             master       #458   diff @@
==========================================
Files            29         29
Lines           670        670
Methods           0          0
Messages          0          0
Branches         85         85
==========================================
Hits            587        587
Misses           83         83
Partials          0          0
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [44ceefb...527b353][cc-compare]
[cc-base-branch]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/compare/44ceefb94b008960085cc43065034b65c81f3e9a...527b3535edf058c0518cb30fd8b7da5962fd6de9
[cc-pull]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/458?src=pr
- <a href='https://github.com/fayndee'><img border=0 src='https://avatars.githubusercontent.com/u/5112670?v=3' height=16 width=16'></a> @damianszczepanik any chance to accept one of two PRs to enable docstring in reports?
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Please resolve conflicts and add expandable like other message or output. Today I'm going to release next version.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Sorry for the delay - I believe change is almost ready to be merged and release. Add expandable for now and further improvements when needed!
- <a href='https://github.com/fayndee'><img border=0 src='https://avatars.githubusercontent.com/u/5112670?v=3' height=16 width=16'></a> @damianszczepanik, conflicts resolved, expandable added.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> One more: squash commits into one
- <a href='https://github.com/fayndee'><img border=0 src='https://avatars.githubusercontent.com/u/5112670?v=3' height=16 width=16'></a> now it's good to go :)
- [x] <a href='#crh-comment-Pull 527b3535edf058c0518cb30fd8b7da5962fd6de9 src/main/resources/templates/macros/report/elements.vm 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/458#discussion_r65406569'>File: src/main/resources/templates/macros/report/elements.vm:L39-47</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> why elseif? I guess rows and docstring can exist together so there should be simple if, not elseif
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> can you make this expandable? I guess that would be nice to make this hidden/invisible if the docstring is very long
- <a href='https://github.com/fayndee'><img border=0 src='https://avatars.githubusercontent.com/u/5112670?v=3' height=16 width=16'></a> Good to know that, I was thinking Doc String and Rows are mutually exclusive, maybe because I've never thought to use it in that way :)
For the expandable, I've also thought about. Just like the rows, if it's actually too long, then it definitely makes sense. Otherwise it would also be a pain to manually expand it for every small piece of thing...
- [x] <a href='#crh-comment-Pull 527b3535edf058c0518cb30fd8b7da5962fd6de9 src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java 38'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/458#discussion_r65406877'>File: src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java:L223-249</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> maybe pass DocString type, not pure string into the hasDocString()
- [x] <a href='#crh-comment-Pull 527b3535edf058c0518cb30fd8b7da5962fd6de9 src/test/resources/json/sample.json 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/458#discussion_r65407167'>File: src/test/resources/json/sample.json:L32-61</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> nice :)
- [x] <a href='#crh-comment-Pull 527b3535edf058c0518cb30fd8b7da5962fd6de9 src/test/resources/json/sample.json 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/458#discussion_r65407889'>File: src/test/resources/json/sample.json:L32-61</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> and the content_type is empty? can you check with the report you have in your report? shouldn't be set to something similar to embedding?
- <a href='https://github.com/fayndee'><img border=0 src='https://avatars.githubusercontent.com/u/5112670?v=3' height=16 width=16'></a> The content_type is an user specified value, for instance:
"""json
{"field": "value"}
"""
Here I just left it out for simplicity :)
- [x] <a href='#crh-comment-Pull ee1b6ee9445cb38a81b6b873a2f0ec437d8cb490 src/main/resources/templates/macros/report/elements.vm 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/458#discussion_r66823888'>File: src/main/resources/templates/macros/report/elements.vm:L41-51</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> Maybe you can simple reuse or copy this https://github.com/damianszczepanik/cucumber-reporting/blob/master/src/main/resources/templates/macros/report/steps.vm#L26 so expandable will be quite simple to add
- [x] <a href='#crh-comment-Pull ee1b6ee9445cb38a81b6b873a2f0ec437d8cb490 src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java 25'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/458#discussion_r66823994'>File: src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java:L223-249</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> SAMPLE_JSON - typo already fixed :)


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/458?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/458?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/458'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>