### PR TITLE
Fix broken message boxes

### DIFF
--- a/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
@@ -18,6 +18,7 @@ import org.apache.velocity.app.VelocityEngine;
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportResult;
 import net.masterthought.cucumber.ValidationException;
+import net.masterthought.cucumber.util.Counter;
 
 /**
  * Delivers common methods for page generation.
@@ -81,6 +82,8 @@ public abstract class AbstractPage {
     }
 
     private void buildGeneralParameters() {
+        // to provide unique ids for elements on each page
+        context.put("counter", new Counter());
         context.put("jenkins_source", configuration.isRunWithJenkins());
         context.put("jenkins_base", configuration.getJenkinsBasePath());
         context.put("build_project_name", configuration.getProjectName());

--- a/src/main/java/net/masterthought/cucumber/util/Counter.java
+++ b/src/main/java/net/masterthought/cucumber/util/Counter.java
@@ -1,0 +1,17 @@
+package net.masterthought.cucumber.util;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+
+/**
+ * Simple counter to give elements on a page a unique ID. Using object hashes
+ * doesn't guarantee uniqueness.
+ */
+public class Counter extends MutableInt {
+    /**
+     * @return The next integer
+     */
+    public int next() {
+        increment();
+        return intValue();
+    }
+}

--- a/src/main/resources/templates/macros/report/docstring.vm
+++ b/src/main/resources/templates/macros/report/docstring.vm
@@ -3,10 +3,11 @@
 #if ($docString)
   <div class="inner-level">
     <div class="docstring indention">
-      <div data-toggle="collapse" class="collapsable-control" data-target="#msg-$docString.hashCode()">
+      #set($docStringId = $counter.next())
+      <div data-toggle="collapse" class="collapsable-control" data-target="#msg-$docStringId">
           <a>Doc string</a>
       </div>
-      <div id="msg-$docString.hashCode()" class="collapse collapsable-details">
+      <div id="msg-$docStringId" class="collapse collapsable-details">
         <pre>$docString.getValue()</pre>
       </div>
     </div>

--- a/src/main/resources/templates/macros/report/element.vm
+++ b/src/main/resources/templates/macros/report/element.vm
@@ -9,12 +9,13 @@
 
   #includeTags($element.getTags())
 
-  <span data-toggle="collapse" class="#if ($element.getElementStatus().isPassed()) collapsed #end collapsable-control" data-target="#element-$element.hashCode()">
+  #set($elementId = $counter.next())
+  <span data-toggle="collapse" class="#if ($element.getElementStatus().isPassed()) collapsed #end collapsable-control" data-target="#element-$elementId">
     #includeBrief($element.getKeyword(), $element.getElementStatus(), $element.getEscapedName(), true)
   </span>
   <div class="description indention">$element.getDescription()</div>
 
-  <div id="element-$element.hashCode()" class="collapse collapsable-details #if(!$element.getElementStatus().isPassed()) in #end">
+  <div id="element-$elementId" class="collapse collapsable-details #if(!$element.getElementStatus().isPassed()) in #end">
     #includeHooks("Before", $element.getBefore(), $element.getBeforeStatus())
 
     #includeSteps($element.getSteps())

--- a/src/main/resources/templates/macros/report/hooks.vm
+++ b/src/main/resources/templates/macros/report/hooks.vm
@@ -2,11 +2,12 @@
 
 #if($hooks.size() > 0)
   <div class="inner-level hooks-$keyword.toLowerCase()">
-    <div data-toggle="collapse" class="#if($status.isPassed()) collapsed #end collapsable-control" data-target="#$keyword.toLowerCase()-$hooks.hashCode()">
+    #set($hookId = $counter.next())
+    <div data-toggle="collapse" class="#if($status.isPassed()) collapsed #end collapsable-control" data-target="#$keyword.toLowerCase()-$hookId">
       #includeBrief("Hooks", $status, "", true)
     </div>
 
-    <div id="$keyword.toLowerCase()-$hooks.hashCode()" class="inner-level collapse collapsable-details #if (!$status.isPassed()) in #end">
+    <div id="$keyword.toLowerCase()-$hookId" class="inner-level collapse collapsable-details #if (!$status.isPassed()) in #end">
       #foreach($hook in $hooks)
         <div class="hook">
           <div class="brief $hook.getResult().getStatus().getRawName()">

