### PR TITLE
Fixes ERROR: Step ?Cucumber reports?

### DIFF
--- a/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
@@ -11,7 +11,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
+
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -109,13 +109,13 @@ public abstract class AbstractPage {
         context.put("build_time", formattedTime);
 
         // build number is not mandatory
-        String buildNumber = configuration.getBuildNumber();
-        if (StringUtils.isNotBlank(buildNumber) && configuration.isRunWithJenkins()) {
-            if (NumberUtils.isCreatable(buildNumber)) {
-                context.put("build_previous_number", Integer.parseInt(buildNumber) - 1);
-            } else {
-                LOG.log(Level.INFO, String.format("Could not parse build number: %1$s.", configuration.getBuildNumber()));
-            }
+        // the build number could contain " ". calling strip will return 'null' to
+        // buildNumber
+        String buildNumber = StringUtils.stripToNull(configuration.getBuildNumber());
+        if (StringUtils.isNumeric(buildNumber) && configuration.isRunWithJenkins()) {
+            context.put("build_previous_number", Integer.parseInt(buildNumber) - 1);
+        } else {
+             LOG.log(Level.INFO, String.format("Could not parse build number: %1$s.", configuration.getBuildNumber()));
         }
     }
 }


### PR DESCRIPTION
Fixes:

ERROR: Step ?Cucumber reports? aborted due to exception:
java.lang.NoSuchMethodError: org.apache.commons.lang3.math.NumberUtils.isCreatable(Ljava/lang/String;)Z
            at net.masterthought.cucumber.generators.AbstractPage.buildGeneralParameters(AbstractPage.java:114)
            at net.masterthought.cucumber.generators.AbstractPage.<init>(AbstractPage.java:52)
            at net.masterthought.cucumber.generators.FeaturesOverviewPage.<init>(FeaturesOverviewPage.java:12)
            at net.masterthought.cucumber.ReportBuilder.generatePages(ReportBuilder.java:151)
            at net.masterthought.cucumber.ReportBuilder.generateReports(ReportBuilder.java:98)
            at net.masterthought.jenkins.CucumberReportPublisher.generateReport(CucumberReportPublisher.java:300)
            at net.masterthought.jenkins.CucumberReportPublisher.perform(CucumberReportPublisher.java:229)
            at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:81)
            at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
            at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:744)
            at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:690)
            at hudson.maven.MavenModuleSetBuild$MavenModuleSetBuildExecution.post2(MavenModuleSetBuild.java:1073)
            at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:635)
            at hudson.model.Run.execute(Run.java:1749)
            at hudson.maven.MavenModuleSetBuild.run(MavenModuleSetBuild.java:543)
            at hudson.model.ResourceController.execute(ResourceController.java:97)
            at hudson.model.Executor.run(Executor.java:429)