### PR TITLE
Support screenshots in v2 and v3 reports

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/deserializers/EmbeddingDeserializer.java
+++ b/src/main/java/net/masterthought/cucumber/json/deserializers/EmbeddingDeserializer.java
@@ -24,12 +24,22 @@ public class EmbeddingDeserializer extends CucumberJsonDeserializer<Embedding> {
     @Override
     public Embedding deserialize(JsonNode rootNode, Configuration configuration) {
         String data = rootNode.get("data").asText();
-        String mimeType = rootNode.get("mime_type").asText();
+        String mimeType = findMimeType(rootNode);
 
         Embedding embedding = new Embedding(mimeType, data);
         storeEmbedding(embedding, configuration.getEmbeddingDirectory());
 
         return embedding;
+    }
+
+    private String findMimeType(JsonNode rootNode) {
+        JsonNode media = rootNode.get("media");
+
+        if (media != null) {
+            return media.get("type").asText();
+        }
+
+        return rootNode.get("mime_type").asText();
     }
 
     private void storeEmbedding(Embedding embedding, File embeddingDirectory) {

--- a/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageTest.java
@@ -2,6 +2,9 @@ package net.masterthought.cucumber.generators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import net.masterthought.cucumber.json.Element;
+import net.masterthought.cucumber.json.Embedding;
+import net.masterthought.cucumber.json.Step;
 import org.apache.velocity.VelocityContext;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,5 +51,33 @@ public class FeatureReportPageTest extends PageTest {
         assertThat(context.getKeys()).hasSize(9);
         assertThat(context.get("parallel")).isEqualTo(configuration.isParallelTesting());
         assertThat(context.get("feature")).isEqualTo(feature);
+    }
+
+    @Test
+    public void getMimeType_OnEmbeddingFromV2CucumberReportFile_SupportsScreenshots() {
+        // given
+        Feature feature = features.get(0);
+        Element element = feature.getElements()[0];
+        Step step = element.getSteps()[0];
+
+        // when
+        Embedding[] embeddings = step.getEmbeddings();
+
+        // then
+        assertThat(embeddings[0].getMimeType()).isEqualTo("image/url");
+    }
+
+    @Test
+    public void getMimeType_OnEmbeddingFromV3CucumberReportFile_SupportsScreenshots() {
+        // given
+        Feature feature = features.get(0);
+        Element element = feature.getElements()[0];
+        Step step = element.getSteps()[0];
+
+        // when
+        Embedding[] embeddings = step.getEmbeddings();
+
+        // then
+        assertThat(embeddings[1].getMimeType()).isEqualTo("text/plain");
     }
 }

--- a/src/test/resources/json/sample.json
+++ b/src/test/resources/json/sample.json
@@ -33,6 +33,12 @@
                             {
                                 "mime_type": "image/url",
                                 "data": "aHR0cDovL2xvY2FsaG9zdC9zdGF0aWMvbG9nby5wbmc="
+                            },
+                            {
+                                "data":"file:///path/to/index.html",
+                                "media":{
+                                    "type":"text/plain"
+                                }
                             }
                         ]
                     },


### PR DESCRIPTION
Fixes jenkinsci/cucumber-reports-plugin#193 by conditionally trying to load the mime type of an embedding from the v3 location, if not found it will fall back to v2.  Also adds tests for the same.

Happy to make any amends necessary.