### PR TITLE
Restore whitespace significant formatting for message

### DIFF
--- a/src/main/resources/css/cucumber.css
+++ b/src/main/resources/css/cucumber.css
@@ -232,14 +232,6 @@ tr:hover {
     color: #eee;
 }
 
-.white-space-normal {
-    white-space: normal;
-}
-
-.white-space-pre-wrap {
-    white-space: pre-wrap;
-}
-
 pre {
     margin: 10px;
 }

--- a/src/main/resources/templates/macros/json/hooks.vm
+++ b/src/main/resources/templates/macros/json/hooks.vm
@@ -1,6 +1,6 @@
-#macro(includeHooks, $keyword, $hooks, $status)
+#macro(includeHooks $keyword, $hooks, $status)
 
-#if($hooks.size() > 0)
+#if(!$hooks.isEmpty())
   <div class="inner-level hooks-$keyword.toLowerCase()">
     #set($hookId = $counter.next())
     <div data-toggle="collapse" class="#if($status.isPassed()) collapsed #end collapsable-control" data-target="#$keyword.toLowerCase()-$hookId">

--- a/src/main/resources/templates/macros/json/output.vm
+++ b/src/main/resources/templates/macros/json/output.vm
@@ -1,6 +1,6 @@
-#macro(includeOutput, $outputs, $isPassed)
+#macro(includeOutput $outputs, $isPassed)
 
-#if($outputs)
+#if(!$outputs.isEmpty())
   <div class="outputs inner-level">
     #foreach($output in $outputs)
       #set($outputId = $counter.next())
@@ -11,11 +11,10 @@
           <i class="chevron fa fa-fw"></i>
         </div>
         <div id="output-$outputId" class="collapse collapsable-details #if (!$isPassed) in #end" #if (!$isPassed) aria-expanded="true" #end>
-          <pre class="white-space-normal">
-            #foreach($message in $output.getMessages())
-              <span>$message</span><br>
-            #end
-          </pre>
+          #**
+           * DO NOT format the line below. Whitespace nodes are significant in a pre-block.
+           *#
+          <pre>#foreach($message in $output.getMessages())<p>$message</p>#end</pre>
         </div>
       </div>
     #end

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/OutputAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/OutputAssertion.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class OutputAssertion extends ReportAssertion {
 
     public void hasMessages(String[] messages) {
-        WebAssertion[] outputMessages = allBySelector("span", WebAssertion.class);
+        WebAssertion[] outputMessages = allBySelector("p", WebAssertion.class);
         assertThat(outputMessages).hasSameSizeAs(messages);
         for (int i = 0; i < messages.length; i++) {
             assertThat(outputMessages[i].text()).isEqualTo(messages[i]);


### PR DESCRIPTION
As reported in https://github.com/jenkinsci/cucumber-reports-plugin/issues/145 pull request #594
 broke formatting of output messages by adding white-space-normal to the pre
 block. Presumably to solve the formatting issues caused by adding new lines
 around the span.

  This has been resolved removing the  white-space-normal class and using a single
  line in the template. The span has been replaced with a p to ensure there is a
  significant distance between different output messages.