### PR TITLE
Fix Failures Overview page

### DIFF
--- a/src/main/java/net/masterthought/cucumber/generators/FailuresOverviewPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/FailuresOverviewPage.java
@@ -2,6 +2,11 @@ package net.masterthought.cucumber.generators;
 
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportResult;
+import net.masterthought.cucumber.json.Element;
+import net.masterthought.cucumber.json.Feature;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class FailuresOverviewPage extends AbstractPage {
 
@@ -16,6 +21,17 @@ public class FailuresOverviewPage extends AbstractPage {
 
     @Override
     public void prepareReport() {
-        context.put("all_features", report.getAllFeatures());
+        List<Element> failures = new ArrayList<>();
+        for (Feature feature : report.getAllFeatures()) {
+            if (feature.getStatus().isPassed()) continue;
+
+            for (Element element : feature.getElements()) {
+                if (!element.getStepsStatus().isPassed()) {
+                    failures.add(element);
+                }
+            }
+        }
+
+        context.put("failures", failures);
     }
 }

--- a/src/main/resources/templates/generators/failuresOverview.vm
+++ b/src/main/resources/templates/generators/failuresOverview.vm
@@ -17,20 +17,12 @@
 <div class="container-fluid" id="summary">
   <div class="row">
     <div class="col-md-10 col-md-offset-1">
-      #if($all_features.isEmpty())
-        <p>You have no failed scenarios in your cucumber report</p>
+      #if($failures.isEmpty())
+        <p>You have no failed scenarios in your Cucumber report</p>
       #else
         <div class="elements">
-          #foreach($feature in $all_features)
-            #if(!$feature.getStatus().isPassed())
-
-              #foreach($element in $feature.getElements())
-                #if(!$element.getStatus().isPassed())
-                  #includeElement($element, true)
-                #end
-              #end
-
-            #end
+          #foreach($element in $failures)
+            #includeElement($element, true)
           #end
         </div>
       #end

--- a/src/test/java/net/masterthought/cucumber/ReportGenerator.java
+++ b/src/test/java/net/masterthought/cucumber/ReportGenerator.java
@@ -1,14 +1,14 @@
 package net.masterthought.cucumber;
 
+import net.masterthought.cucumber.json.Feature;
+import net.masterthought.cucumber.json.support.StepObject;
+import net.masterthought.cucumber.json.support.TagObject;
+
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-
-import net.masterthought.cucumber.json.Feature;
-import net.masterthought.cucumber.json.support.StepObject;
-import net.masterthought.cucumber.json.support.TagObject;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -22,6 +22,7 @@ public abstract class ReportGenerator {
     protected static final String EMPTY_JSON = "empty.json";
     protected static final String INVALID_JSON = "invalid.json";
     protected static final String INVALID_REPORT_JSON = "invalid-report.json";
+    protected static final String FAILURES_JSON = "failures.json";
 
     private final File reportDirectory;
 

--- a/src/test/java/net/masterthought/cucumber/generators/FailureOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FailureOverviewPageTest.java
@@ -1,0 +1,65 @@
+package net.masterthought.cucumber.generators;
+
+import mockit.Deencapsulation;
+import net.masterthought.cucumber.generators.integrations.PageTest;
+import net.masterthought.cucumber.json.Element;
+import net.masterthought.cucumber.json.support.Status;
+import org.apache.velocity.VelocityContext;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+
+public class FailureOverviewPageTest extends PageTest {
+    private List<Element> testFailReport(String jsonToTest, int expectedFailedScenarios) {
+        List<Element> failures = new ArrayList<>();
+
+        // given
+        setUpWithJson(jsonToTest);
+        page = new FailuresOverviewPage(reportResult, configuration);
+
+        // when
+        page.prepareReport();
+
+        // then
+        VelocityContext context = Deencapsulation.getField(page, "context");
+        Object failsFromContext = context.get("failures");
+
+        assertThat(failsFromContext)
+                .isNotNull()
+                .isInstanceOf(failures.getClass())
+                .asList()
+                .hasSize(expectedFailedScenarios);
+
+        //noinspection unchecked
+        failures = (List<Element>) failsFromContext;
+
+        for (Element failure : failures) {
+            assertFalse(failure.getElementStatus().isPassed());
+        }
+
+        return failures;
+    }
+
+    @Test
+    public void shouldBeEmptyForPassedTest() {
+        testFailReport(SIMPLE_JSON, 0);
+    }
+
+    @Test
+    public void shouldHaveFailedScenariosForFailedTests() {
+        List<Element> failures = testFailReport(FAILURES_JSON, 2);
+
+        // first scenario is before failure, causing steps to be skipped, which
+        // is considered a failure with the configuration PageTest uses
+        assertThat(failures.get(0).getBeforeStatus()).isEqualTo(Status.FAILED);
+        assertThat(failures.get(0).getStepsStatus()).isEqualTo(Status.SKIPPED);
+
+        // second scenario is step failure
+        assertThat(failures.get(1).getBeforeStatus()).isEqualTo(Status.PASSED);
+        assertThat(failures.get(1).getStepsStatus()).isEqualTo(Status.FAILED);
+    }
+}

--- a/src/test/java/net/masterthought/cucumber/generators/FailuresOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FailuresOverviewPageTest.java
@@ -1,13 +1,17 @@
 package net.masterthought.cucumber.generators;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import mockit.Deencapsulation;
+import net.masterthought.cucumber.generators.integrations.PageTest;
+import net.masterthought.cucumber.json.Element;
+import net.masterthought.cucumber.json.Feature;
 import org.apache.velocity.VelocityContext;
 import org.junit.Before;
 import org.junit.Test;
 
-import net.masterthought.cucumber.generators.integrations.PageTest;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -37,6 +41,20 @@ public class FailuresOverviewPageTest extends PageTest {
 
         // given
         page = new FailuresOverviewPage(reportResult, configuration);
+        // this page only has failed scenarios (elements) so extract them into
+        // a list to compare
+        List<Element> failures = new ArrayList<>();
+        for (Feature feature : features) {
+            if (feature.getStatus().isPassed())
+                continue;
+
+            for (Element element : feature.getElements()) {
+                if (element.getStepsStatus().isPassed())
+                    continue;
+
+                failures.add(element);
+            }
+        }
 
         // when
         page.prepareReport();
@@ -44,7 +62,6 @@ public class FailuresOverviewPageTest extends PageTest {
         // then
         VelocityContext context = Deencapsulation.getField(page, "context");
         assertThat(context.getKeys()).hasSize(6);
-
-        assertThat(context.get("all_features")).isEqualTo(features);
+        assertThat(context.get("failures")).isEqualTo(failures);
     }
 }

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FailuresOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FailuresOverviewPageIntegrationTest.java
@@ -1,14 +1,13 @@
 package net.masterthought.cucumber.generators.integrations;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.Test;
-
 import net.masterthought.cucumber.generators.FailuresOverviewPage;
 import net.masterthought.cucumber.generators.integrations.helpers.DocumentAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.ElementAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.LeadAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.SummaryAssertion;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -67,7 +66,7 @@ public class FailuresOverviewPageIntegrationTest extends PageTest {
         // then
         DocumentAssertion document = documentFrom(page.getWebPage());
         SummaryAssertion summary = document.getSummary();
-        assertThat(summary.getEmptyReportMessage()).isEqualTo("You have no failed scenarios in your cucumber report");
+        assertThat(summary.getEmptyReportMessage()).isEqualTo("You have no failed scenarios in your Cucumber report");
     }
 
     @Test
@@ -83,8 +82,7 @@ public class FailuresOverviewPageIntegrationTest extends PageTest {
         // then
         DocumentAssertion document = documentFrom(page.getWebPage());
         ElementAssertion[] elements = document.getElements();
-        assertThat(elements).hasSize(2);
+        assertThat(elements).hasSize(1);
         assertThat(elements[0].getBrief().getName()).isEqualTo(features.get(1).getElements()[0].getEscapedName());
-
     }
 }

--- a/src/test/resources/json/failures.json
+++ b/src/test/resources/json/failures.json
@@ -1,0 +1,170 @@
+[
+    {
+        "id":"simpleId",
+        "name":"Failing feature",
+        "keyword":"Feature",
+        "elements":[
+            {
+                "keyword":"Scenario",
+                "name":"Before hook fails",
+                "before": [
+                    {
+                        "result":{
+                            "duration":10744700,
+                            "status":"failed"
+                        },
+                        "match":{
+                            "location":"tests.before()"
+                        }
+                    }
+                ],
+                "steps":[
+                    {
+                        "result":{
+                            "duration":123456789,
+                            "status":"skipped"
+                        },
+                        "name":"Simple step name",
+                        "keyword":"Given ",
+                        "match":{
+                            "location":"tests.step()"
+                        }
+                    }
+                ],
+                "after": [
+                    {
+                        "result":{
+                            "duration":10744700,
+                            "status":"passed"
+                        },
+                        "match":{
+                            "location":"tests.after()"
+                        }
+                    }
+                ],
+                "type":"scenario"
+            },
+            {
+                "keyword":"Scenario",
+                "name":"Step fails",
+                "before": [
+                    {
+                        "result":{
+                            "duration":10744700,
+                            "status":"passed"
+                        },
+                        "match":{
+                            "location":"tests.before()"
+                        }
+                    }
+                ],
+                "steps":[
+                    {
+                        "result":{
+                            "duration":123456789,
+                            "status":"failed"
+                        },
+                        "name":"Simple step name",
+                        "keyword":"Given ",
+                        "match":{
+                            "location":"tests.step()"
+                        }
+                    }
+                ],
+                "after": [
+                    {
+                        "result":{
+                            "duration":10744700,
+                            "status":"passed"
+                        },
+                        "match":{
+                            "location":"tests.after()"
+                        }
+                    }
+                ],
+                "type":"scenario"
+            },
+            {
+                "keyword":"Scenario",
+                "name":"After hook fails",
+                "before": [
+                    {
+                        "result":{
+                            "duration":10744700,
+                            "status":"passed"
+                        },
+                        "match":{
+                            "location":"tests.before()"
+                        }
+                    }
+                ],
+                "steps":[
+                    {
+                        "result":{
+                            "duration":123456789,
+                            "status":"passed"
+                        },
+                        "name":"Simple step name",
+                        "keyword":"Given ",
+                        "match":{
+                            "location":"tests.step()"
+                        }
+                    }
+                ],
+                "after": [
+                    {
+                        "result":{
+                            "duration":10744700,
+                            "status":"failed"
+                        },
+                        "match":{
+                            "location":"tests.after()"
+                        }
+                    }
+                ],
+                "type":"scenario"
+            },
+            {
+                "keyword":"Scenario",
+                "name":"All passed",
+                "before": [
+                    {
+                        "result":{
+                            "duration":10744700,
+                            "status":"passed"
+                        },
+                        "match":{
+                            "location":"tests.before()"
+                        }
+                    }
+                ],
+                "steps":[
+                    {
+                        "result":{
+                            "duration":123456789,
+                            "status":"passed"
+                        },
+                        "name":"Simple step name",
+                        "keyword":"Given ",
+                        "match":{
+                            "location":"tests.step()"
+                        }
+                    }
+                ],
+                "after": [
+                    {
+                        "result":{
+                            "duration":10744700,
+                            "status":"passed"
+                        },
+                        "match":{
+                            "location":"tests.after()"
+                        }
+                    }
+                ],
+                "type":"scenario"
+            }
+        ],
+        "uri":"simple:uri"
+    }
+]


### PR DESCRIPTION
Only show failed scenarios.

Tested with multiple feature files in a single test run:
* Feature file with 1 failure and 1 pass
* Feature file with 2 failures and 1 pass
* Feature file with 1 pass

Only failed scenarios shown in the failures overview page.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23issuecomment-226975649%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23issuecomment-226976749%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23discussion_r67615412%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23discussion_r67615458%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23discussion_r67621063%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23discussion_r67621065%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23discussion_r67626066%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23issuecomment-230610776%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23issuecomment-230627306%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23issuecomment-231407796%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23issuecomment-231420405%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23discussion_r71218752%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23discussion_r71219792%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23discussion_r71222630%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23issuecomment-234087840%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23issuecomment-234093793%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23issuecomment-226975649%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/issues/474%22%2C%20%22created_at%22%3A%20%222016-06-19T02%3A25%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A84.85%25%2A%2A%5Cn%3E%20Merging%20%5B%23476%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20decrease%20coverage%20by%20%2A%2A1.08%25%2A%2A%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23476%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%2033%20%20%20%20%20%20%20%20%2033%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20704%20%20%20%20%20%20%20%20713%20%20%20%20%20%2B9%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%2079%20%20%20%20%20%20%20%20%2085%20%20%20%20%20%2B6%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%20%20%20605%20%20%20%20%20%20%20%20605%20%20%20%20%20%20%20%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20%20%20%2082%20%20%20%20%20%20%20%20%2091%20%20%20%20%20%2B9%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%2017%20%20%20%20%20%20%20%20%2017%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5Bebab3ab...2c77a05%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/compare/ebab3abb906ecb239832727e50964a19ee1b14b2...2c77a05f856b23fe024839a1a8d9ed62bae19cc0%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/476%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-06-19T03%3A08%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40midopa%20this%20branch%20has%20conflicts.%20Will%20you%20update%20the%20patch%20and%20resolve%20conflict%3F%22%2C%20%22created_at%22%3A%20%222016-07-05T21%3A37%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20once%20I%27m%20back%20from%20vacation.%20Maybe%20end%20of%20this%20week.%20Same%20for%20the%5Cnother%20PR%20about%20globally%20unique%20IDs.%5CnOn%20Jul%205%2C%202016%203%3A37%20PM%2C%20%5C%22Damian%20Szczepanik%5C%22%20%3Cnotifications%40github.com%3E%5Cnwrote%3A%5Cn%5Cn%3E%20%40midopa%20%3Chttps%3A//github.com/midopa%3E%20this%20branch%20has%20conflicts.%20Will%20you%5Cn%3E%20update%20the%20patch%20and%20resolve%20conflict%3F%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20You%20are%20receiving%20this%20because%20you%20were%20mentioned.%5Cn%3E%20Reply%20to%20this%20email%20directly%2C%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23issuecomment-230610776%3E%2C%5Cn%3E%20or%20mute%20the%20thread%5Cn%3E%20%3Chttps%3A//github.com/notifications/unsubscribe/ABc53bzQBaiV2-EJvoCftxajLMwZfdGaks5qSs61gaJpZM4I5E3w%3E%5Cn%3E%20.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-05T22%3A59%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22Actually%20I%20won%27t%20be%20back%20until%20next%20week.%20Sorry%2C%20sudden%20change%20of%20plans.%5CnOn%20Jul%205%2C%202016%203%3A59%20PM%2C%20%5C%22midopa%5C%22%20%3Cmidopa%40gmail.com%3E%20wrote%3A%5Cn%5Cn%3E%20Yes%2C%20once%20I%27m%20back%20from%20vacation.%20Maybe%20end%20of%20this%20week.%20Same%20for%20the%5Cn%3E%20other%20PR%20about%20globally%20unique%20IDs.%5Cn%3E%20On%20Jul%205%2C%202016%203%3A37%20PM%2C%20%5C%22Damian%20Szczepanik%5C%22%20%3Cnotifications%40github.com%3E%5Cn%3E%20wrote%3A%5Cn%3E%5Cn%3E%3E%20%40midopa%20%3Chttps%3A//github.com/midopa%3E%20this%20branch%20has%20conflicts.%20Will%20you%5Cn%3E%3E%20update%20the%20patch%20and%20resolve%20conflict%3F%5Cn%3E%3E%5Cn%3E%3E%20%5Cu2014%5Cn%3E%3E%20You%20are%20receiving%20this%20because%20you%20were%20mentioned.%5Cn%3E%3E%20Reply%20to%20this%20email%20directly%2C%20view%20it%20on%20GitHub%5Cn%3E%3E%20%3Chttps%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23issuecomment-230610776%3E%2C%5Cn%3E%3E%20or%20mute%20the%20thread%5Cn%3E%3E%20%3Chttps%3A//github.com/notifications/unsubscribe/ABc53bzQBaiV2-EJvoCftxajLMwZfdGaks5qSs61gaJpZM4I5E3w%3E%5Cn%3E%3E%20.%5Cn%3E%3E%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-08T16%3A33%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20need%20to%20harry.%20%20I%20will%20wait.%20%22%2C%20%22created_at%22%3A%20%222016-07-08T17%3A24%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20want%20to%20include%20this%20patch%20into%20incoming%20release%20-%20hopefully%20this%20week%22%2C%20%22created_at%22%3A%20%222016-07-20T21%3A24%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Is%20there%20anything%20remaining%20to%20do%3F%22%2C%20%22created_at%22%3A%20%222016-07-20T21%3A47%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%202023cade331f5efcff00452ba28ebc7c0efa530f%20src/test/resources/json/after-step-fails.json%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23discussion_r67615458%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20believe%20you%20can%20merge%20this%20into%20sample.json%20and%20select%20proper%20elements%20to%20assertion%22%2C%20%22created_at%22%3A%20%222016-06-19T11%3A44%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sure%22%2C%20%22created_at%22%3A%20%222016-06-19T17%3A52%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22For%20simplicity%2C%20I%20collapsed%20all%20the%20failure%20cases%20into%20a%20single%20JSON.%20If%20I%20put%20everything%20into%20sample.json%2C%20a%20lot%20of%20tests%20fail%20and%20it%20becomes%20a%20chore%20to%20update%20every%20other%20test.%20This%20seems%20like%20a%20happy%20medium.%22%2C%20%22created_at%22%3A%20%222016-07-18T20%3A04%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20decided%20to%20have%20one%20simple%20json%20file%20but%20then%20I%20found%20that%20some%20border%20cases%20are%20hard%20to%20test.%20That%27s%20a%20place%20for%20further%20improvements.%22%2C%20%22created_at%22%3A%20%222016-07-18T20%3A27%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/resources/json/after-step-fails.json%3AL1-39%22%7D%2C%20%22Pull%209085e44daf1679c709da0b4f11cd8c1deb0caee5%20src/test/java/net/masterthought/cucumber/generators/FailureOverviewPageTest.java%2041%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23discussion_r67626066%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%21%5BCodacy%5D%28https%3A//www.codacy.com/assets/images/favicon.png%29%20Issue%20found%3A%20%5BassertTrue%28%21expr%29%20can%20be%20replaced%20by%20assertFalse%28expr%29%5D%28https%3A//www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2791602199/issues/source%3Fbid%3D3059308%26fileBranchId%3D3369233%23l41%29%22%2C%20%22created_at%22%3A%20%222016-06-19T23%3A51%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/19940114%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codacy-bot%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/java/net/masterthought/cucumber/generators/FailureOverviewPageTest.java%3AL1-72%22%7D%2C%20%22Pull%202023cade331f5efcff00452ba28ebc7c0efa530f%20src/main/java/net/masterthought/cucumber/generators/FailuresOverviewPage.java%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/476%23discussion_r67615412%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20that%20case%20if%20the%20Before%20or%20After%20is%20failed%20but%20the%20scenario%20passes%20you%20will%20print%20the%20element%20even%20it%20is%20passed.%5Cr%5Cn%5Cr%5CnIs%20that%20what%20you%20expected%3F%20%22%2C%20%22created_at%22%3A%20%222016-06-19T11%3A41%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm.%20It%20depends.%20Before%20steps%20are%20usually%20to%20setup%20a%20test%20environment.%20It%20might%20be%20important%20to%20know%20that%20those%20failed.%20In%20the%20same%20manner%2C%20after%20steps%20are%20generally%20used%20to%20cleanup%20the%20test%20environment/data.%20It%20might%20also%20be%20good%20to%20know%20that%20failed%20as%20well.%22%2C%20%22created_at%22%3A%20%222016-06-19T17%3A51%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20that%20case%20there%20should%20be%20a%20configuration%20flag%20to%20mark%20scenarios%20as%20failed%20if%20their%20hooks%20fail.%20But%20that%27s%20a%20separate%20issue%20so%20I%27ve%20created%20it%3A%20%23497%22%2C%20%22created_at%22%3A%20%222016-07-18T20%3A10%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/generators/FailuresOverviewPage.java%3AL21-40%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/476#issuecomment-226975649'>General Comment</a></b>
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> https://github.com/damianszczepanik/cucumber-reporting/issues/474
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **84.85%**
> Merging [#476][cc-pull] into [master][cc-base-branch] will decrease coverage by **1.08%**
```diff
@@             master       #476   diff @@
==========================================
Files            33         33
Lines           704        713     +9
Methods           0          0
Messages          0          0
Branches         79         85     +6
==========================================
Hits            605        605
- Misses           82         91     +9
Partials         17         17
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [ebab3ab...2c77a05][cc-compare]
[cc-base-branch]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/compare/ebab3abb906ecb239832727e50964a19ee1b14b2...2c77a05f856b23fe024839a1a8d9ed62bae19cc0
[cc-pull]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/476?src=pr
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> @midopa this branch has conflicts. Will you update the patch and resolve conflict?
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Yes, once I'm back from vacation. Maybe end of this week. Same for the
other PR about globally unique IDs.
On Jul 5, 2016 3:37 PM, "Damian Szczepanik" <notifications@github.com>
wrote:
> @midopa <https://github.com/midopa> this branch has conflicts. Will you
> update the patch and resolve conflict?
>
> —
> You are receiving this because you were mentioned.
> Reply to this email directly, view it on GitHub
> <https://github.com/damianszczepanik/cucumber-reporting/pull/476#issuecomment-230610776>,
> or mute the thread
> <https://github.com/notifications/unsubscribe/ABc53bzQBaiV2-EJvoCftxajLMwZfdGaks5qSs61gaJpZM4I5E3w>
> .
>
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Actually I won't be back until next week. Sorry, sudden change of plans.
On Jul 5, 2016 3:59 PM, "midopa" <midopa@gmail.com> wrote:
> Yes, once I'm back from vacation. Maybe end of this week. Same for the
> other PR about globally unique IDs.
> On Jul 5, 2016 3:37 PM, "Damian Szczepanik" <notifications@github.com>
> wrote:
>
>> @midopa <https://github.com/midopa> this branch has conflicts. Will you
>> update the patch and resolve conflict?
>>
>> —
>> You are receiving this because you were mentioned.
>> Reply to this email directly, view it on GitHub
>> <https://github.com/damianszczepanik/cucumber-reporting/pull/476#issuecomment-230610776>,
>> or mute the thread
>> <https://github.com/notifications/unsubscribe/ABc53bzQBaiV2-EJvoCftxajLMwZfdGaks5qSs61gaJpZM4I5E3w>
>> .
>>
>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> No need to harry.  I will wait.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> I want to include this patch into incoming release - hopefully this week
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Is there anything remaining to do?
- [x] <a href='#crh-comment-Pull 2023cade331f5efcff00452ba28ebc7c0efa530f src/main/java/net/masterthought/cucumber/generators/FailuresOverviewPage.java 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/476#discussion_r67615412'>File: src/main/java/net/masterthought/cucumber/generators/FailuresOverviewPage.java:L21-40</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> In that case if the Before or After is failed but the scenario passes you will print the element even it is passed.
Is that what you expected?
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Hm. It depends. Before steps are usually to setup a test environment. It might be important to know that those failed. In the same manner, after steps are generally used to cleanup the test environment/data. It might also be good to know that failed as well.
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> In that case there should be a configuration flag to mark scenarios as failed if their hooks fail. But that's a separate issue so I've created it: #497
- [ ] <a href='#crh-comment-Pull 2023cade331f5efcff00452ba28ebc7c0efa530f src/test/resources/json/after-step-fails.json 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/476#discussion_r67615458'>File: src/test/resources/json/after-step-fails.json:L1-39</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> I believe you can merge this into sample.json and select proper elements to assertion
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Sure
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> For simplicity, I collapsed all the failure cases into a single JSON. If I put everything into sample.json, a lot of tests fail and it becomes a chore to update every other test. This seems like a happy medium.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> I decided to have one simple json file but then I found that some border cases are hard to test. That's a place for further improvements.
- [x] <a href='#crh-comment-Pull 9085e44daf1679c709da0b4f11cd8c1deb0caee5 src/test/java/net/masterthought/cucumber/generators/FailureOverviewPageTest.java 41'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/476#discussion_r67626066'>File: src/test/java/net/masterthought/cucumber/generators/FailureOverviewPageTest.java:L1-72</a></b>
- <a href='https://github.com/codacy-bot'><img border=0 src='https://avatars.githubusercontent.com/u/19940114?v=3' height=16 width=16'></a> ![Codacy](https://www.codacy.com/assets/images/favicon.png) Issue found: [assertTrue(!expr) can be replaced by assertFalse(expr)](https://www.codacy.com/app/damianszczepanik/cucumber-reporting/file/2791602199/issues/source?bid=3059308&fileBranchId=3369233#l41)


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/476?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/476?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/476'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>