### PR TITLE
expand output and embed contents when EXPAND_ALL_STEPS config is used

### DIFF
--- a/src/main/resources/templates/macros/json/embeddings.vm
+++ b/src/main/resources/templates/macros/json/embeddings.vm
@@ -46,7 +46,7 @@
       <span class="download-button glyphicon glyphicon-download-alt"></span>
     </a>
   </div>
-  <div id="embedding-$embeddingId" class="collapse collapsable-details">
+  <div id="embedding-$embeddingId" class="collapse collapsable-details #if ($expand_all_steps) in #end">
     <div class="embedding-content">
       <div class="html-content">
         <iframe seamless="true" sandbox="allow-scripts" src="embeddings/$embedding.getFileName()" srcdoc="$embedding.getDecodedData()"></iframe>
@@ -66,7 +66,7 @@
         <span class="download-button glyphicon glyphicon-download-alt"></span>
       </a>
     </div>
-    <div id="embedding-$embeddingId" class="collapse collapsable-details">
+    <div id="embedding-$embeddingId" class="collapse collapsable-details #if ($expand_all_steps) in #end">
       <div class="embedding-content">
         <video width="854" height="480" controls>
           <source src="embeddings/$embedding.getFileName()" type="video/mp4">
@@ -87,7 +87,7 @@
         <span class="download-button glyphicon glyphicon-download-alt"></span>
       </a>
     </div>
-    <div id="embedding-$embeddingId" class="collapse collapsable-details">
+    <div id="embedding-$embeddingId" class="collapse collapsable-details #if ($expand_all_steps) in #end">
       <div class="embedding-content">
         <img src="embeddings/$embedding.getFileName()">
       </div>
@@ -105,7 +105,7 @@
         <span class="download-button glyphicon glyphicon-download-alt"></span>
       </a>
     </div>
-    <div id="embedding-$embeddingId" class="collapse collapsable-details">
+    <div id="embedding-$embeddingId" class="collapse collapsable-details #if ($expand_all_steps) in #end">
       <div class="embedding-content">
         <img src="$embedding.getDecodedData()">
       </div>
@@ -123,7 +123,8 @@
         <span class="download-button glyphicon glyphicon-download-alt"></span>
       </a>
     </div>
-    <div id="embedding-$embeddingId" class="collapse collapsable-details">
+
+    <div id="embedding-$embeddingId" class="collapse collapsable-details #if ($expand_all_steps) in #end">
       <pre class="embedding-content">$embedding.getDecodedData()</pre>
     </div>
   </div>
@@ -139,7 +140,7 @@
         <span class="download-button glyphicon glyphicon-download-alt"></span>
       </a>
     </div>
-    <div id="embedding-$embeddingId" class="collapse collapsable-details">
+    <div id="embedding-$embeddingId" class="collapse collapsable-details #if ($expand_all_steps) in #end">
         <pre class="embedding-content">This file cannot be displayed. Use download button to get the content as file.</pre>
     </div>
   </div>

--- a/src/main/resources/templates/macros/json/output.vm
+++ b/src/main/resources/templates/macros/json/output.vm
@@ -6,11 +6,11 @@
       #set($outputId = $counter.next())
       #set($index = $foreach.index + 1)
       <div class="output indention">
-        <div data-toggle="collapse" class="#if ($isPassed) collapsed #end collapsable-control" data-target="#output-$outputId">
+        <div data-toggle="collapse" class="#if ($isPassed && !$expand_all_steps) collapsed #end collapsable-control" data-target="#output-$outputId">
           Output $index
           <i class="chevron fa fa-fw"></i>
         </div>
-        <div id="output-$outputId" class="collapse collapsable-details #if (!$isPassed) in #end" #if (!$isPassed) aria-expanded="true" #end>
+        <div id="output-$outputId" class="collapse collapsable-details #if (!$isPassed || $expand_all_steps) in #end" #if (!$isPassed || $expand_all_steps) aria-expanded="true" #end>
           #**
            * DO NOT format the line below. Whitespace nodes are significant in a pre-block.
            *#
@@ -20,5 +20,4 @@
     #end
   </div>
 #end
-
 #end


### PR DESCRIPTION
@damianszczepanik - as discussed, this PR adds capability to expand output and embed contents when EXPAND_ALL_STEPS config is used.

resolves #872 