### PR TITLE
use undecoded data when embedded text is processed

### DIFF
--- a/src/main/resources/templates/macros/json/embeddings.vm
+++ b/src/main/resources/templates/macros/json/embeddings.vm
@@ -99,7 +99,7 @@
       </a>
     </div>
     <div id="embedding-$embeddingId" class="collapse collapsable-details">
-      <pre class="embedding-content">$embedding.getDecodedData()</pre>
+      <pre class="embedding-content">$embedding.getData()</pre>
     </div>
   </div>
 #end

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/EmbeddingAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/EmbeddingAssertion.java
@@ -25,7 +25,7 @@ public class EmbeddingAssertion extends ReportAssertion {
 
     public void hasTextContent(String content) {
         assertThat(getBox().oneBySelector("pre", WebAssertion.class).text())
-                .isEqualTo(getDecodedData(content));
+                .isEqualTo(content);
     }
 
     private WebAssertion getBox() {


### PR DESCRIPTION
Embeddings with mime_type text/plain, text/xml, and application/json are decoded as if it was base64. I disabled this so the text is readable in the html report.