### PR TITLE
 Escape HTML using the velocity engine

### DIFF
--- a/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.app.event.EventCartridge;
 import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 
 import net.masterthought.cucumber.Configuration;
@@ -84,6 +85,11 @@ public abstract class AbstractPage {
     }
 
     private void buildGeneralParameters() {
+        // to escape html and xml
+        EventCartridge ec = new EventCartridge();
+        ec.addEventHandler(new EscapeHtmlReference());
+        context.attachEventCartridge(ec);
+
         // to provide unique ids for elements on each page
         context.put("counter", new Counter());
         context.put("util", Util.INSTANCE);

--- a/src/main/java/net/masterthought/cucumber/generators/EscapeHtmlReference.java
+++ b/src/main/java/net/masterthought/cucumber/generators/EscapeHtmlReference.java
@@ -1,0 +1,20 @@
+package net.masterthought.cucumber.generators;
+
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.velocity.app.event.ReferenceInsertionEventHandler;
+
+/**
+ * Escapes all html and xml that was provided in a reference before inserting it into a template.
+ */
+final class EscapeHtmlReference implements ReferenceInsertionEventHandler {
+
+    @Override
+    public Object referenceInsert(String reference, Object value) {
+        if (value == null) {
+            return null;
+        } else {
+            return StringEscapeUtils.escapeHtml(value.toString());
+        }
+    }
+
+}

--- a/src/main/java/net/masterthought/cucumber/json/Element.java
+++ b/src/main/java/net/masterthought/cucumber/json/Element.java
@@ -1,6 +1,5 @@
 package net.masterthought.cucumber.json;
 
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 
 import net.masterthought.cucumber.json.support.Status;
@@ -62,10 +61,6 @@ public class Element {
 
     public String getName() {
         return name;
-    }
-
-    public String getEscapedName() {
-        return StringUtils.defaultString(StringEscapeUtils.escapeHtml(name));
     }
 
     public String getKeyword() {

--- a/src/main/java/net/masterthought/cucumber/json/Embedding.java
+++ b/src/main/java/net/masterthought/cucumber/json/Embedding.java
@@ -3,7 +3,6 @@ package net.masterthought.cucumber.json;
 import java.nio.charset.StandardCharsets;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.codehaus.plexus.util.Base64;
 
 import net.masterthought.cucumber.json.deserializers.EmbeddingDeserializer;
@@ -38,11 +37,6 @@ public class Embedding {
 
     public String getDecodedData() {
         return new String(Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
-    }
-
-    /** Returns encoded and escaped data so it is ready to display in HTML page. */
-    public String getEscapedDecodedData() {
-        return StringEscapeUtils.escapeHtml(getDecodedData());
     }
 
     public String getFileName() {

--- a/src/main/java/net/masterthought/cucumber/json/Result.java
+++ b/src/main/java/net/masterthought/cucumber/json/Result.java
@@ -1,8 +1,6 @@
 package net.masterthought.cucumber.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang.StringEscapeUtils;
-
 import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.util.Util;
 
@@ -27,8 +25,7 @@ public class Result {
         return Util.formatDuration(duration);
     }
 
-    /** Returns error message escaped so it is properly displayed as HTML. */
     public String getErrorMessage() {
-        return StringEscapeUtils.escapeHtml(errorMessage);
+        return errorMessage;
     }
 }

--- a/src/main/resources/templates/generators/errorpage.vm
+++ b/src/main/resources/templates/generators/errorpage.vm
@@ -17,7 +17,7 @@
 
 #includeNavigation()
 
-#includeLead("Error", "Something went wrong with project <i>$build_project_name</i>, build $build_number")
+#includeLead("Error", "Something went wrong with project $build_project_name, build $build_number")
 
 <div class="container-fluid" id="report">
   <div class="row">

--- a/src/main/resources/templates/macros/json/element.vm
+++ b/src/main/resources/templates/macros/json/element.vm
@@ -12,7 +12,7 @@
 
   #set($elementId = $counter.next())
   <span data-toggle="collapse" class="#if ($element.getStatus().isPassed()) collapsed #end collapsable-control" data-target="#element-$elementId">
-    #includeBrief($element.getKeyword(), $element.getStatus(), $element.getEscapedName(), true)
+    #includeBrief($element.getKeyword(), $element.getStatus(), $element.getName(), true)
   </span>
   <div class="description indention">$element.getDescription()</div>
 

--- a/src/main/resources/templates/macros/json/embeddings.vm
+++ b/src/main/resources/templates/macros/json/embeddings.vm
@@ -1,8 +1,8 @@
 #macro(includeEmbeddings, $embeddings)
 
-#if (!$embeddings.isEmpty())
+  #if (!$embeddings.isEmpty())
   <div class="embeddings inner-level">
-  #foreach($embedding in $embeddings)
+    #foreach($embedding in $embeddings)
     #if ($embedding.getMimeType() == "image/png")
       #includeImageEmbedding($embedding, "png", $foreach.index)
     #elseif ($embedding.getMimeType() == "image/bmp")
@@ -10,7 +10,7 @@
     #elseif ($embedding.getMimeType() == "image/jpeg")
       #includeImageEmbedding($embedding, "jpeg", $foreach.index)
     #elseif ($embedding.getMimeType() == "text/xml")
-      #includeEscapedTextEmbedding($embedding, "XML text", $foreach.index)
+      #includeTextEmbedding($embedding, "XML text", $foreach.index)
     #elseif ($embedding.getMimeType() == "text/plain")
       #includeTextEmbedding($embedding, "Plain text", $foreach.index)
     #elseif ($embedding.getMimeType() == "text/html")
@@ -24,46 +24,78 @@
     #end
   #end
   </div>
-#end
+  #end
 
 #end
 
 
 
 #macro(includeImageEmbedding, $embedding, $image_type, $index)
-  #set($Quote = '"')
-  #includeExpandableEmbedding($embedding, $image_type, "<img src=${Quote}embeddings/$embedding.getFileName()${Quote}>", $index)
-#end
-
-#macro(includeImageReferenceEmbedding, $embedding, $index)
-  #set($Quote = '"')
-  #includeExpandableEmbedding($embedding, "Image", "<img src=${Quote}$embedding.getDecodedData()${Quote}>", $index)
-#end
-
-#macro(includeTextEmbedding, $embedding, $format, $index)
-  #includeExpandableEmbedding($embedding, $format, "<pre>$embedding.getDecodedData()</pre>", $index)
-#end
-
-#macro(includeEscapedTextEmbedding, $embedding, $format, $index)
-  #includeExpandableEmbedding($embedding, $format, "<pre>$embedding.getEscapedDecodedData()</pre>", $index)
-#end
-
-#macro(includeUnknownEmbedding, $embedding, $index)
-  #set($Quote = '"')
-  #includeExpandableEmbedding($embedding, $embedding.getMimeType(), "This file cannot be displayed. Use download button to get the content as file.", $index)
-#end
-
-
-#macro(includeExpandableEmbedding, $embedding, $type, $content, $index)
   #set($index = $index + 1)
   <div class="embedding indention">
     #set($embeddingId = $counter.next())
     <div data-toggle="collapse" data-target="#embedding-$embeddingId" class="collapsable-control">
-      <a>Attachment $index ($type)</a>
-      <a href="embeddings/$embedding.getFileName()" target="_blank"><span class="download-button glyphicon glyphicon-download-alt"></span></a>
+      <a>Attachment $index ($image_type)</a>
+      <a href="embeddings/$embedding.getFileName()" target="_blank">
+        <span class="download-button glyphicon glyphicon-download-alt"></span>
+      </a>
     </div>
     <div id="embedding-$embeddingId" class="collapse collapsable-details">
-      <span class="embedding-content">$content</span>
+      <span class="embedding-content">
+        <img src="embeddings/$embedding.getFileName()">
+      </span>
+    </div>
+  </div>
+#end
+
+#macro(includeImageReferenceEmbedding, $embedding, $index)
+  #set($index = $index + 1)
+  <div class="embedding indention">
+    #set($embeddingId = $counter.next())
+    <div data-toggle="collapse" data-target="#embedding-$embeddingId" class="collapsable-control">
+      <a>Attachment $index (Image)</a>
+      <a href="embeddings/$embedding.getFileName()" target="_blank">
+        <span class="download-button glyphicon glyphicon-download-alt"></span>
+      </a>
+    </div>
+    <div id="embedding-$embeddingId" class="collapse collapsable-details">
+      1<span class="embedding-content">
+        <img src="$embedding.getDecodedData()">
+      </span>
+    </div>
+  </div>
+#end
+
+#macro(includeTextEmbedding, $embedding, $format, $index)
+  #set($index = $index + 1)
+  <div class="embedding indention">
+    #set($embeddingId = $counter.next())
+    <div data-toggle="collapse" data-target="#embedding-$embeddingId" class="collapsable-control">
+      <a>Attachment $index ($format)</a>
+      <a href="embeddings/$embedding.getFileName()" target="_blank">
+        <span class="download-button glyphicon glyphicon-download-alt"></span>
+      </a>
+    </div>
+    <div id="embedding-$embeddingId" class="collapse collapsable-details">
+      <span class="embedding-content">
+        <pre>$embedding.getDecodedData()</pre>
+      </span>
+    </div>
+  </div>
+#end
+
+#macro(includeUnknownEmbedding, $embedding, $index)
+  #set($index = $index + 1)
+  <div class="embedding indention">
+    #set($embeddingId = $counter.next())
+    <div data-toggle="collapse" data-target="#embedding-$embeddingId" class="collapsable-control">
+      <a>Attachment $index ($embedding.getMimeType())</a>
+      <a href="embeddings/$embedding.getFileName()" target="_blank">
+        <span class="download-button glyphicon glyphicon-download-alt"></span>
+      </a>
+    </div>
+    <div id="embedding-$embeddingId" class="collapse collapsable-details">
+        <span class="embedding-content">This file cannot be displayed. Use download button to get the content as file.</span>
     </div>
   </div>
 #end

--- a/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
@@ -17,6 +17,7 @@ import net.masterthought.cucumber.ReportBuilder;
 import net.masterthought.cucumber.Trends;
 import net.masterthought.cucumber.ValidationException;
 import net.masterthought.cucumber.generators.integrations.PageTest;
+import net.masterthought.cucumber.generators.integrations.helpers.DocumentAssertion;
 import net.masterthought.cucumber.util.Counter;
 import net.masterthought.cucumber.util.Util;
 
@@ -46,6 +47,33 @@ public class AbstractPageTest extends PageTest {
         File reportFile = new File(configuration.getReportDirectory(),
                 ReportBuilder.BASE_DIRECTORY + File.separatorChar + page.getWebPage());
         assertThat(reportFile).exists();
+    }
+
+
+    @Test
+    public void generateReport_DisplaysContentAsEscapedText() {
+
+        // given
+        page = new FeatureReportPage(reportResult, configuration, features.get(1));
+
+        // when
+        page.generatePage();
+
+        // then
+        DocumentAssertion document = documentFrom(page.getWebPage());
+        assertThat(document.getFeature().getDescription())
+                .isEqualTo("As an Account Holder I want to withdraw cash from an ATM,<br>so that I can get money when the bank is closed");
+        assertThat(document.getFeature().getElements()[0].getStepsSection().getSteps()[5].getEmbedding()[3].text())
+                .isEqualTo("Attachment 4 (HTML) <i>Hello</i> <b>World!</b>");
+        assertThat(document.getFeature().getElements()[0].getStepsSection().getSteps()[5].getMessage().text())
+                .isEqualTo("Error message java.lang.AssertionError: \n" +
+                        "Expected: is <80>\n" +
+                        "     got: <90>\n" +
+                        "\n" +
+                        "\tat org.junit.Assert.assertThat(Assert.java:780)\n" +
+                        "\tat org.junit.Assert.assertThat(Assert.java:738)\n" +
+                        "\tat net.masterthought.example.ATMScenario.checkBalance(ATMScenario.java:69)\n" +
+                        "\tat ✽.And the account balance should be 90(net/masterthought/example/ATMK.feature:12)");
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/EscapeHtmlReferenceTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/EscapeHtmlReferenceTest.java
@@ -1,0 +1,34 @@
+package net.masterthought.cucumber.generators;
+
+import org.apache.velocity.app.event.ReferenceInsertionEventHandler;
+import org.junit.Test;
+
+import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author M.P. Korstanje (mpkorstanje@github)
+ */
+public class EscapeHtmlReferenceTest {
+
+    private static final String SOME_REFERENCE = "someReference";
+    private final ReferenceInsertionEventHandler insertionEventHandler = new EscapeHtmlReference();
+
+    @Test
+    public void referenceInsert_returnNormalText(){
+        String normalText = "a plain statement";
+        assertThat(insertionEventHandler.referenceInsert(SOME_REFERENCE, normalText)).isEqualTo(normalText);
+    }
+
+    @Test
+    public void referenceInsert_shouldEscapeHtmlForAnyLabel(){
+        String html = "<b>a bold statement</b>";
+        assertThat(insertionEventHandler.referenceInsert(SOME_REFERENCE, html)).isEqualTo(escapeHtml(html));
+    }
+
+    @Test
+    public void referenceInsert_shouldReturnNullForNull(){
+        assertThat(insertionEventHandler.referenceInsert(SOME_REFERENCE, null)).isNull();
+    }
+
+}

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FailuresOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FailuresOverviewPageIntegrationTest.java
@@ -84,6 +84,6 @@ public class FailuresOverviewPageIntegrationTest extends PageTest {
         DocumentAssertion document = documentFrom(page.getWebPage());
         ElementAssertion[] elements = document.getElements();
         assertThat(elements).hasSize(1);
-        assertThat(elements[0].getBrief().getName()).isEqualTo(features.get(1).getElements()[0].getEscapedName());
+        assertThat(elements[0].getBrief().getName()).isEqualTo(features.get(1).getElements()[0].getName());
     }
 }

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/EmbeddingAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/EmbeddingAssertion.java
@@ -19,7 +19,8 @@ public class EmbeddingAssertion extends ReportAssertion {
     }
 
     public void hasTextContent(String content) {
-        assertThat(getBox().oneBySelector("pre", WebAssertion.class).html()).isEqualTo(getDecodedData(content));
+        assertThat(getBox().oneBySelector("pre", WebAssertion.class).text())
+                .isEqualTo(getDecodedData(content));
     }
 
     private WebAssertion getBox() {

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/StepAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/StepAssertion.java
@@ -24,4 +24,8 @@ public class StepAssertion extends ReportAssertion {
     public DocStringAssertion getDocString() {
         return oneByClass("docstring", DocStringAssertion.class);
     }
+
+    public WebAssertion getMessage() {
+        return oneByClass("message", WebAssertion.class);
+    }
 }

--- a/src/test/java/net/masterthought/cucumber/json/ElementTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/ElementTest.java
@@ -169,21 +169,6 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getEscapedName_ReturnsNameAsPlainText() {
-
-        // given
-        Element element = features.get(0).getElements()[1];
-
-        // when
-        String name = element.getEscapedName();
-
-        // then
-        // test only this name which has escaped characters
-        assertThat(name).isNotEqualTo(element.getName());
-        assertThat(name).isEqualTo("Account has &lt;sufficient funds&gt;");
-    }
-
-    @Test
     public void getKeyword_ReturnsName() {
 
         // given

--- a/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
@@ -50,31 +50,6 @@ public class EmbeddingTest {
         assertThat(content).isEqualTo("function logger(message) {  }");
     }
 
-    @Test
-    public void getEscapedDecodedData_OnXMLText_ReturnsEspacedData() {
-
-        // given
-        Embedding embedding = new Embedding("mimeType", "PHhtbD48c29tZU5vZGUgYXR0cj0idmFsdWUiIC8+PC94bWw+");
-
-        // when
-        String data = embedding.getEscapedDecodedData();
-
-        // then
-        assertThat(data).isEqualTo("&lt;xml&gt;&lt;someNode attr=&quot;value&quot; /&gt;&lt;/xml&gt;");
-    }
-
-    @Test
-    public void getEscapedDecodedData_OnPlainText_ReturnsData() {
-
-        // given
-        Embedding embedding = new Embedding("mimeType", "b25lLCB0d28sIHRocmVlIQ==");
-
-        // when
-        String data = embedding.getEscapedDecodedData();
-
-        // then
-        assertThat(data).isEqualTo("one, two, three!");
-    }
 
     @Test
     public void getFileName_ReturnsFileName() {

--- a/src/test/java/net/masterthought/cucumber/json/FeatureTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/FeatureTest.java
@@ -56,7 +56,7 @@ public class FeatureTest extends PageTest {
 
         // then
         assertThat(elements).hasSize(2);
-        assertThat(elements[0].getEscapedName()).isEqualTo("Activate Credit Card");
+        assertThat(elements[0].getName()).isEqualTo("Activate Credit Card");
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/json/ResultTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/ResultTest.java
@@ -58,7 +58,7 @@ public class ResultTest extends PageTest {
     }
 
     @Test
-    public void getErrorMessage_ReturnEscapedErrorMessage() {
+    public void getErrorMessage_ReturnsErrorMessage() {
 
         // given
         Result result = features.get(1).getElements()[0].getSteps()[5].getResult();
@@ -68,13 +68,13 @@ public class ResultTest extends PageTest {
 
         // then
         assertThat(errorMessage).isEqualTo("java.lang.AssertionError: \n" +
-                "Expected: is &lt;80&gt;\n" +
-                "     got: &lt;90&gt;\n" +
+                "Expected: is <80>\n" +
+                "     got: <90>\n" +
                 "\n" +
                 "\tat org.junit.Assert.assertThat(Assert.java:780)\n" +
                 "\tat org.junit.Assert.assertThat(Assert.java:738)\n" +
                 "\tat net.masterthought.example.ATMScenario.checkBalance(ATMScenario.java:69)\n" +
-                "\tat &#10045;.And the account balance should be 90(net/masterthought/example/ATMK.feature:12)\n");
+                "\tat ✽.And the account balance should be 90(net/masterthought/example/ATMK.feature:12)\n");
     }
 
 }


### PR DESCRIPTION
It is preferable to escape HTML through the template engine over escaping it at in
the template. This ensures none can be forgotten on accident. The unfortunate side
effect of this is that it no longer possible to  provide html as an argument in a
macro. This leads to some duplication in embeddings.vm

 Existing methods to escape html have been removed.