### PR TITLE
Update embeddings.vm

### DIFF
--- a/src/main/resources/templates/macros/json/embeddings.vm
+++ b/src/main/resources/templates/macros/json/embeddings.vm
@@ -64,7 +64,7 @@
     </div>
     <div id="embedding-$embeddingId" class="collapse collapsable-details">
       <div class="embedding-content">
-        <img src="embeddings/$embedding.getFileName()">
+        <img src="$embedding.getDecodedData()">
       </div>
     </div>
   </div>


### PR DESCRIPTION
I had to patch this to be able to display from JSON generated pngs using the Jenkins cucumber plugin... I may be tripping, but this seems to be the standard: https://en.wikipedia.org/wiki/Data_URI_scheme
It's up to you to accept this change.... how ever, embedding a base64 image using src=<path> doesn't work in any browser....