### PR TITLE
Move scenario column to be in same order as trends

### DIFF
--- a/src/main/resources/templates/macros/report/reportHeader.vm
+++ b/src/main/resources/templates/macros/report/reportHeader.vm
@@ -6,8 +6,8 @@
       <th></th>
     #end
     <th></th>
-    <th colspan="6">Steps</th>
     <th colspan="3">Scenarios</th>
+    <th colspan="6">Steps</th>
     <th colspan="2">Features</th>
   </tr>
   <tr>
@@ -17,13 +17,13 @@
     #end
     <th class="passed">Passed</th>
     <th class="failed">Failed</th>
-    <th class="skipped">Skipped</th>
-    <th class="pending">Pending</th>
-    <th class="undefined">Undefined</th>
     <th class="total">Total</th>
 
     <th class="passed">Passed</th>
     <th class="failed">Failed</th>
+    <th class="skipped">Skipped</th>
+    <th class="pending">Pending</th>
+    <th class="undefined">Undefined</th>
     <th class="total">Total</th>
 
     <th>Duration</th>

--- a/src/main/resources/templates/macros/report/reportTable.vm
+++ b/src/main/resources/templates/macros/report/reportTable.vm
@@ -13,16 +13,16 @@
           #if ($parallel)
             <td>$reportable.getDeviceName()</td>
           #end
+          <td #if ($reportable.getPassedScenarios() != 0) class="passed"    #end>$reportable.getPassedScenarios()</td>
+          <td #if ($reportable.getFailedScenarios() != 0) class="failed"    #end>$reportable.getFailedScenarios()</td>
+          <td class="total">$reportable.getScenarios()</td>
+
           <td #if ($reportable.getPassedSteps() != 0)     class="passed"    #end>$reportable.getPassedSteps()</td>
           <td #if ($reportable.getFailedSteps() != 0)     class="failed"    #end>$reportable.getFailedSteps()</td>
           <td #if ($reportable.getSkippedSteps() != 0)    class="skipped"   #end>$reportable.getSkippedSteps()</td>
           <td #if ($reportable.getPendingSteps() != 0)    class="pending"   #end>$reportable.getPendingSteps()</td>
           <td #if ($reportable.getUndefinedSteps() != 0)  class="undefined" #end>$reportable.getUndefinedSteps()</td>
           <td class="total">$reportable.getSteps()</td>
-
-          <td #if ($reportable.getPassedScenarios() != 0) class="passed"    #end>$reportable.getPassedScenarios()</td>
-          <td #if ($reportable.getFailedScenarios() != 0) class="failed"    #end>$reportable.getFailedScenarios()</td>
-          <td class="total">$reportable.getScenarios()</td>
 
           <td class="duration" data-value="$reportable.getDurations()">$reportable.getFormattedDurations()</td>
           <td class="$reportable.getStatus().getRawName()">$reportable.getStatus().getLabel()</td>

--- a/src/main/resources/templates/macros/report/statsTable.vm
+++ b/src/main/resources/templates/macros/report/statsTable.vm
@@ -10,6 +10,9 @@
         #if ($parallel)
           <td>$item.getDeviceName()</td>
         #end
+        <td #if ($item.getPassedScenarios() > 0) class="passed"    #end>$item.getPassedScenarios()</td>
+        <td #if ($item.getFailedScenarios() > 0) class="failed"    #end>$item.getFailedScenarios()</td>
+        <td class="total">$item.getScenarios()</td>
 
         <td #if ($item.getPassedSteps() > 0)     class="passed"    #end>$item.getPassedSteps()</td>
         <td #if ($item.getFailedSteps() > 0)     class="failed"    #end>$item.getFailedSteps()</td>
@@ -17,10 +20,6 @@
         <td #if ($item.getPendingSteps() > 0)    class="pending"   #end>$item.getPendingSteps()</td>
         <td #if ($item.getUndefinedSteps() > 0)  class="undefined" #end>$item.getUndefinedSteps()</td>
         <td class="total">$item.getSteps()</td>
-
-        <td #if ($item.getPassedScenarios() > 0) class="passed"    #end>$item.getPassedScenarios()</td>
-        <td #if ($item.getFailedScenarios() > 0) class="failed"    #end>$item.getFailedScenarios()</td>
-        <td class="total">$item.getScenarios()</td>
 
         <td class="duration" data-value="$item.getDurations()">$item.getFormattedDurations()</td>
         <td class="$item.getStatus().getRawName()">$item.getStatus().getLabel()</td>
@@ -34,6 +33,10 @@
       #if ($parallel)
         <td>-</td>
       #end
+      <td>$report_summary.getPassedScenarios()</td>
+      <td>$report_summary.getFailedScenarios()</td>
+      <td>$report_summary.getScenarios()</td>
+
       <td>$report_summary.getPassedSteps()</td>
       <td>$report_summary.getFailedSteps()</td>
       <td>$report_summary.getSkippedSteps()</td>
@@ -41,9 +44,7 @@
       <td>$report_summary.getUndefinedSteps()</td>
       <td>$report_summary.getSteps()</td>
 
-      <td>$report_summary.getPassedScenarios()</td>
-      <td>$report_summary.getFailedScenarios()</td>
-      <td>$report_summary.getScenarios()</td>
+
 
       <td class="duration">$report_summary.getFormattedDurations()</td>
       <td></td>
@@ -53,14 +54,14 @@
       #if ($parallel)
         <td>-</td>
       #end
+      <td>$util.formatAsPercentage($report_summary.getPassedScenarios(), $report_summary.getScenarios())</td>
+      <td>$util.formatAsPercentage($report_summary.getFailedScenarios(), $report_summary.getScenarios())</td>
+      <td></td>
       <td>$util.formatAsPercentage($report_summary.getPassedSteps(), $report_summary.getSteps())</td>
       <td>$util.formatAsPercentage($report_summary.getFailedSteps(), $report_summary.getSteps())</td>
       <td>$util.formatAsPercentage($report_summary.getSkippedSteps(), $report_summary.getSteps())</td>
       <td>$util.formatAsPercentage($report_summary.getPendingSteps(), $report_summary.getSteps())</td>
       <td>$util.formatAsPercentage($report_summary.getUndefinedSteps(), $report_summary.getSteps())</td>
-      <td></td>
-      <td>$util.formatAsPercentage($report_summary.getPassedScenarios(), $report_summary.getScenarios())</td>
-      <td>$util.formatAsPercentage($report_summary.getFailedScenarios(), $report_summary.getScenarios())</td>
       <td></td>
       <td></td>
       <td>$util.formatAsPercentage($report_summary.getPassedFeatures(), $report_summary.getFeatures())</td>


### PR DESCRIPTION
In my experience, stakeholders are confused by the Steps section, and really only care about Scenarios. This pull request proposes to swap the postion of the Steps and Scenarios sections to alleviate this confusion. It also puts the organization in congruence with the Trends pages.

<img width="1916" alt="screen shot 2016-11-15 at 10 32 08 pm" src="https://cloud.githubusercontent.com/assets/10365264/20335884/66913228-ab83-11e6-8236-8dd75a9d19a4.png">

<img width="1918" alt="screen shot 2016-11-15 at 10 30 35 pm" src="https://cloud.githubusercontent.com/assets/10365264/20335844/321dcc04-ab83-11e6-8c95-8a8e7ae85493.png">




