### PR TITLE
Support PDF embedding with `.pdf` extension

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/Embedding.java
+++ b/src/main/java/net/masterthought/cucumber/json/Embedding.java
@@ -1,11 +1,10 @@
 package net.masterthought.cucumber.json;
 
-import java.nio.charset.StandardCharsets;
-
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import net.masterthought.cucumber.json.deserializers.EmbeddingDeserializer;
 import org.codehaus.plexus.util.Base64;
 
-import net.masterthought.cucumber.json.deserializers.EmbeddingDeserializer;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -68,6 +67,8 @@ public class Embedding {
             return "image";
         case "text/plain":
             return "txt";
+        case "application/pdf":
+            return "pdf";
         default:
             return "unknown";
         }

--- a/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
@@ -1,8 +1,8 @@
 package net.masterthought.cucumber.json;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -101,6 +101,19 @@ public class EmbeddingTest {
 
         // then
         assertThat(extension).isEqualTo("image");
+    }
+
+    @Test
+    public void getExtension__OnApplicationPdfMimeType_ReturnsPdf() {
+
+        // given
+        Embedding embedding = new Embedding("application/pdf", "");
+
+        // when
+        String extension = embedding.getExtension();
+
+        // then
+        assertThat(extension).isEqualTo("pdf");
     }
 
     @Test


### PR DESCRIPTION
Currently the PDF embedding is downloaded as "unknown":
![download_unknown](https://user-images.githubusercontent.com/6797074/29729399-59856d52-89b2-11e7-9a5f-28dd4e9eb6c4.png)
With this commit the PDF embedding will be downloaded as "PDF document":
![download_pdf](https://user-images.githubusercontent.com/6797074/29729456-9604b8fa-89b2-11e7-8358-28d85b81b4ff.png)
