### PR TITLE
Throw exception when embeddingDirectory not present and not created

### DIFF
--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -129,7 +129,10 @@ public class ReportBuilder {
     }
 
     private void createEmbeddingsDirectory() {
-        configuration.getEmbeddingDirectory().mkdirs();
+        final File embeddingDirectory = configuration.getEmbeddingDirectory();
+        if(!embeddingDirectory.exists() && !embeddingDirectory.mkdirs()){
+            throw new ValidationException("Failed to create: " + embeddingDirectory);
+        }
     }
 
     private void copyResources(String resourceLocation, String... resources) {

--- a/src/test/java/net/masterthought/cucumber/ReportGenerator.java
+++ b/src/test/java/net/masterthought/cucumber/ReportGenerator.java
@@ -116,6 +116,9 @@ public abstract class ReportGenerator {
     }
 
     private void createEmbeddingsDirectory() {
-        configuration.getEmbeddingDirectory().mkdirs();
+        final File embeddingDirectory = configuration.getEmbeddingDirectory();
+        if(!embeddingDirectory.exists() && !embeddingDirectory.mkdirs()){
+            throw new ValidationException("Failed to create: " + embeddingDirectory);
+        }
     }
 }


### PR DESCRIPTION
Check if embeddingDirectory can be created, otherwise throw ValidationException

sibling PR related to issue https://github.com/jenkinsci/cucumber-reports-plugin/issues/213: https://github.com/damianszczepanik/cucumber-reporting/pull/717