### PR TITLE
Embed html in a sandboxed iframe

### DIFF
--- a/src/main/resources/css/cucumber.css
+++ b/src/main/resources/css/cucumber.css
@@ -64,7 +64,7 @@ a:hover {
 /* same as <pre> from bootstrap library */
 .embedding-content {
     display: block;
-    padding: 9.5px;
+    padding: 10px;
     margin-left: 10px;
     margin-right: 10px;
     margin-bottom: 10px;
@@ -75,6 +75,23 @@ a:hover {
     border: 1px solid #ccc;
     border-radius: 4px;
     white-space: nowrap;
+}
+
+.html-content {
+    position: relative;
+    /* proportion value to aspect ratio 16:9 (9 / 16 = 0.5625 or 56.25%) */
+    padding: 0 0 56.25%;
+    height: 0;
+    overflow: hidden;
+}
+
+.html-content iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border:none;
 }
 
 .download-button {

--- a/src/main/resources/templates/macros/json/embeddings.vm
+++ b/src/main/resources/templates/macros/json/embeddings.vm
@@ -1,4 +1,4 @@
-#macro(includeEmbeddings, $embeddings)
+#macro(includeEmbeddings $embeddings)
 
   #if (!$embeddings.isEmpty())
   <div class="embeddings inner-level">
@@ -16,7 +16,7 @@
     #elseif ($embedding.getMimeType() == "text/plain")
       #includeTextEmbedding($embedding, "Plain text", $foreach.index)
     #elseif ($embedding.getMimeType() == "text/html")
-      #includeTextEmbedding($embedding, "HTML", $foreach.index)
+      #includeHtmlEmbedding($embedding, "HTML", $foreach.index)
     #elseif ($embedding.getMimeType() == "application/json")
       #includeTextEmbedding($embedding, "JSON", $foreach.index)
     #elseif ($embedding.getMimeType() == "image/url")
@@ -30,15 +30,35 @@
 
 #end
 
+#macro(includeHtmlEmbedding $embedding, $format, $index)
+  #set($index = $index + 1)
+<div class="embedding indention">
+  #set($embeddingId = $counter.next())
+  <div data-toggle="collapse" data-target="#embedding-$embeddingId" class="collapsable-control">
+    <a>Attachment $index ($format)</a>
+    <a href="embeddings/$embedding.getFileName()" download target="_blank">
+      <span class="download-button glyphicon glyphicon-download-alt"></span>
+    </a>
+  </div>
+  <div id="embedding-$embeddingId" class="collapse collapsable-details">
+    <div class="embedding-content">
+      <div class="html-content">
+        <iframe seamless="true" sandbox="allow-scripts" src="embeddings/$embedding.getFileName()" srcdoc="$embedding.getDecodedData()"></iframe>
+      </div>
+    </div>
+  </div>
+</div>
+#end
 
 
-#macro(includeImageEmbedding, $embedding, $image_type, $index)
+
+#macro(includeImageEmbedding $embedding, $image_type, $index)
   #set($index = $index + 1)
   <div class="embedding indention">
     #set($embeddingId = $counter.next())
     <div data-toggle="collapse" data-target="#embedding-$embeddingId" class="collapsable-control">
       <a>Attachment $index ($image_type)</a>
-      <a href="embeddings/$embedding.getFileName()" target="_blank">
+      <a href="embeddings/$embedding.getFileName()" download target="_blank">
         <span class="download-button glyphicon glyphicon-download-alt"></span>
       </a>
     </div>
@@ -50,13 +70,13 @@
   </div>
 #end
 
-#macro(includeImageReferenceEmbedding, $embedding, $index)
+#macro(includeImageReferenceEmbedding $embedding, $index)
   #set($index = $index + 1)
   <div class="embedding indention">
     #set($embeddingId = $counter.next())
     <div data-toggle="collapse" data-target="#embedding-$embeddingId" class="collapsable-control">
       <a>Attachment $index (Image)</a>
-      <a href="embeddings/$embedding.getFileName()" target="_blank">
+      <a href="embeddings/$embedding.getFileName()" download target="_blank">
         <span class="download-button glyphicon glyphicon-download-alt"></span>
       </a>
     </div>
@@ -68,13 +88,13 @@
   </div>
 #end
 
-#macro(includeTextEmbedding, $embedding, $format, $index)
+#macro(includeTextEmbedding $embedding, $format, $index)
   #set($index = $index + 1)
   <div class="embedding indention">
     #set($embeddingId = $counter.next())
     <div data-toggle="collapse" data-target="#embedding-$embeddingId" class="collapsable-control">
       <a>Attachment $index ($format)</a>
-      <a href="embeddings/$embedding.getFileName()" target="_blank">
+      <a href="embeddings/$embedding.getFileName()" download target="_blank">
         <span class="download-button glyphicon glyphicon-download-alt"></span>
       </a>
     </div>
@@ -86,13 +106,13 @@
   </div>
 #end
 
-#macro(includeUnknownEmbedding, $embedding, $index)
+#macro(includeUnknownEmbedding $embedding, $index)
   #set($index = $index + 1)
   <div class="embedding indention">
     #set($embeddingId = $counter.next())
     <div data-toggle="collapse" data-target="#embedding-$embeddingId" class="collapsable-control">
       <a>Attachment $index ($embedding.getMimeType())</a>
-      <a href="embeddings/$embedding.getFileName()" target="_blank">
+      <a href="embeddings/$embedding.getFileName()" download target="_blank">
         <span class="download-button glyphicon glyphicon-download-alt"></span>
       </a>
     </div>

--- a/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
@@ -64,7 +64,7 @@ public class AbstractPageTest extends PageTest {
         assertThat(document.getFeature().getDescription())
                 .isEqualTo("As an Account Holder I want to withdraw cash from an ATM,<br>so that I can get money when the bank is closed");
         assertThat(document.getFeature().getElements()[0].getStepsSection().getSteps()[5].getEmbedding()[3].text())
-                .isEqualTo("Attachment 4 (HTML) <i>Hello</i> <b>World!</b>");
+                .isEqualTo("Attachment 4 (HTML)");
         assertThat(document.getFeature().getElements()[0].getStepsSection().getSteps()[5].getMessage().text())
                 .isEqualTo("java.lang.AssertionError: java.lang.AssertionError: \n" +
                         "Expected: is <80>\n" +

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java
@@ -306,7 +306,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
         asserEmbeddingFileExist(embeddings[0]);
         embeddingsElement[2].hasTextContent(embeddings[2].getData());
         asserEmbeddingFileExist(embeddings[2]);
-        embeddingsElement[3].hasTextContent(embeddings[3].getData());
+        embeddingsElement[3].hasSrcDocContent(embeddings[3].getData());
         asserEmbeddingFileExist(embeddings[3]);
     }
 

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/EmbeddingAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/EmbeddingAssertion.java
@@ -18,6 +18,11 @@ public class EmbeddingAssertion extends ReportAssertion {
         assertThat(src).endsWith(embedding.getFileName());
     }
 
+    public void hasSrcDocContent(String content) {
+        assertThat(getBox().oneBySelector("iframe", WebAssertion.class).attr("srcDoc"))
+                .isEqualTo(getDecodedData(content));
+    }
+
     public void hasTextContent(String content) {
         assertThat(getBox().oneBySelector("pre", WebAssertion.class).text())
                 .isEqualTo(getDecodedData(content));

--- a/src/test/resources/json/sample.json
+++ b/src/test/resources/json/sample.json
@@ -440,7 +440,7 @@
                             },
                             {
                                 "mime_type": "text/html",
-                                "data": "PGk+SGVsbG88L2k+IDxiPldvcmxkITwvYj4="
+                                "data": "PGh0bWw+PGhlYWQ+PC9oZWFkPjxib2R5PjxwPjxpPkhlbGxvPC9pPiA8Yj5Xb3JsZCE8L2I+PC9wPjxwPlRoZSB3aWtpcGVkaWEgbG9nbyBzaG91bGQgYXBwZWFyIGJlbG93PC9wPjxpbWcgc3JjPSJodHRwczovL2VuLndpa2lwZWRpYS5vcmcvc3RhdGljL2ltYWdlcy9wcm9qZWN0LWxvZ29zL2Vud2lraS5wbmciPjwvYm9keT48L2h0bWw+"
                             },
                             {
                                 "mime_type": "text/xml",


### PR DESCRIPTION
It preferable to allow the browser to render embedded  html documents. To ensure this is done safely the html is placed in a sandboxed iframe. The html is embeded in the srcdoc as recommend by  the w3c[1]. The src attribute is provided as a backup for legacy browsers.

  Additionally because the cucumber-reporting-plugin must necessarily serve embedded html documents from the same domain as the report  the download link will now force a popup to open. While this can not prevent the embedded content from tricking the user into opening it directly, it at least mitigates some of the issues mentioned by the w3c[1].

   1. https://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element