### PR TITLE
Fixes error when there is an empty match at end of string. Closes #789.

### DIFF
--- a/src/main/java/net/masterthought/cucumber/util/StepNameFormatter.java
+++ b/src/main/java/net/masterthought/cucumber/util/StepNameFormatter.java
@@ -31,15 +31,27 @@ public class StepNameFormatter {
 
     private static void surroundArguments(Argument[] arguments, String preArgument, String postArgument, String[] chars) {
         for (Argument argument : arguments) {
-            if (argument.getOffset() == null) {
+            if (isNotMatchedArgument(argument)) {
                 continue;
             }
 
             int start = argument.getOffset();
             int end = start + argument.getVal().length() - 1;
+            if (isArgumentAtEndOfString(start, chars)) {
+                continue;
+            }
+
             chars[start] = preArgument + chars[start];
             chars[end] = chars[end] + postArgument;
         }
+    }
+
+    private static boolean isNotMatchedArgument(Argument argument) {
+        return argument.getOffset() == null;
+    }
+
+    private static boolean isArgumentAtEndOfString(int start, String[] chars) {
+        return start >= chars.length;
     }
 
     private static void escape(String[] chars) {

--- a/src/test/java/net/masterthought/cucumber/util/StepNameFormatterTest.java
+++ b/src/test/java/net/masterthought/cucumber/util/StepNameFormatterTest.java
@@ -92,6 +92,19 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
+    public void format_emptyArgumentAtEndOfString() {
+
+        // given
+        Step step = features.get(1).getElements()[0].getSteps()[1];
+
+        // when
+        String formatted = StepNameFormatter.format(step.getName(), step.getMatch().getArguments(), "<arg>", "</arg>");
+
+        // then
+        assertThat(formatted).isEqualTo("the card is valid");
+    }
+
+    @Test
     public void format_shouldEscape() {
 
         // given

--- a/src/test/resources/json/sample.json
+++ b/src/test/resources/json/sample.json
@@ -379,6 +379,12 @@
                         "keyword": "And ",
                         "line": 8,
                         "match": {
+                            "arguments": [
+                                {
+                                    "val": "",
+                                    "offset": 17
+                                }
+                            ],
                             "location": "ATMScenario.createCreditCard()"
                         },
                         "after": [


### PR DESCRIPTION
When there is an empty match at the end of string, such as
@Given("^the card is valid(.*)$")
(with not extra text after "valid), an ArrayIndexOutOfBounds was
generated.