### PR TITLE
Handle missing 'result' properties

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/Element.java
+++ b/src/main/java/net/masterthought/cucumber/json/Element.java
@@ -1,10 +1,11 @@
 package net.masterthought.cucumber.json;
 
+import org.apache.commons.lang.StringUtils;
+
 import net.masterthought.cucumber.json.support.Durationable;
 import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.StatusCounter;
 import net.masterthought.cucumber.util.Util;
-import org.apache.commons.lang.StringUtils;
 
 public class Element implements Durationable {
 

--- a/src/main/java/net/masterthought/cucumber/json/Element.java
+++ b/src/main/java/net/masterthought/cucumber/json/Element.java
@@ -1,11 +1,10 @@
 package net.masterthought.cucumber.json;
 
-import org.apache.commons.lang.StringUtils;
-
 import net.masterthought.cucumber.json.support.Durationable;
 import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.StatusCounter;
 import net.masterthought.cucumber.util.Util;
+import org.apache.commons.lang.StringUtils;
 
 public class Element implements Durationable {
 
@@ -126,6 +125,9 @@ public class Element implements Durationable {
         StatusCounter statusCounter = new StatusCounter();
         for (Step step : steps) {
             Result result = step.getResult();
+            if (result == null) {
+                result = new Result();
+            }
             statusCounter.incrementFor(result.getStatus());
             duration += result.getDuration();
         }

--- a/src/test/java/net/masterthought/cucumber/ReportGenerator.java
+++ b/src/test/java/net/masterthought/cucumber/ReportGenerator.java
@@ -20,6 +20,7 @@ public abstract class ReportGenerator {
 
     protected static final String SAMPLE_JSON = "sample.json";
     public static final String SIMPLE_JSON = "simple.json";
+    public static final String MISSING_RESULT_JSON = "missing-result.json";
     protected static final String EMPTY_JSON = "empty.json";
     protected static final String INVALID_JSON = "invalid.json";
     protected static final String INVALID_REPORT_JSON = "invalid-report.json";

--- a/src/test/java/net/masterthought/cucumber/ReportParserTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportParserTest.java
@@ -6,6 +6,8 @@ import static org.hamcrest.core.StringEndsWith.endsWith;
 
 import java.util.List;
 
+import net.masterthought.cucumber.json.Step;
+import net.masterthought.cucumber.json.support.Status;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -33,6 +35,27 @@ public class ReportParserTest extends ReportGenerator {
         // then
         assertThat(features).hasSize(3);
     }
+
+    @Test
+    public void parseJsonResults_OnMissingResultInStep_ReturnsFeatureFile() {
+
+        // given
+        initWithJSon(MISSING_RESULT_JSON);
+        ReportParser reportParser = new ReportParser(configuration);
+
+        // when
+        List<Feature> features = reportParser.parseJsonFiles(jsonReports);
+
+        // then
+        assertThat(features).hasSize(1);
+        Feature firstFeature = features.get(0);
+        assertThat(firstFeature.getSteps()).isEqualTo(2);
+        assertThat(firstFeature.getElements().length).isEqualTo(1);
+        Step[] steps = firstFeature.getElements()[0].getSteps();
+        assertThat(steps.length).isEqualTo(2);
+        assertThat(steps[1].getResult().getStatus()).isEqualTo(Status.UNDEFINED);
+    }
+
 
     @Test
     public void parseJsonResults_OnNoFeatures_ThrowsException() {

--- a/src/test/resources/json/missing-result.json
+++ b/src/test/resources/json/missing-result.json
@@ -1,0 +1,34 @@
+[
+    {
+        "id":"missingResultId",
+        "name":"Missing result feature",
+        "keyword":"Feature",
+        "elements":[
+            {
+                "keyword":"Scenario",
+                "steps":[
+                    {
+                        "result":{
+                            "duration":123456789,
+                            "status":"passed"
+                        },
+                        "name":"First step name",
+                        "keyword":"Given ",
+                        "match":{
+                            "location":"simple.location()"
+                        }
+                    },
+                    {
+                        "name":"Second step name",
+                        "keyword":"Given ",
+                        "match":{
+                            "location":"simple.location()"
+                        }
+                    }
+                ],
+                "type":"scenario"
+            }
+        ],
+        "uri":"simple:uri"
+    }
+]


### PR DESCRIPTION
We've implemented graceful shutdown with writing pretty json file even in case of interrupted test process.
Unfortunately, result property is missing from steps that haven't executed yet.

This change will allow us to generate html even for such json.

And, judging from the comment in https://github.com/damianszczepanik/cucumber-reporting/blob/master/src/main/java/net/masterthought/cucumber/json/Result.java#L13
we can just use Status.UNDEFINED without breaking the contract for Result.


Current behaviour is to throw
```
java.lang.NullPointerException
	at net.masterthought.cucumber.json.Element.calculateStepsStatus(Element.java:115)
	at net.masterthought.cucumber.json.Element.setMetaData(Element.java:91)
	at net.masterthought.cucumber.json.Feature.setMetaData(Feature.java:161)
	at net.masterthought.cucumber.ReportParser.setMetadata(ReportParser.java:97)
	at net.masterthought.cucumber.ReportParser.parseJsonFiles(ReportParser.java:60)
...

```
What do you think?