### PR TITLE
Santize span and img tags

### DIFF
--- a/src/main/java/net/masterthought/cucumber/generators/EscapeHtmlReference.java
+++ b/src/main/java/net/masterthought/cucumber/generators/EscapeHtmlReference.java
@@ -12,17 +12,17 @@ import org.owasp.html.PolicyFactory;
  */
 final class EscapeHtmlReference implements ReferenceInsertionEventHandler {
 
-    private static final PolicyFactory LINKS = new HtmlPolicyBuilder()
-            .allowStandardUrlProtocols().allowElements("a").allowAttributes("href")
-            .onElements("a").requireRelNofollowOnLinks().requireRelsOnLinks("noopener", "noreferrer")
+    private static final PolicyFactory TAGS = new HtmlPolicyBuilder()
+            .allowStandardUrlProtocols().allowElements("a", "span", "img").allowAttributes("href", "onclick", "src", "id", "style")
+            .onElements("a", "span", "img").requireRelNofollowOnLinks().requireRelsOnLinks("noopener", "noreferrer")
             .toFactory();
 
     @Override
     public Object referenceInsert(String reference, Object value) {
         if (value == null) {
             return null;
-        } else if(reference.startsWith("$_sanitize_")) {
-            return LINKS.sanitize(value.toString());
+        } else if(reference.contains("$_sanitize_")) {
+            return TAGS.sanitize(value.toString());
         } else {
             return StringEscapeUtils.escapeHtml(value.toString());
         }

--- a/src/main/java/net/masterthought/cucumber/generators/EscapeHtmlReference.java
+++ b/src/main/java/net/masterthought/cucumber/generators/EscapeHtmlReference.java
@@ -21,7 +21,7 @@ final class EscapeHtmlReference implements ReferenceInsertionEventHandler {
     public Object referenceInsert(String reference, Object value) {
         if (value == null) {
             return null;
-        } else if(reference.contains("$_sanitize_")) {
+        } else if(reference.startsWith("$_sanitize_")) {
             return TAGS.sanitize(value.toString());
         } else {
             return StringEscapeUtils.escapeHtml(value.toString());

--- a/src/main/resources/templates/macros/json/output.vm
+++ b/src/main/resources/templates/macros/json/output.vm
@@ -14,7 +14,7 @@
           #**
            * DO NOT format the line below. Whitespace nodes are significant in a pre-block.
            *#
-          <pre>#foreach($message in $output.getMessages())<p>$message</p>#end</pre>
+          <pre>#foreach($_sanitize_message in $output.getMessages())<p>$_sanitize_message</p>#end</pre>
         </div>
       </div>
     #end

--- a/src/test/java/net/masterthought/cucumber/generators/EscapeHtmlReferenceTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/EscapeHtmlReferenceTest.java
@@ -34,7 +34,13 @@ public class EscapeHtmlReferenceTest {
     @Test
     public void referenceInsert_shouldSanitize(){
         String html = "<a href=\"www.example.com\" rel=\"nofollow noopener noreferrer\">a hyper web reference</a>";
+        String img = "<img src=\"screenshot.png\" />";
+        String span = "<span style=\"background-color: #66CCEE;\">some text</span>";
         assertThat(insertionEventHandler.referenceInsert("$_sanitize_" + SOME_REFERENCE, html))
                 .isEqualTo(html);
+        assertThat(insertionEventHandler.referenceInsert("$_sanitize_" + SOME_REFERENCE, img))
+        		.isEqualTo(img);
+        assertThat(insertionEventHandler.referenceInsert("$_sanitize_" + SOME_REFERENCE, span))
+				.isEqualTo(span);
     }
 }


### PR DESCRIPTION
Hello Damian,

I've made some changes in EscapeHtmlReference.java , it allows to hightlight text and add image to a report. Thus we escapes "span" and "img" html tags now. 
Could you take a look and accept pull request if everything is good?

![2017-04-17_1526](https://cloud.githubusercontent.com/assets/20298105/25087766/5a8791e4-2382-11e7-8169-93bc4a898bc3.png)

![2017-04-17_1524](https://cloud.githubusercontent.com/assets/20298105/25087767/5d45d1d4-2382-11e7-9b9d-6514e1d5d99c.png)