--- a/src/main/resources/templates/macros/report/message.vm
+++ b/src/main/resources/templates/macros/report/message.vm
@@ -1,12 +1,14 @@
 #macro(includeMessage, $messageName, $message)
 
 #if ($message)
+  #set($msgId = $counter.next())
+
   <div class="inner-level">
     <div class="message indention">
-      <div data-toggle="collapse" class="collapsable-control" data-target="#msg-$message.hashCode()">
+      <div data-toggle="collapse" class="collapsable-control" data-target="#msg-$msgId">
           <a>$messageName</a>
       </div>
-      <div id="msg-$message.hashCode()" class="collapse collapsable-details">
+      <div id="msg-$msgId" class="collapse collapsable-details">
         <pre>$message</pre>
       </div>
     </div>

--- a/src/main/resources/templates/macros/report/output.vm
+++ b/src/main/resources/templates/macros/report/output.vm
@@ -4,11 +4,12 @@
   <div class="outputs inner-level">
     #foreach($message in $output.getMessages())
       <div class="output indention">
-        <div data-toggle="collapse" class="collapsable-control" data-target="#msg-$message.hashCode()">
+        #set($outputId = $counter.next())
+        <div data-toggle="collapse" class="collapsable-control" data-target="#msg-$outputId">
           #set($index = $foreach.index + 1)
           <a>Output $index</a>
         </div>
-        <div id="msg-$message.hashCode()" class="collapse collapsable-details">
+        <div id="msg-$outputId" class="collapse collapsable-details">
           <pre>$message</pre>
         </div>
       </div>

--- a/src/main/resources/templates/macros/report/steps.vm
+++ b/src/main/resources/templates/macros/report/steps.vm
@@ -1,11 +1,12 @@
 #macro(includeSteps, $steps)
 
 <div class="steps inner-level">
-  <div data-toggle="collapse" class="#if ($element.getElementStatus().isPassed()) collapsed #end collapsable-control" data-target="#steps-$element.getSteps().hashCode()">
+  #set($stepsId = $counter.next())
+  <div data-toggle="collapse" class="#if ($element.getElementStatus().isPassed()) collapsed #end collapsable-control" data-target="#steps-$stepsId">
     #includeBrief("Steps", $element.getStepsStatus(), "", true)
   </div>
 
-  <div id="steps-$element.getSteps().hashCode()" class="inner-level collapse collapsable-details #if (!$element.getElementStatus().isPassed()) in #end">
+  <div id="steps-$stepsId" class="inner-level collapse collapsable-details #if (!$element.getElementStatus().isPassed()) in #end">
     #foreach($step in $element.getSteps())
       <div class="step">
         #includeBrief($step.getKeyword(), $step.getResult().getStatus(), $step.getName(), false, $step.getResult())

--- a/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
@@ -1,16 +1,16 @@
 package net.masterthought.cucumber.generators;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.File;
-import java.util.Properties;
-
 import mockit.Deencapsulation;
+import net.masterthought.cucumber.generators.integrations.PageTest;
+import net.masterthought.cucumber.util.Counter;
 import org.apache.velocity.VelocityContext;
 import org.junit.Before;
 import org.junit.Test;
 
-import net.masterthought.cucumber.generators.integrations.PageTest;
+import java.io.File;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -63,12 +63,17 @@ public class AbstractPageTest extends PageTest {
 
         // then
         VelocityContext context = Deencapsulation.getField(page, "context");
-        assertThat(context.getKeys()).hasSize(5);
+        assertThat(context.getKeys()).hasSize(6);
         assertThat(context.get("jenkins_source")).isEqualTo(configuration.isRunWithJenkins());
         assertThat(context.get("jenkins_base")).isEqualTo(configuration.getJenkinsBasePath());
         assertThat(context.get("build_project_name")).isEqualTo(configuration.getProjectName());
         assertThat(context.get("build_number")).isEqualTo(configuration.getBuildNumber());
         assertThat(context.get("jenkins_source")).isNotNull();
+
+        Object obj = context.get("counter");
+        assertThat(obj).isInstanceOf(Counter.class);
+        Counter counter = (Counter) obj;
+        assertThat(counter.next()).isEqualTo(1);
     }
 
     @Test
