### PR TITLE
Reduce memory use when generating pages

### DIFF
--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -18,14 +18,12 @@ import java.util.List;
 import mockit.Deencapsulation;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.apache.commons.lang3.mutable.MutableInt;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import net.masterthought.cucumber.generators.AbstractPage;
 import net.masterthought.cucumber.generators.OverviewReport;
 import net.masterthought.cucumber.json.Feature;
 
@@ -42,9 +40,9 @@ public class ReportBuilderTest extends ReportGenerator {
 
     @Before
     public void setUp() throws IOException {
-        reportDirectory = new File("target" + File.separatorChar + System.currentTimeMillis());
+        reportDirectory = new File("target", String.valueOf(System.currentTimeMillis()));
         // random temp directory
-        reportDirectory.mkdir();
+        reportDirectory.mkdirs();
         // root report directory
         new File(reportDirectory, ReportBuilder.BASE_DIRECTORY).mkdir();
 
@@ -58,6 +56,10 @@ public class ReportBuilderTest extends ReportGenerator {
     @After
     public void cleanUp() throws IOException {
         FileUtils.deleteDirectory(reportDirectory);
+        if (configuration != null) {
+			FileUtils.deleteDirectory(new File(configuration.getReportDirectory(), 
+					ReportBuilder.BASE_DIRECTORY));
+        }
     }
 
     @Test
@@ -222,10 +224,10 @@ public class ReportBuilderTest extends ReportGenerator {
         Deencapsulation.setField(builder, "reportResult", new ReportResult(features, configuration.getSortingMethod()));
 
         // when
-        List<AbstractPage> pages = Deencapsulation.invoke(builder, "collectPages", new Trends());
+        Deencapsulation.invoke(builder, "generatePages", new Trends());
 
         // then
-        assertThat(pages).hasSize(9);
+        assertThat(countHtmlFiles(configuration).length).isEqualTo(9);
     }
 
     @Test
@@ -239,43 +241,10 @@ public class ReportBuilderTest extends ReportGenerator {
         Deencapsulation.setField(builder, "reportResult", new ReportResult(features, configuration.getSortingMethod()));
 
         // when
-        List<AbstractPage> pages = Deencapsulation.invoke(builder, "collectPages", new Trends());
+        Deencapsulation.invoke(builder, "generatePages", new Trends());
 
         // then
-        assertThat(pages).hasSize(10);
-    }
-
-    @Test
-    public void generatePages_CallsGeneratePagesOverPassedPages() {
-
-        // given
-        Configuration configuration = new Configuration(null, null);
-        ReportBuilder builder = new ReportBuilder(jsonReports, configuration);
-
-        final MutableInt counter = new MutableInt();
-        AbstractPage page = new AbstractPage(null, null, configuration) {
-            @Override
-            public String getWebPage() {
-                return null;
-            }
-
-            @Override
-            protected void prepareReport() {
-                // only to satisfy abstract class contract
-            }
-
-            @Override
-            public void generatePage() {
-                counter.increment();
-            }
-        };
-        List<AbstractPage> pages = Arrays.asList(page, page, page);
-
-        // when
-        Deencapsulation.invoke(builder, "generatePages", pages);
-
-        // then
-        assertThat(counter.getValue()).isEqualTo(pages.size());
+        assertThat(countHtmlFiles(configuration).length).isEqualTo(10);
     }
 
     @Test
@@ -522,6 +491,12 @@ public class ReportBuilderTest extends ReportGenerator {
 
         // then
         assertPageExists(reportDirectory, ReportBuilder.HOME_PAGE);
+    }
+    
+    private File[] countHtmlFiles(Configuration configuration) {
+    	FileFilter fileFilter = new WildcardFileFilter("*.html");
+    	File dir = new File(configuration.getReportDirectory(), ReportBuilder.BASE_DIRECTORY);
+        return dir.listFiles(fileFilter);
     }
 
     private File[] countHtmlFiles() {


### PR DESCRIPTION
The `ReportBuilder` kept a list of pages to generate for no obvious reason. This change removes this list and collects and generates pages in a single pass.