### PR TITLE
Fixes error when there is an empty match at end of string. Closes #789.

### DIFF
--- a/src/main/java/net/masterthought/cucumber/util/StepNameFormatter.java
+++ b/src/main/java/net/masterthought/cucumber/util/StepNameFormatter.java
@@ -31,7 +31,7 @@ public class StepNameFormatter {
 
     private static void surroundArguments(Argument[] arguments, String preArgument, String postArgument, String[] chars) {
         for (Argument argument : arguments) {
-            if (argument.getOffset() == null) {
+            if (argument.getOffset() == null || StringUtils.isEmpty(argument.getVal())) {
                 continue;
             }
 

--- a/src/test/java/net/masterthought/cucumber/util/StepNameFormatterTest.java
+++ b/src/test/java/net/masterthought/cucumber/util/StepNameFormatterTest.java
@@ -92,6 +92,19 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
+    public void format_emptyArgumentAtEndOfString() {
+
+        // given
+        Step step = features.get(1).getElements()[0].getSteps()[1];
+
+        // when
+        String formatted = StepNameFormatter.format(step.getName(), step.getMatch().getArguments(), "<arg>", "</arg>");
+
+        // then
+        assertThat(formatted).isEqualTo("the card is valid");
+    }
+
+    @Test
     public void format_shouldEscape() {
 
         // given

--- a/src/test/resources/json/sample.json
+++ b/src/test/resources/json/sample.json
@@ -379,6 +379,12 @@
                         "keyword": "And ",
                         "line": 8,
                         "match": {
+                            "arguments": [
+                                {
+                                    "val": "",
+                                    "offset": 17
+                                }
+                            ],
                             "location": "ATMScenario.createCreditCard()"
                         },
                         "after": [


### PR DESCRIPTION
When there is an empty match at the end of string, such as
@Given("^the card is valid(.*)$")
(with not extra text after "valid), an ArrayIndexOutOfBounds was
generated.

Also avoids wrapping empty arguments with unnecessary tags.