@@ -83,7 +88,7 @@ public class AbstractPageTest extends PageTest {
 
         // then
         VelocityContext context = Deencapsulation.getField(page, "context");
-        assertThat(context.getKeys()).hasSize(6);
+        assertThat(context.getKeys()).hasSize(7);
         assertThat(context.get("build_time")).isNotNull();
     }
 
@@ -99,7 +104,7 @@ public class AbstractPageTest extends PageTest {
 
         // then
         VelocityContext context = Deencapsulation.getField(page, "context");
-        assertThat(context.getKeys()).hasSize(5);
+        assertThat(context.getKeys()).hasSize(6);
         assertThat(context.get("build_previous_number")).isNull();
     }
 
@@ -115,7 +120,7 @@ public class AbstractPageTest extends PageTest {
 
         // then
         VelocityContext context = Deencapsulation.getField(page, "context");
-        assertThat(context.getKeys()).hasSize(6);
+        assertThat(context.getKeys()).hasSize(7);
         assertThat(context.get("build_previous_number")).isEqualTo(33);
     }
 }

--- a/src/test/java/net/masterthought/cucumber/generators/ErrorPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/ErrorPageTest.java
@@ -32,7 +32,7 @@ public class ErrorPageTest extends PageTest {
 
         // then
         VelocityContext context = Deencapsulation.getField(page, "context");
-        assertThat(context.getKeys()).hasSize(7);
+        assertThat(context.getKeys()).hasSize(8);
         assertThat(context.get("output_message")).isEqualTo(ExceptionUtils.getStackTrace(exception));
         assertThat(context.get("json_files")).isEqualTo(jsonReports);
     }

--- a/src/test/java/net/masterthought/cucumber/generators/FailuresOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FailuresOverviewPageTest.java
@@ -61,7 +61,7 @@ public class FailuresOverviewPageTest extends PageTest {
 
         // then
         VelocityContext context = Deencapsulation.getField(page, "context");
-        assertThat(context.getKeys()).hasSize(6);
+        assertThat(context.getKeys()).hasSize(7);
         assertThat(context.get("failures")).isEqualTo(failures);
     }
 }

--- a/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageTest.java
@@ -46,7 +46,7 @@ public class FeatureReportPageTest extends PageTest {
 
         // then
         VelocityContext context = Deencapsulation.getField(page, "context");
-        assertThat(context.getKeys()).hasSize(7);
+        assertThat(context.getKeys()).hasSize(8);
         assertThat(context.get("parallel")).isEqualTo(configuration.isParallelTesting());
         assertThat(context.get("feature")).isEqualTo(feature);
     }

