### PR TITLE
Escaping error message

### DIFF
--- a/src/main/java/net/masterthought/cucumber/generators/ErrorPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/ErrorPage.java
@@ -2,6 +2,7 @@ package net.masterthought.cucumber.generators;
 
 import java.util.List;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import net.masterthought.cucumber.Configuration;
@@ -27,7 +28,11 @@ public class ErrorPage extends AbstractPage {
 
     @Override
     public void prepareReport() {
-        context.put("output_message", ExceptionUtils.getStackTrace(exception));
+        context.put("output_message", StringEscapeUtils.escapeHtml(outputStackTrace()));
         context.put("json_files", jsonFiles);
+    }
+
+    String outputStackTrace() {
+        return ExceptionUtils.getStackTrace(exception);
     }
 }


### PR DESCRIPTION
Hi,

I would like to have Error messages escaped so no matter what the message contains, it will always be visible.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/517?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/517'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>