### PR TITLE
Allow undefined and pending steps to not fail

### DIFF
--- a/src/main/java/net/masterthought/cucumber/Configuration.java
+++ b/src/main/java/net/masterthought/cucumber/Configuration.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
 import net.masterthought.cucumber.sorting.SortingMethod;
 
 public class Configuration {

--- a/src/main/java/net/masterthought/cucumber/Configuration.java
+++ b/src/main/java/net/masterthought/cucumber/Configuration.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-
 import net.masterthought.cucumber.sorting.SortingMethod;
 
 public class Configuration {
@@ -17,6 +16,7 @@ public class Configuration {
 
     private boolean parallelTesting;
     private boolean runWithJenkins;
+    private boolean strict = true;
 
     private File reportDirectory;
 
@@ -30,6 +30,7 @@ public class Configuration {
     private Collection<Pattern> tagsToExcludeFromChart = new ArrayList<>();
     private SortingMethod sortingMethod = SortingMethod.NATURAL;
     private List<String> classificationFiles;
+
 
     public Configuration(File reportOutputDirectory, String projectName) {
         this.reportDirectory = reportOutputDirectory;
@@ -79,6 +80,20 @@ public class Configuration {
 
     public int getTrendsLimit() {
         return trendsLimit;
+    }
+
+    /**
+     * Sets whether to treat pending and undefined steps as failed.
+     * 
+     * @param strict
+     *            true if pending and undefined steps should be classed as failed.
+     */
+    public void setStrict(boolean strict) {
+        this.strict = strict;
+    }
+
+    public boolean isStrict() {
+        return strict;
     }
 
     /**

--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -1,9 +1,5 @@
 package net.masterthought.cucumber;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -15,6 +11,11 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -1,5 +1,9 @@
 package net.masterthought.cucumber;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -11,15 +15,6 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import net.masterthought.cucumber.generators.AbstractPage;
 import net.masterthought.cucumber.generators.ErrorPage;
 import net.masterthought.cucumber.generators.FailuresOverviewPage;
@@ -31,6 +26,9 @@ import net.masterthought.cucumber.generators.TagsOverviewPage;
 import net.masterthought.cucumber.generators.TrendsOverviewPage;
 import net.masterthought.cucumber.json.Feature;
 import net.masterthought.cucumber.json.support.TagObject;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ReportBuilder {
 
@@ -88,7 +86,7 @@ public class ReportBuilder {
 
             // parse json files for results
             List<Feature> features = reportParser.parseJsonFiles(jsonFiles);
-            reportResult = new ReportResult(features, configuration.getSortingMethod());
+            reportResult = new ReportResult(features, configuration);
             Reportable reportable = reportResult.getFeatureReport();
 
             if (configuration.isTrendsStatsFile()) {

--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -15,6 +15,10 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import net.masterthought.cucumber.generators.AbstractPage;
 import net.masterthought.cucumber.generators.ErrorPage;
 import net.masterthought.cucumber.generators.FailuresOverviewPage;
@@ -26,9 +30,6 @@ import net.masterthought.cucumber.generators.TagsOverviewPage;
 import net.masterthought.cucumber.generators.TrendsOverviewPage;
 import net.masterthought.cucumber.json.Feature;
 import net.masterthought.cucumber.json.support.TagObject;
-import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class ReportBuilder {
 

--- a/src/main/java/net/masterthought/cucumber/ReportResult.java
+++ b/src/main/java/net/masterthought/cucumber/ReportResult.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
 

--- a/src/main/java/net/masterthought/cucumber/ReportResult.java
+++ b/src/main/java/net/masterthought/cucumber/ReportResult.java
@@ -6,10 +6,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.ArrayUtils;
-
 import net.masterthought.cucumber.generators.OverviewReport;
 import net.masterthought.cucumber.json.Element;
 import net.masterthought.cucumber.json.Feature;
@@ -22,7 +18,8 @@ import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.StepObject;
 import net.masterthought.cucumber.json.support.TagObject;
 import net.masterthought.cucumber.sorting.SortingFactory;
-import net.masterthought.cucumber.sorting.SortingMethod;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 public class ReportResult {
 
@@ -38,10 +35,12 @@ public class ReportResult {
 
     private final OverviewReport featuresReport = new OverviewReport();
     private final OverviewReport tagsReport = new OverviewReport();
+    private boolean strict;
 
-    public ReportResult(List<Feature> features, SortingMethod sortingMethod) {
+    public ReportResult(List<Feature> features, Configuration configuration) {
         this.buildTime = getCurrentTime();
-        this.sortingFactory = new SortingFactory(sortingMethod);
+        this.sortingFactory = new SortingFactory(configuration.getSortingMethod());
+        this.strict = configuration.isStrict();
 
         for (Feature feature : features) {
             processFeature(feature);
@@ -143,7 +142,7 @@ public class ReportResult {
         StepObject stepObject = allSteps.get(methodName);
         // if first occurrence of this location add element to the map
         if (stepObject == null) {
-            stepObject = new StepObject(methodName);
+            stepObject = new StepObject(methodName, strict);
         }
 
         // happens that report is not valid - does not contain information about result

--- a/src/main/java/net/masterthought/cucumber/ReportResult.java
+++ b/src/main/java/net/masterthought/cucumber/ReportResult.java
@@ -6,6 +6,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+
 import net.masterthought.cucumber.generators.OverviewReport;
 import net.masterthought.cucumber.json.Element;
 import net.masterthought.cucumber.json.Feature;
@@ -18,8 +21,6 @@ import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.StepObject;
 import net.masterthought.cucumber.json.support.TagObject;
 import net.masterthought.cucumber.sorting.SortingFactory;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.ArrayUtils;
 
 public class ReportResult {
 

--- a/src/main/java/net/masterthought/cucumber/json/Element.java
+++ b/src/main/java/net/masterthought/cucumber/json/Element.java
@@ -1,11 +1,10 @@
 package net.masterthought.cucumber.json;
 
-import org.apache.commons.lang.StringUtils;
-
 import net.masterthought.cucumber.json.support.Durationable;
 import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.StatusCounter;
 import net.masterthought.cucumber.util.Util;
+import org.apache.commons.lang.StringUtils;
 
 public class Element implements Durationable {
 
@@ -96,39 +95,39 @@ public class Element implements Durationable {
         return Util.formatDuration(duration);
     }
 
-    public void setMetaData(Feature feature) {
+    public void setMetaData(Feature feature, boolean strict) {
         this.feature = feature;
 
-        beforeStatus = calculateHookStatus(before);
-        afterStatus = calculateHookStatus(after);
-        stepsStatus = calculateStepsStatus();
-        elementStatus = calculateElementStatus();
+        beforeStatus = calculateHookStatus(before, strict);
+        afterStatus = calculateHookStatus(after, strict);
+        stepsStatus = calculateStepsStatus(strict);
+        elementStatus = calculateElementStatus(strict);
     }
 
-    private Status calculateHookStatus(Hook[] hooks) {
+    private Status calculateHookStatus(Hook[] hooks, boolean strict) {
         StatusCounter statusCounter = new StatusCounter();
         for (Hook hook : hooks) {
             statusCounter.incrementFor(hook.getResult().getStatus());
         }
 
-        return statusCounter.getFinalStatus();
+        return statusCounter.getFinalStatus(strict);
     }
 
-    private Status calculateElementStatus() {
+    private Status calculateElementStatus(boolean strict) {
         StatusCounter statusCounter = new StatusCounter();
         statusCounter.incrementFor(stepsStatus);
         statusCounter.incrementFor(beforeStatus);
         statusCounter.incrementFor(afterStatus);
-        return statusCounter.getFinalStatus();
+        return statusCounter.getFinalStatus(strict);
     }
 
-    private Status calculateStepsStatus() {
+    private Status calculateStepsStatus(boolean strict) {
         StatusCounter statusCounter = new StatusCounter();
         for (Step step : steps) {
             Result result = step.getResult();
             statusCounter.incrementFor(result.getStatus());
             duration += result.getDuration();
         }
-        return statusCounter.getFinalStatus();
+        return statusCounter.getFinalStatus(strict);
     }
 }

--- a/src/main/java/net/masterthought/cucumber/json/Element.java
+++ b/src/main/java/net/masterthought/cucumber/json/Element.java
@@ -1,10 +1,11 @@
 package net.masterthought.cucumber.json;
 
+import org.apache.commons.lang.StringUtils;
+
 import net.masterthought.cucumber.json.support.Durationable;
 import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.StatusCounter;
 import net.masterthought.cucumber.util.Util;
-import org.apache.commons.lang.StringUtils;
 
 public class Element implements Durationable {
 

--- a/src/main/java/net/masterthought/cucumber/json/Feature.java
+++ b/src/main/java/net/masterthought/cucumber/json/Feature.java
@@ -1,8 +1,9 @@
 package net.masterthought.cucumber.json;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.StringUtils;
 
 import net.masterthought.cucumber.Configuration;

--- a/src/main/java/net/masterthought/cucumber/json/Feature.java
+++ b/src/main/java/net/masterthought/cucumber/json/Feature.java
@@ -1,17 +1,15 @@
 package net.masterthought.cucumber.json;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang.StringUtils;
-
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.Reportable;
 import net.masterthought.cucumber.json.support.Durationable;
 import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.StatusCounter;
 import net.masterthought.cucumber.util.Util;
+import org.apache.commons.lang.StringUtils;
 
 public class Feature implements Reportable, Durationable {
 
@@ -161,7 +159,7 @@ public class Feature implements Reportable, Durationable {
         this.jsonFile = jsonFile;
 
         for (Element element : elements) {
-            element.setMetaData(this);
+            element.setMetaData(this, configuration.isStrict());
 
             if (element.isScenario()) {
                 scenarios.add(element);
@@ -170,7 +168,7 @@ public class Feature implements Reportable, Durationable {
 
         deviceName = calculateDeviceName();
         calculateReportFileName(jsonFileNo, configuration);
-        featureStatus = calculateFeatureStatus();
+        featureStatus = calculateFeatureStatus(configuration);
 
         calculateSteps();
     }
@@ -206,12 +204,12 @@ public class Feature implements Reportable, Durationable {
         reportFileName += ".html";
     }
 
-    private Status calculateFeatureStatus() {
+    private Status calculateFeatureStatus(Configuration configuration) {
         StatusCounter statusCounter = new StatusCounter();
         for (Element element : elements) {
             statusCounter.incrementFor(element.getStatus());
         }
-        return statusCounter.getFinalStatus();
+        return statusCounter.getFinalStatus(configuration.isStrict());
     }
 
     private void calculateSteps() {

--- a/src/main/java/net/masterthought/cucumber/json/Feature.java
+++ b/src/main/java/net/masterthought/cucumber/json/Feature.java
@@ -3,13 +3,14 @@ package net.masterthought.cucumber.json;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang.StringUtils;
+
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.Reportable;
 import net.masterthought.cucumber.json.support.Durationable;
 import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.StatusCounter;
 import net.masterthought.cucumber.util.Util;
-import org.apache.commons.lang.StringUtils;
 
 public class Feature implements Reportable, Durationable {
 

--- a/src/main/java/net/masterthought/cucumber/json/support/StatusCounter.java
+++ b/src/main/java/net/masterthought/cucumber/json/support/StatusCounter.java
@@ -12,12 +12,6 @@ public class StatusCounter {
 
     private EnumMap<Status, Integer> counter = new EnumMap<>(Status.class);
 
-    /**
-     * Is equal to {@link Status#FAILED} when at least counted status is not {@link Status#PASSED},
-     * otherwise set to {@link Status#PASSED}.
-     */
-    private Status finalStatus = Status.PASSED;
-
     private int size = 0;
 
     public StatusCounter() {
@@ -36,10 +30,6 @@ public class StatusCounter {
         final int statusCounter = getValueFor(status) + 1;
         this.counter.put(status, statusCounter);
         size++;
-
-        if (finalStatus == Status.PASSED && status != Status.PASSED) {
-            finalStatus = Status.FAILED;
-        }
     }
 
     /**
@@ -66,7 +56,10 @@ public class StatusCounter {
      *
      * @return final status for this counter
      */
-    public Status getFinalStatus() {
-        return finalStatus;
+    public Status getFinalStatus(boolean strict) {
+        if (strict) {
+            return counter.get(Status.PASSED) == size() ? Status.PASSED : Status.FAILED;
+        }
+        return Status.PASSED;
     }
 }

--- a/src/main/java/net/masterthought/cucumber/json/support/StepObject.java
+++ b/src/main/java/net/masterthought/cucumber/json/support/StepObject.java
@@ -1,9 +1,8 @@
 package net.masterthought.cucumber.json.support;
 
-import org.apache.commons.lang.StringUtils;
-
 import net.masterthought.cucumber.ValidationException;
 import net.masterthought.cucumber.util.Util;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Keeps information about steps statistics.
@@ -24,7 +23,10 @@ public class StepObject {
 
     private final StatusCounter statusCounter = new StatusCounter();
 
-    public StepObject(String location) {
+    private boolean strict;
+
+    public StepObject(String location, boolean strict) {
+        this.strict = strict;
         if (StringUtils.isEmpty(location)) {
             throw new ValidationException("Location cannnot be null!");
         }
@@ -76,6 +78,6 @@ public class StepObject {
     }
 
     public Status getStatus() {
-        return statusCounter.getFinalStatus();
+        return statusCounter.getFinalStatus(strict);
     }
 }

--- a/src/main/java/net/masterthought/cucumber/json/support/StepObject.java
+++ b/src/main/java/net/masterthought/cucumber/json/support/StepObject.java
@@ -1,8 +1,9 @@
 package net.masterthought.cucumber.json.support;
 
+import org.apache.commons.lang.StringUtils;
+
 import net.masterthought.cucumber.ValidationException;
 import net.masterthought.cucumber.util.Util;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Keeps information about steps statistics.

--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -14,8 +14,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
 import mockit.Deencapsulation;
+import net.masterthought.cucumber.generators.AbstractPage;
+import net.masterthought.cucumber.generators.OverviewReport;
+import net.masterthought.cucumber.json.Feature;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -24,10 +26,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import net.masterthought.cucumber.generators.AbstractPage;
-import net.masterthought.cucumber.generators.OverviewReport;
-import net.masterthought.cucumber.json.Feature;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -219,7 +217,7 @@ public class ReportBuilderTest extends ReportGenerator {
         setUpWithJson(SAMPLE_JSON);
 
         ReportBuilder builder = new ReportBuilder(jsonReports, configuration);
-        Deencapsulation.setField(builder, "reportResult", new ReportResult(features, configuration.getSortingMethod()));
+        Deencapsulation.setField(builder, "reportResult", new ReportResult(features, configuration));
 
         // when
         List<AbstractPage> pages = Deencapsulation.invoke(builder, "collectPages", new Trends());
@@ -236,7 +234,7 @@ public class ReportBuilderTest extends ReportGenerator {
         configuration.setTrendsStatsFile(trendsFileTmp);
 
         ReportBuilder builder = new ReportBuilder(jsonReports, configuration);
-        Deencapsulation.setField(builder, "reportResult", new ReportResult(features, configuration.getSortingMethod()));
+        Deencapsulation.setField(builder, "reportResult", new ReportResult(features, configuration));
 
         // when
         List<AbstractPage> pages = Deencapsulation.invoke(builder, "collectPages", new Trends());
@@ -471,7 +469,7 @@ public class ReportBuilderTest extends ReportGenerator {
             }
         };
 
-        ReportResult reportResult = new ReportResult(Collections.<Feature>emptyList(), configuration.getSortingMethod()) {
+        ReportResult reportResult = new ReportResult(Collections.<Feature>emptyList(), configuration) {
             @Override
             public Reportable getFeatureReport() {
                 return reportable;

--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+
 import mockit.Deencapsulation;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;

--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -15,9 +15,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import mockit.Deencapsulation;
-import net.masterthought.cucumber.generators.AbstractPage;
-import net.masterthought.cucumber.generators.OverviewReport;
-import net.masterthought.cucumber.json.Feature;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -26,6 +23,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import net.masterthought.cucumber.generators.AbstractPage;
+import net.masterthought.cucumber.generators.OverviewReport;
+import net.masterthought.cucumber.json.Feature;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)

--- a/src/test/java/net/masterthought/cucumber/ReportGenerator.java
+++ b/src/test/java/net/masterthought/cucumber/ReportGenerator.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+
 import net.masterthought.cucumber.json.Feature;
 import net.masterthought.cucumber.json.support.StepObject;
 import net.masterthought.cucumber.json.support.TagObject;

--- a/src/test/java/net/masterthought/cucumber/ReportGenerator.java
+++ b/src/test/java/net/masterthought/cucumber/ReportGenerator.java
@@ -5,7 +5,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-
 import net.masterthought.cucumber.json.Feature;
 import net.masterthought.cucumber.json.support.StepObject;
 import net.masterthought.cucumber.json.support.TagObject;
@@ -63,8 +62,9 @@ public abstract class ReportGenerator {
 
     protected void initWithJson(String... jsonFiles) {
         if (jsonFiles != null) {
-            for (String jsonFile : jsonFiles)
+            for (String jsonFile : jsonFiles) {
                 jsonReports.add(reportFromResource(jsonFile));
+            }
         }
 
         // may be already created so don't overwrite it
@@ -76,8 +76,9 @@ public abstract class ReportGenerator {
     }
 
     protected void initWithProperties(String... propertyFiles) {
-        for (String propertyFile : propertyFiles)
-           this.classificationFiles.add(reportFromResourceProperties(propertyFile));
+        for (String propertyFile : propertyFiles) {
+            this.classificationFiles.add(reportFromResourceProperties(propertyFile));
+        }
 
         // may be already created so don't overwrite it
         if (configuration == null) {
@@ -108,7 +109,7 @@ public abstract class ReportGenerator {
         ReportParser reportParser = new ReportParser(configuration);
 
         List<Feature> featuresFromJson = reportParser.parseJsonFiles(jsonReports);
-        reportResult = new ReportResult(featuresFromJson, configuration.getSortingMethod());
+        reportResult = new ReportResult(featuresFromJson, configuration);
 
         features = reportResult.getAllFeatures();
         tags = reportResult.getAllTags();

--- a/src/test/java/net/masterthought/cucumber/generators/TrendsOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TrendsOverviewPageTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+
 import mockit.Deencapsulation;
 import org.apache.commons.io.FileUtils;
 import org.apache.velocity.VelocityContext;

--- a/src/test/java/net/masterthought/cucumber/generators/TrendsOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TrendsOverviewPageTest.java
@@ -5,16 +5,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import mockit.Deencapsulation;
-import net.masterthought.cucumber.ReportBuilder;
-import net.masterthought.cucumber.ReportResult;
-import net.masterthought.cucumber.Trends;
-import net.masterthought.cucumber.generators.integrations.PageTest;
 import org.apache.commons.io.FileUtils;
 import org.apache.velocity.VelocityContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import net.masterthought.cucumber.ReportBuilder;
+import net.masterthought.cucumber.ReportResult;
+import net.masterthought.cucumber.Trends;
+import net.masterthought.cucumber.generators.integrations.PageTest;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)

--- a/src/test/java/net/masterthought/cucumber/generators/TrendsOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TrendsOverviewPageTest.java
@@ -4,19 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-
 import mockit.Deencapsulation;
+import net.masterthought.cucumber.ReportBuilder;
+import net.masterthought.cucumber.ReportResult;
+import net.masterthought.cucumber.Trends;
+import net.masterthought.cucumber.generators.integrations.PageTest;
 import org.apache.commons.io.FileUtils;
 import org.apache.velocity.VelocityContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import net.masterthought.cucumber.ReportBuilder;
-import net.masterthought.cucumber.ReportResult;
-import net.masterthought.cucumber.Trends;
-import net.masterthought.cucumber.generators.integrations.PageTest;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -57,7 +55,7 @@ public class TrendsOverviewPageTest extends PageTest {
         Trends trends = Deencapsulation.invoke(ReportBuilder.class, "loadTrends", new File(TRENDS_TMP_FILE));
         page = new TrendsOverviewPage(reportResult, configuration, trends);
 
-        Deencapsulation.setField(page, "reportResult", new ReportResult(features, configuration.getSortingMethod()));
+        Deencapsulation.setField(page, "reportResult", new ReportResult(features, configuration));
 
         // when
         page.prepareReport();

--- a/src/test/java/net/masterthought/cucumber/json/support/StepObjectTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/support/StepObjectTest.java
@@ -2,12 +2,11 @@ package net.masterthought.cucumber.json.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import net.masterthought.cucumber.ValidationException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import net.masterthought.cucumber.ValidationException;
 
 /**
  * @author Sam Park (midopa@github)
@@ -21,7 +20,7 @@ public class StepObjectTest {
 
     @Before
     public void setUp() {
-        stepObject = new StepObject("Test step location");
+        stepObject = new StepObject("Test step location", true);
         stepObject.addDuration(1000000000L, Status.PASSED);
         stepObject.addDuration(2200000000L, Status.FAILED);
         stepObject.addDuration( 303000000L, Status.UNDEFINED);
@@ -34,7 +33,7 @@ public class StepObjectTest {
 
         // then
         thrown.expect(ValidationException.class);
-        new StepObject(null);
+        new StepObject(null, true);
     }
 
     @Test
@@ -54,7 +53,7 @@ public class StepObjectTest {
     public void addDurationSumsDurations() {
 
         // give
-        StepObject step = new StepObject("ble bla ble");
+        StepObject step = new StepObject("ble bla ble", true);
 
         // when
         step.addDuration(20L, Status.PASSED);
@@ -123,7 +122,7 @@ public class StepObjectTest {
     public void getPercentageResult_OnOnlyFailures_Returns0Percent() {
 
         // given
-        StepObject step = new StepObject("Test step location");
+        StepObject step = new StepObject("Test step location", true);
         step.addDuration(2200000000L, Status.FAILED);
         step.addDuration(303000000L, Status.UNDEFINED);
 

--- a/src/test/java/net/masterthought/cucumber/json/support/StepObjectTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/support/StepObjectTest.java
@@ -2,11 +2,12 @@ package net.masterthought.cucumber.json.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import net.masterthought.cucumber.ValidationException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import net.masterthought.cucumber.ValidationException;
 
 /**
  * @author Sam Park (midopa@github)

--- a/src/test/java/net/masterthought/cucumber/sorting/StepObjectAlphabeticalComparatorTest.java
+++ b/src/test/java/net/masterthought/cucumber/sorting/StepObjectAlphabeticalComparatorTest.java
@@ -3,10 +3,8 @@ package net.masterthought.cucumber.sorting;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Comparator;
-
-import org.junit.Test;
-
 import net.masterthought.cucumber.json.support.StepObject;
+import org.junit.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -19,8 +17,8 @@ public class StepObjectAlphabeticalComparatorTest {
     public void compareTo_OnDifferentLocation_ReturnsNoneZero() {
 
         // given
-        StepObject step1 = new StepObject("one");
-        StepObject step2 = new StepObject("two");
+        StepObject step1 = new StepObject("one", true);
+        StepObject step2 = new StepObject("two", true);
 
         // when
         int result = comparator.compare(step1, step2);
@@ -33,8 +31,8 @@ public class StepObjectAlphabeticalComparatorTest {
     public void compareTo_OnSameLocation_ReturnsZero() {
 
         // given
-        StepObject step1 = new StepObject("one");
-        StepObject step2 = new StepObject("one");
+        StepObject step1 = new StepObject("one", true);
+        StepObject step2 = new StepObject("one", true);
 
         // when
         int result = comparator.compare(step1, step2);

--- a/src/test/java/net/masterthought/cucumber/sorting/StepObjectAlphabeticalComparatorTest.java
+++ b/src/test/java/net/masterthought/cucumber/sorting/StepObjectAlphabeticalComparatorTest.java
@@ -3,8 +3,9 @@ package net.masterthought.cucumber.sorting;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Comparator;
-import net.masterthought.cucumber.json.support.StepObject;
 import org.junit.Test;
+
+import net.masterthought.cucumber.json.support.StepObject;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)

--- a/src/test/java/net/masterthought/cucumber/sorting/StepObjectAlphabeticalComparatorTest.java
+++ b/src/test/java/net/masterthought/cucumber/sorting/StepObjectAlphabeticalComparatorTest.java
@@ -3,6 +3,7 @@ package net.masterthought.cucumber.sorting;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Comparator;
+
 import org.junit.Test;
 
 import net.masterthought.cucumber.json.support.StepObject;


### PR DESCRIPTION
Hi, This is a cut down version of #636, allows you to pass `strict` into the configuration object and makes the status `PASSED` as long as there are no `FAILURES`.  It would also mark `PENDING` as passed if strict was false too, but happy to make a change and fixup the imports if your willing to merge.

@a1dutch

