### PR TITLE
Fixes #781: NPE with optional step arguments.

### DIFF
--- a/src/main/java/net/masterthought/cucumber/util/StepNameFormatter.java
+++ b/src/main/java/net/masterthought/cucumber/util/StepNameFormatter.java
@@ -31,6 +31,10 @@ public class StepNameFormatter {
 
     private static void surroundArguments(Argument[] arguments, String preArgument, String postArgument, String[] chars) {
         for (Argument argument : arguments) {
+            if (argument.getOffset() == null) {
+                continue;
+            }
+
             int start = argument.getOffset();
             int end = start + argument.getVal().length() - 1;
             chars[start] = preArgument + chars[start];

--- a/src/test/java/net/masterthought/cucumber/util/StepNameFormatterTest.java
+++ b/src/test/java/net/masterthought/cucumber/util/StepNameFormatterTest.java
@@ -79,6 +79,19 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
+    public void format_optionalArgumentNotMatched() {
+
+        // given
+        Step step = features.get(1).getElements()[0].getSteps()[0];
+
+        // when
+        String formatted = StepNameFormatter.format(step.getName(), step.getMatch().getArguments(), "<arg>", "</arg>");
+
+        // then
+        assertThat(formatted).isEqualTo("the account balance is <arg>100</arg>");
+    }
+
+    @Test
     public void format_shouldEscape() {
 
         // given

--- a/src/test/resources/json/sample.json
+++ b/src/test/resources/json/sample.json
@@ -348,7 +348,8 @@
                                 {
                                     "val": "100",
                                     "offset": 23
-                                }
+                                },
+                                {}
                             ]
                         },
                         "matchedColumns": [


### PR DESCRIPTION
When a step has an optional matching argument and the argument is not
matched, the JSON report has an empty object in place of that argument
in the match array. A check has been added to skip those empty
arguments.