### PR TITLE
Show text embedding without superfluous borders

### DIFF
--- a/src/main/resources/css/cucumber.css
+++ b/src/main/resources/css/cucumber.css
@@ -61,9 +61,11 @@ a:hover {
     overflow: auto;
 }
 
-/* same as <pre> from bootstrap library */
+/*
+   same as <pre> from bootstrap library.
+   padding and overflow-x added.
+*/
 .embedding-content {
-    display: block;
     padding: 10px;
     margin-left: 10px;
     margin-right: 10px;
@@ -71,10 +73,12 @@ a:hover {
     font-size: 13px;
     overflow-x: auto;
     line-height: 1.42857143;
+    color: #333;
+    word-break: break-all;
+    word-wrap: break-word;
     background-color: #f5f5f5;
     border: 1px solid #ccc;
     border-radius: 4px;
-    white-space: nowrap;
 }
 
 .html-content {

--- a/src/main/resources/templates/macros/json/embeddings.vm
+++ b/src/main/resources/templates/macros/json/embeddings.vm
@@ -63,9 +63,9 @@
       </a>
     </div>
     <div id="embedding-$embeddingId" class="collapse collapsable-details">
-      <span class="embedding-content">
+      <div class="embedding-content">
         <img src="embeddings/$embedding.getFileName()">
-      </span>
+      </div>
     </div>
   </div>
 #end
@@ -81,9 +81,9 @@
       </a>
     </div>
     <div id="embedding-$embeddingId" class="collapse collapsable-details">
-      1<span class="embedding-content">
+      <div class="embedding-content">
         <img src="$embedding.getDecodedData()">
-      </span>
+      </div>
     </div>
   </div>
 #end
@@ -99,9 +99,7 @@
       </a>
     </div>
     <div id="embedding-$embeddingId" class="collapse collapsable-details">
-      <span class="embedding-content">
-        <pre>$embedding.getDecodedData()</pre>
-      </span>
+      <pre class="embedding-content">$embedding.getDecodedData()</pre>
     </div>
   </div>
 #end
@@ -117,7 +115,7 @@
       </a>
     </div>
     <div id="embedding-$embeddingId" class="collapse collapsable-details">
-        <span class="embedding-content">This file cannot be displayed. Use download button to get the content as file.</span>
+        <pre class="embedding-content">This file cannot be displayed. Use download button to get the content as file.</pre>
     </div>
   </div>
 #end


### PR DESCRIPTION
Text and xml embedding were surounded by a border while other plain elements such as errors
and image attachment did not. This looked rather messy.