### PR TITLE
Update jackson-databind to address CVE-2018-7489

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.11.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>


### PR DESCRIPTION
Per #721, update jackson-databind from v2.8.6 to v2.8.11.1 to address [CVE-2018-7489](https://nvd.nist.gov/vuln/detail/CVE-2018-7489), a deserialization flaw with CVSS v3.0 Base Score of 9.8 (critical)

The fix for CVE-2018-7489 also addresses CVE-2017-15095 and CVE-2017-7525

Whilst the fix is also available in jackson-databind v2.9.5,  v2.8.11.1 was selected so as to be conservative (minimize risk) and because v3.x should be released shortly.