### PR TITLE
Highlight step arguments by making them bold. (#771)

### DIFF
--- a/src/main/java/net/masterthought/cucumber/util/StepNameFormatter.java
+++ b/src/main/java/net/masterthought/cucumber/util/StepNameFormatter.java
@@ -1,11 +1,13 @@
 package net.masterthought.cucumber.util;
 
-import net.masterthought.cucumber.json.support.Argument;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import net.masterthought.cucumber.json.support.Argument;
+
 public class StepNameFormatter {
+
     public static final StepNameFormatter INSTANCE = new StepNameFormatter();
 
     public static String format(String stepName, Argument[] arguments, String preArgument, String postArgument) {
@@ -31,7 +33,7 @@ public class StepNameFormatter {
 
     private static void surroundArguments(Argument[] arguments, String preArgument, String postArgument, String[] chars) {
         for (Argument argument : arguments) {
-            if (argument.getOffset() == null) {
+            if (argument.getOffset() == null || StringUtils.isEmpty(argument.getVal())) {
                 continue;
             }
 

--- a/src/test/java/net/masterthought/cucumber/util/StepNameFormatterTest.java
+++ b/src/test/java/net/masterthought/cucumber/util/StepNameFormatterTest.java
@@ -2,19 +2,21 @@ package net.masterthought.cucumber.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import net.masterthought.cucumber.generators.integrations.PageTest;
-import net.masterthought.cucumber.json.Step;
 import org.junit.Before;
 import org.junit.Test;
 
+import net.masterthought.cucumber.generators.integrations.PageTest;
+import net.masterthought.cucumber.json.Step;
+
 public class StepNameFormatterTest extends PageTest {
+
     @Before
     public void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void format_noArguments() {
+    public void format_OnNoArgument_ReturnsUnchangedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[1];
@@ -23,11 +25,11 @@ public class StepNameFormatterTest extends PageTest {
         String formatted = StepNameFormatter.format(step.getName(), step.getMatch().getArguments(), "<arg>", "</arg>");
 
         // then
-        assertThat(formatted).isEqualTo("the card is valid");
+        assertThat(formatted).isEqualTo(step.getName());
     }
 
     @Test
-    public void format_endsWithArguments() {
+    public void format_OnLastPosition_ReturnsFormattedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[0];
@@ -40,7 +42,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_argumentInTheMiddle() {
+    public void format_ReturnsFormattedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[4];
@@ -53,7 +55,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_startsWithArgument() {
+    public void format_StartPosition_ReturnsFormattedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[2];
@@ -66,7 +68,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_twoArguments() {
+    public void format_OnMultipleArguments_ReturnsFormattedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[3];
@@ -75,7 +77,20 @@ public class StepNameFormatterTest extends PageTest {
         String formatted = StepNameFormatter.format(step.getName(), step.getMatch().getArguments(), "<arg>", "</arg>");
 
         // then
-        assertThat(formatted).isEqualTo("the Account Holder requests <arg>10</arg>, entering PIN <arg>1234</arg>");
+        assertThat(formatted).isEqualTo("the Account Holder  requests <arg>10</arg>, entering PIN <arg>1234</arg>");
+    }
+
+    @Test
+    public void format_OnEmptyValue_ReturnsUnchangedValue() {
+
+        // given
+        Step step = features.get(0).getElements()[1].getSteps()[3];
+
+        // when
+        String formatted = StepNameFormatter.format(step.getName(), step.getMatch().getArguments(), "<arg>", "</arg>");
+
+        // then
+        assertThat(formatted).isEqualTo("the Account Holder  requests <arg>10</arg>, entering PIN <arg>1234</arg>");
     }
 
     @Test
@@ -92,7 +107,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_shouldEscape() {
+    public void format_ReturnsEscapedValues() {
 
         // given
         String text = "I press <ON> & <C> simulatenously";

--- a/src/test/resources/json/sample.json
+++ b/src/test/resources/json/sample.json
@@ -200,18 +200,22 @@
                             "duration": 11000001,
                             "status": "passed"
                         },
-                        "name": "the Account Holder requests 10, entering PIN 1234",
+                        "name": "the Account Holder  requests 10, entering PIN 1234",
                         "keyword": "When ",
                         "line": 26,
                         "match": {
                             "arguments": [
                                 {
+                                    "val": "",
+                                    "offset": 19
+                                },
+                                {
                                     "val": "10",
-                                    "offset": 28
+                                    "offset": 29
                                 },
                                 {
                                     "val": "1234",
-                                    "offset": 45
+                                    "offset": 46
                                 }
                             ],
                             "location": "ATMScenario.requestMoney(int)"
@@ -349,7 +353,8 @@
                                     "val": "100",
                                     "offset": 23
                                 },
-                                {}
+                                {
+                                }
                             ]
                         },
                         "matchedColumns": [


### PR DESCRIPTION
 - when value for the argument is empty, formatting should be skipped

Issue #789 jenkinsci/cucumber-reports-plugin/issues/280