### PR TITLE
Preserving whitespaces in HTML output

### DIFF
--- a/src/main/resources/css/cucumber.css
+++ b/src/main/resources/css/cucumber.css
@@ -53,6 +53,7 @@ a:hover {
 .description {
     font-style: italic;
     background-color: beige;
+    white-space: pre;
 }
 
 .message, .output, .embedding {


### PR DESCRIPTION
```
Feature: preserving whitespaces in HTML output
    As a user
    I would like to preserve white spaces in this text
    In order to have the output more similar to the .feature file

    Scenario: Running this feature (wow, meta)
      When I run this feature with HTML output
      Then the output should preserve the new lines in the description
```

[Graciously stolen from cucumber-html issue #29](https://github.com/cucumber/cucumber-html/issues/29)