### PR TITLE
Proposed fix for damianszczepanik/cucumber-reporting#675

### DIFF
--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,13 @@
+status = info
+name = PropertiesConfig
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%level] %m%n
+
+rootLogger.level = info
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
Issue #675 was closed because of missing functional impact.
But that ERROR log message still is there and initially confuses every colleague looking at the output.

A simple fix would be supplying an appropriate LOG4J config file (like you do already for unit tests).