--- a/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageTest.java
@@ -44,7 +44,7 @@ public class FeaturesOverviewPageTest extends PageTest {
 
         // then
         VelocityContext context = Deencapsulation.getField(page, "context");
-        assertThat(context.getKeys()).hasSize(10);
+        assertThat(context.getKeys()).hasSize(11);
 
         assertThat(context.get("all_features")).isEqualTo(features);
         assertThat(context.get("report_summary")).isEqualTo(reportResult.getFeatureReport());

--- a/src/test/java/net/masterthought/cucumber/generators/StepsOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/StepsOverviewPageTest.java
@@ -45,7 +45,7 @@ public class StepsOverviewPageTest extends PageTest {
 
         // then
         VelocityContext context = Deencapsulation.getField(page, "context");
-        assertThat(context.getKeys()).hasSize(9);
+        assertThat(context.getKeys()).hasSize(10);
         assertThat(context.get("all_steps")).isEqualTo(steps);
 
         int allOccurrences = 0;

--- a/src/test/java/net/masterthought/cucumber/generators/TagReportPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TagReportPageTest.java
@@ -46,7 +46,7 @@ public class TagReportPageTest extends PageTest {
 
         // then
         VelocityContext context = Deencapsulation.getField(page, "context");
-        assertThat(context.getKeys()).hasSize(6);
+        assertThat(context.getKeys()).hasSize(7);
         assertThat(context.get("tag")).isEqualTo(tag);
     }
 }

--- a/src/test/java/net/masterthought/cucumber/generators/TagsOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TagsOverviewPageTest.java
@@ -47,7 +47,7 @@ public class TagsOverviewPageTest extends PageTest {
 
         // then
         VelocityContext context = Deencapsulation.getField(page, "context");
-        assertThat(context.getKeys()).hasSize(9);
+        assertThat(context.getKeys()).hasSize(10);
 
         assertThat(context.get("all_tags")).isEqualTo(tags);
         assertThat(context.get("report_summary")).isEqualTo(reportResult.getTagReport());

--- a/src/test/java/net/masterthought/cucumber/util/CounterTest.java
+++ b/src/test/java/net/masterthought/cucumber/util/CounterTest.java
@@ -1,0 +1,22 @@
+package net.masterthought.cucumber.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class CounterTest {
+    @Test
+    public void next_shouldIncrement() {
+        // given
+        Counter counter = new Counter();
+        int initValue = counter.intValue();
+
+        // when
+        int nextValue = counter.next();
+
+        // then
+        assertNotEquals(initValue, nextValue);
+        assertEquals(initValue + 1, nextValue);
+    }
+}


### PR DESCRIPTION
When multiple error messages are exactly the same, the UI only
expand/collapses the first message box on the page. This is due to the
same hash codes. An incrementing counter was appended to the IDs to make
them unique.

https://github.com/damianszczepanik/cucumber-reporting/issues/471
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23issuecomment-226978122%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23issuecomment-226992583%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23issuecomment-227010638%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23issuecomment-229512652%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69182230%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69182526%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69182993%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69183163%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69183359%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69183483%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69183525%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r71206293%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r71206757%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r71211147%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r71221038%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r71221625%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r71221782%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r71222041%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r71222090%22%2C%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23issuecomment-234598334%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23issuecomment-226978122%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5Bcc-pull%5D%20is%20%2A%2A85.95%25%2A%2A%5Cn%3E%20Merging%20%5B%23477%5D%5Bcc-pull%5D%20into%20%5Bmaster%5D%5Bcc-base-branch%5D%20will%20increase%20coverage%20by%20%2A%2A0.01%25%2A%2A%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23477%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%2033%20%20%20%20%20%20%20%20%2033%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20704%20%20%20%20%20%20%20%20705%20%20%20%20%20%2B1%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%2079%20%20%20%20%20%20%20%20%2079%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%20%20605%20%20%20%20%20%20%20%20606%20%20%20%20%20%2B1%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20%2082%20%20%20%20%20%20%20%20%2082%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%2017%20%20%20%20%20%20%20%20%2017%20%20%20%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20updated%20by%20%5Bebab3ab...4302c1f%5D%5Bcc-compare%5D%5Cn%5Bcc-base-branch%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master%3Fsrc%3Dpr%5Cn%5Bcc-compare%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/compare/ebab3abb906ecb239832727e50964a19ee1b14b2...4302c1f3fa2af7dc36d7f5c0536f1b54dd5de39c%5Cn%5Bcc-pull%5D%3A%20https%3A//codecov.io/gh/damianszczepanik/cucumber-reporting/pull/477%3Fsrc%3Dpr%22%2C%20%22created_at%22%3A%20%222016-06-19T04%3A00%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20hashCode%20conception%20must%20be%20rewritten%20because%20this%20problems%20happens%20to%20all%20items%20that%20have%20the%20same%20hash.%20Provided%20solution%20is%20like%20hot%20fix%20while%20the%20completely%20new%20solution%20mist%20be%20implemented.%5Cr%5Cn%5Cr%5CnThe%20idea%20is%20to%20have%20global%20%20pseudo%20iterator%20that%20generates%20next%20Id%20and%20guarantee%20global%20uniqness.%20%22%2C%20%22created_at%22%3A%20%222016-06-19T11%3A34%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20global%20uniqueness%20only%20has%20to%20apply%20at%20a%20per-page%20level.%20So%20in%20this%20case%2C%20I%20think%20the%20counter%20can%20be%20reused%20and%20all%20hashes%20can%20simply%20be%20replaced%20with%20its%20value.%20To%20make%20it%20even%20simpler%2C%20a%20subclass%20of%20MutableInt%20could%20be%20made%20with%20an%20API%20%60int%20nextInt%28%29%60%20that%20increments%20the%20internal%20counter%20and%20returns%20the%20value.%20It%20will%20remove%20the%20%60increment%28%29%60%20call%20from%20the%20templates.%22%2C%20%22created_at%22%3A%20%222016-06-19T17%3A50%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22Is%20something%20missing%20for%20merge%3F%22%2C%20%22created_at%22%3A%20%222016-06-29T22%3A49%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22Anything%20else%20left%20to%20do%20for%20this%3F%20Sorry%20if%20I%20didn%27t%20understand%20your%20previous%20concerns.%22%2C%20%22created_at%22%3A%20%222016-07-22T17%3A00%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%209dc3fce49f5d1e400d2740de7d9ed74641e0d3c1%20src/test/java/net/masterthought/cucumber/util/CounterTest.java%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69183483%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22nextValue_ReturnsInitialValue%22%2C%20%22created_at%22%3A%20%222016-06-30T18%3A18%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22Next%20returns%20the%20next%20value%2C%20not%20the%20current.%5Cr%5CnThe%20initial%20value%2C%200%2C%20can%20only%20be%20seen%20if%20%60intValue%60%20is%20used.%5Cr%5CnIn%20fact%2C%20to%20simplify%2C%20I%27m%20tempted%20to%20make%20%60Counter%60%20contain%20%60MutableInt%60%2C%20not%20inherit%20from%20it%2C%20and%20only%20have%20one%20API%3A%20%60next%60.%22%2C%20%22created_at%22%3A%20%222016-07-18T19%3A20%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22Update%3A%20To%20keep%20things%20moving%2C%20I%20decided%20to%20leave%20Counter%20as-is.%22%2C%20%22created_at%22%3A%20%222016-07-18T20%3A22%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3CmetodName%3E%5B_On%3CConditio%7CCase%7C%3E%5D_%3CExpectedReturn%3E%22%2C%20%22created_at%22%3A%20%222016-07-18T20%3A24%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/java/net/masterthought/cucumber/util/CounterTest.java%3AL1-16%22%7D%2C%20%22Pull%209dc3fce49f5d1e400d2740de7d9ed74641e0d3c1%20src/main/java/net/masterthought/cucumber/util/Counter.java%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69182230%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22next%28%29%20or%20nextId%28%29%22%2C%20%22created_at%22%3A%20%222016-06-30T18%3A11%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/net/masterthought/cucumber/util/Counter.java%3AL1-18%22%7D%2C%20%22Pull%209dc3fce49f5d1e400d2740de7d9ed74641e0d3c1%20src/test/java/net/masterthought/cucumber/util/CounterTest.java%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69183525%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22use%20given%2Cwhen%2Cthen%20conception%22%2C%20%22created_at%22%3A%20%222016-06-30T18%3A18%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/java/net/masterthought/cucumber/util/CounterTest.java%3AL1-16%22%7D%2C%20%22Pull%209dc3fce49f5d1e400d2740de7d9ed74641e0d3c1%20src/main/resources/templates/macros/report/element.vm%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69183163%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22and%20then%20instead%20of%20%3Celement-type%3E%20you%20can%20simple%20use%20msg-%20for%20each%20id%20-%20can%20you%20check%20it%3F%22%2C%20%22created_at%22%3A%20%222016-06-30T18%3A16%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20hardcoding%20a%20prefix%20into%20the%20counter%20isn%27t%20ideal.%20It%20will%20work%2C%20but%20can%20confuse%20when%20reading%20the%20code.%20I%20would%20prefer%20to%20keep%20this%20as-is.%20Another%20option%20is%20to%20have%20an%20API%20to%20specify%20the%20prefix%20so%20each%20template%20can%20set%20it.%20But%20since%20counter%20is%20a%20global%20thing%20%28at%20least%20for%20a%20single%20page%29%2C%20it%20can%20easily%20%27leak%27%20across%20templates%20and%20cause%20further%20confusion%20when%20reading%20the%20generated%20code%20%28but%20it%20will%20still%20work%29.%22%2C%20%22created_at%22%3A%20%222016-07-18T18%3A56%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22ok%20-%20anyway%20I%20don%27t%20see%20a%20problem%20when%20the%20counter%20is%20continued%20between%20pages%2C%20so%20this%20is%20global%5Cr%5Cn%5Cr%5Cnit%20must%20be%20unique%20per%20page%20so%20when%20is%20unique%20per%20whole%20report%20it%27s%20fine%20as%20well%2C%20isn%27t%20it%3F%22%2C%20%22created_at%22%3A%20%222016-07-18T20%3A21%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20way%20counter%20is%20currently%20used%2C%20it%27s%20global/unique%20per%20page%20but%20not%20report.%20Since%20the%20HTML%20doesn%27t%20reference%20anything%20across%20pages%20that%20uses%20IDs%20currently%2C%20there%20isn%27t%20a%20conflict.%22%2C%20%22created_at%22%3A%20%222016-07-18T20%3A24%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/resources/templates/macros/report/element.vm%3AL9-22%22%7D%2C%20%22Pull%209dc3fce49f5d1e400d2740de7d9ed74641e0d3c1%20src/main/resources/templates/macros/report/docstring.vm%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69182993%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22if%20nextValue%28%29%20returns%20string%20with%20prefix%20%5C%22msg-%5C%22%20than%20this%20prefix%20does%20not%20have%20to%20be%20added%20to%20each%20occurrence%22%2C%20%22created_at%22%3A%20%222016-06-30T18%3A15%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20would%20be%20misleading%20for%20other%20uses%20of%20the%20counter%2C%20like%20in%20elements%20or%20steps%2C%20etc.%22%2C%20%22created_at%22%3A%20%222016-07-18T18%3A53%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1522141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/midopa%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20is%20true.%20%60%60nextValue%28%29%60%60%20should%20be%20executed%20for%20particular%20type%20such%20as%20element%2C%20step%2C%20embedded...%22%2C%20%22created_at%22%3A%20%222016-07-18T20%3A18%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/resources/templates/macros/report/docstring.vm%3AL3-14%22%7D%2C%20%22Pull%209dc3fce49f5d1e400d2740de7d9ed74641e0d3c1%20src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69183359%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22if%20you%20validate%20isIntanceOf%20you%20probably%20don%27t%20have%20to%20use%20IsNotNull%20at%20the%20same%20time%5Cr%5Cn%5Cr%5Cnalso%20validate%20value%2C%20not%20only%20the%20type%2C%20if%20deterministic%22%2C%20%22created_at%22%3A%20%222016-06-30T18%3A17%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java%3AL64-79%22%7D%2C%20%22Pull%209dc3fce49f5d1e400d2740de7d9ed74641e0d3c1%20src/main/resources/templates/macros/report/docstring.vm%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik/cucumber-reporting/pull/477%23discussion_r69182526%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22docStringId%22%2C%20%22created_at%22%3A%20%222016-06-30T18%3A13%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9612911%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/damianszczepanik%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/resources/templates/macros/report/docstring.vm%3AL3-14%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/477#issuecomment-226978122'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][cc-pull] is **85.95%**
> Merging [#477][cc-pull] into [master][cc-base-branch] will increase coverage by **0.01%**
```diff
@@             master       #477   diff @@
==========================================
Files            33         33
Lines           704        705     +1
Methods           0          0
Messages          0          0
Branches         79         79
==========================================
+ Hits            605        606     +1
Misses           82         82
Partials         17         17
```
> Powered by [Codecov](https://codecov.io?src=pr). Last updated by [ebab3ab...4302c1f][cc-compare]
[cc-base-branch]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/branch/master?src=pr
[cc-compare]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/compare/ebab3abb906ecb239832727e50964a19ee1b14b2...4302c1f3fa2af7dc36d7f5c0536f1b54dd5de39c
[cc-pull]: https://codecov.io/gh/damianszczepanik/cucumber-reporting/pull/477?src=pr
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> The hashCode conception must be rewritten because this problems happens to all items that have the same hash. Provided solution is like hot fix while the completely new solution mist be implemented.
The idea is to have global  pseudo iterator that generates next Id and guarantee global uniqness.
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> The global uniqueness only has to apply at a per-page level. So in this case, I think the counter can be reused and all hashes can simply be replaced with its value. To make it even simpler, a subclass of MutableInt could be made with an API `int nextInt()` that increments the internal counter and returns the value. It will remove the `increment()` call from the templates.
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Is something missing for merge?
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Anything else left to do for this? Sorry if I didn't understand your previous concerns.
- [x] <a href='#crh-comment-Pull 9dc3fce49f5d1e400d2740de7d9ed74641e0d3c1 src/main/java/net/masterthought/cucumber/util/Counter.java 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/477#discussion_r69182230'>File: src/main/java/net/masterthought/cucumber/util/Counter.java:L1-18</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> next() or nextId()
- [x] <a href='#crh-comment-Pull 9dc3fce49f5d1e400d2740de7d9ed74641e0d3c1 src/main/resources/templates/macros/report/docstring.vm 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/477#discussion_r69182526'>File: src/main/resources/templates/macros/report/docstring.vm:L3-14</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> docStringId
- [x] <a href='#crh-comment-Pull 9dc3fce49f5d1e400d2740de7d9ed74641e0d3c1 src/main/resources/templates/macros/report/docstring.vm 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/477#discussion_r69182993'>File: src/main/resources/templates/macros/report/docstring.vm:L3-14</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> if nextValue() returns string with prefix "msg-" than this prefix does not have to be added to each occurrence
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> That would be misleading for other uses of the counter, like in elements or steps, etc.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> That is true. ``nextValue()`` should be executed for particular type such as element, step, embedded...
- [x] <a href='#crh-comment-Pull 9dc3fce49f5d1e400d2740de7d9ed74641e0d3c1 src/main/resources/templates/macros/report/element.vm 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/477#discussion_r69183163'>File: src/main/resources/templates/macros/report/element.vm:L9-22</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> and then instead of <element-type> you can simple use msg- for each id - can you check it?
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> I think hardcoding a prefix into the counter isn't ideal. It will work, but can confuse when reading the code. I would prefer to keep this as-is. Another option is to have an API to specify the prefix so each template can set it. But since counter is a global thing (at least for a single page), it can easily 'leak' across templates and cause further confusion when reading the generated code (but it will still work).
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> ok - anyway I don't see a problem when the counter is continued between pages, so this is global
it must be unique per page so when is unique per whole report it's fine as well, isn't it?
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> The way counter is currently used, it's global/unique per page but not report. Since the HTML doesn't reference anything across pages that uses IDs currently, there isn't a conflict.
- [x] <a href='#crh-comment-Pull 9dc3fce49f5d1e400d2740de7d9ed74641e0d3c1 src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/477#discussion_r69183359'>File: src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java:L64-79</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> if you validate isIntanceOf you probably don't have to use IsNotNull at the same time
also validate value, not only the type, if deterministic
- [x] <a href='#crh-comment-Pull 9dc3fce49f5d1e400d2740de7d9ed74641e0d3c1 src/test/java/net/masterthought/cucumber/util/CounterTest.java 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/477#discussion_r69183483'>File: src/test/java/net/masterthought/cucumber/util/CounterTest.java:L1-16</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> nextValue_ReturnsInitialValue
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Next returns the next value, not the current.
The initial value, 0, can only be seen if `intValue` is used.
In fact, to simplify, I'm tempted to make `Counter` contain `MutableInt`, not inherit from it, and only have one API: `next`.
- <a href='https://github.com/midopa'><img border=0 src='https://avatars.githubusercontent.com/u/1522141?v=3' height=16 width=16'></a> Update: To keep things moving, I decided to leave Counter as-is.
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> <metodName>[_On<Conditio|Case|>]_<ExpectedReturn>
- [x] <a href='#crh-comment-Pull 9dc3fce49f5d1e400d2740de7d9ed74641e0d3c1 src/test/java/net/masterthought/cucumber/util/CounterTest.java 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/damianszczepanik/cucumber-reporting/pull/477#discussion_r69183525'>File: src/test/java/net/masterthought/cucumber/util/CounterTest.java:L1-16</a></b>
- <a href='https://github.com/damianszczepanik'><img border=0 src='https://avatars.githubusercontent.com/u/9612911?v=3' height=16 width=16'></a> use given,when,then conception


<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/477?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/477?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/477'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>