### PR TITLE
Update velocity to 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
             <id>release-sign-artifacts</id>
             <activation>
                 <property>
-                    <!-- will be set by the release plugin upon performing 
+                    <!-- will be set by the release plugin upon performing
                          mvn release:clean release:prepare release:perform -->
                     <name>performRelease</name>
                     <value>true</value>
@@ -213,25 +213,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
-            <version>1.7</version>
+            <artifactId>velocity-engine-core</artifactId>
+            <version>2.1</version>
         </dependency>
         <dependency>
             <artifactId>commons-collections</artifactId>
             <groupId>commons-collections</groupId>
             <version>3.2.2</version>
-        </dependency>
-        <dependency>
-            <groupId>velocity-tools</groupId>
-            <artifactId>velocity-tools</artifactId>
-            <exclusions>
-                <!-- force update dependencies due to https://cwe.mitre.org/data/definitions/502.html -->
-                <exclusion>
-                    <artifactId>commons-collections</artifactId>
-                    <groupId>commons-collections</groupId>
-                </exclusion>
-            </exclusions>
-            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
@@ -85,8 +85,8 @@ public abstract class AbstractPage {
 
     private Properties buildProperties() {
         Properties props = new Properties();
-        props.setProperty("resource.loader", "class");
-        props.setProperty("class.resource.loader.class", ClasspathResourceLoader.class.getCanonicalName());
+        props.setProperty("resource.loaders", "class");
+        props.setProperty("resource.loader.class.class", ClasspathResourceLoader.class.getCanonicalName());
         props.setProperty("runtime.log", new File(configuration.getReportDirectory(), "velocity.log").getPath());
 
         return props;

--- a/src/main/java/net/masterthought/cucumber/generators/EscapeHtmlReference.java
+++ b/src/main/java/net/masterthought/cucumber/generators/EscapeHtmlReference.java
@@ -2,6 +2,7 @@ package net.masterthought.cucumber.generators;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.velocity.app.event.ReferenceInsertionEventHandler;
+import org.apache.velocity.context.Context;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.PolicyFactory;
 
@@ -18,7 +19,7 @@ final class EscapeHtmlReference implements ReferenceInsertionEventHandler {
             .toFactory();
 
     @Override
-    public Object referenceInsert(String reference, Object value) {
+    public Object referenceInsert(Context context, String reference, Object value) {
         if (value == null) {
             return null;
         } else if(reference.startsWith("$_sanitize_")) {

--- a/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
@@ -103,8 +103,8 @@ public class AbstractPageTest extends PageTest {
 
         // then
         assertThat(props).hasSize(3);
-        assertThat(props.getProperty("resource.loader")).isNotNull();
-        assertThat(props.getProperty("class.resource.loader.class")).isNotNull();
+        assertThat(props.getProperty("resource.loaders")).isNotNull();
+        assertThat(props.getProperty("resource.loader.class.class")).isNotNull();
         assertThat(props.getProperty("runtime.log")).isNotNull();
     }
 

--- a/src/test/java/net/masterthought/cucumber/generators/EscapeHtmlReferenceTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/EscapeHtmlReferenceTest.java
@@ -20,7 +20,7 @@ public class EscapeHtmlReferenceTest {
         String normalText = "a plain statement";
 
         // when
-        Object result = insertionEventHandler.referenceInsert(SOME_REFERENCE, normalText);
+        Object result = insertionEventHandler.referenceInsert(null, SOME_REFERENCE, normalText);
 
         // then
         assertThat(result).isEqualTo(normalText);
@@ -32,7 +32,7 @@ public class EscapeHtmlReferenceTest {
         String html = "<b>a bold statement</b>";
 
         // when
-        Object result = insertionEventHandler.referenceInsert(SOME_REFERENCE, html);
+        Object result = insertionEventHandler.referenceInsert(null, SOME_REFERENCE, html);
 
         // then
         assertThat(result).isEqualTo(escapeHtml(html));
@@ -44,7 +44,7 @@ public class EscapeHtmlReferenceTest {
         String html = "<b>a bold statement</b>";
 
         // when
-        Object result = insertionEventHandler.referenceInsert("$_noescape_" + SOME_REFERENCE, html);
+        Object result = insertionEventHandler.referenceInsert(null, "$_noescape_" + SOME_REFERENCE, html);
 
         // then
         assertThat(result).isEqualTo(html);
@@ -56,7 +56,7 @@ public class EscapeHtmlReferenceTest {
         String html = null;
 
         // when
-        Object result = insertionEventHandler.referenceInsert(SOME_REFERENCE, html);
+        Object result = insertionEventHandler.referenceInsert(null, SOME_REFERENCE, html);
 
         // then
         assertThat(result).isNull();
@@ -68,7 +68,7 @@ public class EscapeHtmlReferenceTest {
         String html = "<a href=\"www.example.com\" rel=\"nofollow noopener noreferrer\">a hyper web reference</a>";
 
         // when
-        Object result = insertionEventHandler.referenceInsert("$_sanitize_" + SOME_REFERENCE, html);
+        Object result = insertionEventHandler.referenceInsert(null, "$_sanitize_" + SOME_REFERENCE, html);
 
         // result
         assertThat(result).isEqualTo(html);


### PR DESCRIPTION
Hi there

I've been having some problems with version conflicts between the gradle form of this plugin and owasp gradle plugin as both are using different versions of velocity and I can't seem to get the gradle buildscript to do what I want dependency wise. 

Velocity version is currently at 2.1 (which is what the owasp plugin is using) so I've updated this, removed a redundant depedency on velocity-tools (looks like it was used for the escape tool along while back) and fixed a few deprecation warnings wrt property name changes :-)

The generated demo report looks identical to the hosted one and all tests passed locally.