### PR TITLE
Santize trusted content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,16 @@
             <artifactId>jsoup</artifactId>
             <version>1.10.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+            <artifactId>owasp-java-html-sanitizer</artifactId>
+            <version>20160924.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>21.0</version>
+        </dependency>
         <!-- for testing -->
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/net/masterthought/cucumber/generators/EscapeHtmlReference.java
+++ b/src/main/java/net/masterthought/cucumber/generators/EscapeHtmlReference.java
@@ -2,16 +2,27 @@ package net.masterthought.cucumber.generators;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.velocity.app.event.ReferenceInsertionEventHandler;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 
 /**
  * Escapes all html and xml that was provided in a reference before inserting it into a template.
+ *
+ * References that start with $_sanitize_ will be sanitized to allow urls.
  */
 final class EscapeHtmlReference implements ReferenceInsertionEventHandler {
+
+    private static final PolicyFactory LINKS = new HtmlPolicyBuilder()
+            .allowStandardUrlProtocols().allowElements("a").allowAttributes("href")
+            .onElements("a").requireRelNofollowOnLinks().requireRelsOnLinks("noopener", "noreferrer")
+            .toFactory();
 
     @Override
     public Object referenceInsert(String reference, Object value) {
         if (value == null) {
             return null;
+        } else if(reference.startsWith("$_sanitize_")) {
+            return LINKS.sanitize(value.toString());
         } else {
             return StringEscapeUtils.escapeHtml(value.toString());
         }

--- a/src/main/resources/templates/macros/page/classifications.vm
+++ b/src/main/resources/templates/macros/page/classifications.vm
@@ -2,12 +2,14 @@
 
 <table class="table table-bordered" id="classifications">
   <tbody>
-  #foreach($c in $classifications)
-    <tr class="info">
-      <th>$c.getKey()</th>
-      <td>$c.getValue()</td>
-    </tr>
-  #end
+    #foreach($classification in $classifications)
+      #set($key = $classification.getKey())
+      #set($_sanitize_value = $classification.getValue())
+      <tr class="info">
+        <th>$key</th>
+        <td>$_sanitize_value</td>
+      </tr>
+    #end
   </tbody>
 </table>
 

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FeaturesOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FeaturesOverviewPageIntegrationTest.java
@@ -58,8 +58,8 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     public void generatePage_generatesClassifications() {
 
         // given
-        final String[] names = {"Platform", "Browser", "Branch"};
-        final String[] values = {"Win", "Opera", "master"};
+        final String[] names = {"Platform", "Browser", "Branch", "Repository"};
+        final String[] values = {"Win", "Opera", "master", "<a href=\"example.com\" rel=\"nofollow noopener noreferrer\">Example Repository</a>"};
         setUpWithJson(SAMPLE_JSON);
         for (int i = 0; i < names.length; i++) {
             configuration.addClassifications(names[i], values[i]);
@@ -75,7 +75,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
 
         assertThat(classifications).hasSize(names.length);
         for (int i = 0; i < names.length; i++) {
-            String[] cells = classifications[i].getCellsValues();
+            String[] cells = classifications[i].getCellsHtml();
             assertThat(cells).containsExactly(names[i], values[i]);
         }
     }

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/TableRowAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/TableRowAssertion.java
@@ -26,6 +26,16 @@ public class TableRowAssertion extends ReportAssertion {
         return values;
     }
 
+    public String[] getCellsHtml() {
+        WebAssertion[] cells = getCells();
+        String[] values = new String[cells.length];
+        for (int i = 0; i < cells.length; i++) {
+            values[i] = cells[i].html();
+        }
+        return values;
+    }
+
+
     /**
      * Validates the row cells' text match the given passed values.
      * 


### PR DESCRIPTION
Trusted content such as classifications may contain urls that should not be escaped.

Any reference prefixed with $\_sanitize_ will not be escaped but sanitized instead.