### PR TITLE
Updated workaround for buffer overflow in Inet4AddressImpl::getLocalHostName

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,13 @@ env:
    # via the "travis encrypt" command using the project repo's public key
    - secure: "erPk0ACAA2A4i+ik4RKhLS6xAWRqC03KuaQ8dD91Oy8fsIRJdTu7w+woATRW2rESak6qHsp0aZvzEz9WaIrxFxpn/8DEPPgXQK/Hz3bm+zySTwELy0HCEO+ATEbdGMjpSoGlDRUS3eu0zBGOfZHI7Jp3LQYiycZO7PIzaxWo2UI="
 
-before_install:
-  # Workaround for issue http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7089443
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+
+# Workaround for issue http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7089443
+# See https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
+addons:
+  hosts:
+    - myshorthost
+  hostname: myshorthost
 
 matrix:
   include:


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/damianszczepanik/cucumber-reporting/pull/525?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/damianszczepanik/cucumber-reporting/pull/525'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>