### PR TITLE
Build URL and Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ jsonFiles.add("cucumber-report-2.json");
 
 String buildNumber = "1";
 String projectName = "cucumberProject";
+// optional, for other CI environments
+String buildUrl = "http://some/ci/setup/build";
+String buildName = "Build #123 (Git ...)";
 
 Configuration configuration = new Configuration(reportOutputDirectory, projectName);
 // optional configuration - check javadoc for details
@@ -54,6 +57,9 @@ configuration.addPresentationModes(PresentationMode.RUN_WITH_JENKINS);
 // do not make scenario failed when step has status SKIPPED
 configuration.setNotFailingStatuses(Collections.singleton(Status.SKIPPED));
 configuration.setBuildNumber(buildNumber);
+// optional
+configuration.setBuildUrl(buildUrl);
+configuration.setBuildName(buildName);
 // addidtional metadata presented on main page
 configuration.addClassifications("Platform", "Windows");
 configuration.addClassifications("Browser", "Firefox");

--- a/src/main/java/net/masterthought/cucumber/Configuration.java
+++ b/src/main/java/net/masterthought/cucumber/Configuration.java
@@ -25,6 +25,8 @@ public class Configuration {
     private File trendsFile;
     private int trendsLimit;
     private String buildNumber;
+    private String buildName;
+    private String buildUrl;
     private String projectName;
 
     private List<Map.Entry<String, String>> classifications = new ArrayList<>();
@@ -125,6 +127,42 @@ public class Configuration {
      */
     public void setBuildNumber(String buildNumber) {
         this.buildNumber = buildNumber;
+    }
+
+    /**
+     * Gets the build name for this report.
+     *
+     * @return build name
+     */
+    public String getBuildName() {
+        return buildName;
+    }
+
+    /**
+     * Sets the name of the build, used for the generated link
+     *
+     * @param buildName name of the build
+     */
+    public void setBuildName(String buildName) {
+        this.buildName = buildName;
+    }
+
+    /**
+     * Gets the build URL for this report.
+     *
+     * @return build url
+     */
+    public String getBuildUrl() {
+        return buildUrl;
+    }
+
+    /**
+     * Sets the HTTP URL of the build, used for the generated link
+     *
+     * @param buildUrl URL of the build
+     */
+    public void setBuildUrl(String buildUrl) {
+        this.buildUrl = buildUrl;
     }
 
     /**

--- a/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
@@ -1,23 +1,5 @@
 package net.masterthought.cucumber.generators;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
-import org.apache.velocity.Template;
-import org.apache.velocity.VelocityContext;
-import org.apache.velocity.app.VelocityEngine;
-import org.apache.velocity.app.event.EventCartridge;
-import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
-
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportBuilder;
 import net.masterthought.cucumber.ReportResult;
@@ -27,6 +9,19 @@ import net.masterthought.cucumber.reducers.ReducingMethod;
 import net.masterthought.cucumber.util.Counter;
 import net.masterthought.cucumber.util.StepNameFormatter;
 import net.masterthought.cucumber.util.Util;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.velocity.Template;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.app.event.EventCartridge;
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Delivers common methods for page generation.
@@ -114,10 +109,10 @@ public abstract class AbstractPage {
         String buildUrl = configuration.getBuildUrl();
         if (StringUtils.isNotBlank(buildUrl)) {
             context.put("build_url", buildUrl);
-            String buildName = configuration.getBuildName();
-            if (StringUtils.isBlank(buildName)) {
-                buildName = "Build #" + configuration.getBuildNumber();
-            }
+            String buildName = StringUtils.defaultIfBlank(
+                    configuration.getBuildName(),
+                    "Build #" + configuration.getBuildNumber()
+            );
             context.put("build_name", buildName);
         }
 

--- a/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
@@ -111,6 +111,16 @@ public abstract class AbstractPage {
         context.put("build_project_name", configuration.getProjectName());
         context.put("build_number", configuration.getBuildNumber());
 
+        String buildUrl = configuration.getBuildUrl();
+        if (StringUtils.isNotBlank(buildUrl)) {
+            context.put("build_url", buildUrl);
+            String buildName = configuration.getBuildName();
+            if (StringUtils.isBlank(buildName)) {
+                buildName = "Build #" + configuration.getBuildNumber();
+            }
+            context.put("build_name", buildName);
+        }
+
         // if report generation fails then report is null
         String formattedTime = reportResult != null ? reportResult.getBuildTime() : ReportResult.getCurrentTime();
         context.put("build_time", formattedTime);

--- a/src/main/resources/templates/macros/page/buildinfo.vm
+++ b/src/main/resources/templates/macros/page/buildinfo.vm
@@ -7,6 +7,9 @@
       #if($build_number)
         <th>Number</th>
       #end
+      #if($build_url)
+        <th>Link</th>
+      #end
       <th>Date</th>
     </tr>
   </thead>
@@ -15,6 +18,9 @@
       <td>$build_project_name</td>
       #if($build_number)
         <td>$build_number</td>
+      #end
+      #if($build_url)
+        <td><a href="$build_url">$build_name</a></td>
       #end
       <td>$build_time</td>
     </tr>

--- a/src/test/java/net/masterthought/cucumber/ConfigurationTest.java
+++ b/src/test/java/net/masterthought/cucumber/ConfigurationTest.java
@@ -128,6 +128,36 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void getBuildUrl_ReturnsBuildUrl() {
+
+        // given
+        Configuration configuration = new Configuration(outputDirectory, projectName);
+        String buildUrl = "http://somehost/something";
+        configuration.setBuildUrl(buildUrl);
+
+        // when
+        String build = configuration.getBuildUrl();
+
+        // then
+        assertThat(build).isEqualTo(buildUrl);
+    }
+
+    @Test
+    public void getBuildName_ReturnsBuildName() {
+
+        // given
+        Configuration configuration = new Configuration(outputDirectory, projectName);
+        String buildName = "123xyz";
+        configuration.setBuildName(buildName);
+
+        // when
+        String build = configuration.getBuildName();
+
+        // then
+        assertThat(build).isEqualTo(buildName);
+    }
+
+    @Test
     public void getProjectName_ReturnsProjectName() {
 
         // given

--- a/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
@@ -114,6 +114,8 @@ public class AbstractPageTest extends PageTest {
         // given
         configuration.addReducingMethod(ReducingMethod.HIDE_EMPTY_HOOKS);
         configuration.addPresentationModes(PresentationMode.EXPAND_ALL_STEPS);
+        configuration.setBuildUrl("http://some/build/url");
+        configuration.setBuildName("123foo");
         page = new TagsOverviewPage(reportResult, configuration);
 
         // when
@@ -121,7 +123,7 @@ public class AbstractPageTest extends PageTest {
 
         // then
         VelocityContext context = page.context;
-        assertThat(context.getKeys()).hasSize(10);
+        assertThat(context.getKeys()).hasSize(12);
 
         Object obj = context.get("counter");
         assertThat(obj).isInstanceOf(Counter.class);
@@ -137,6 +139,26 @@ public class AbstractPageTest extends PageTest {
 
         assertThat(context.get("build_project_name")).isEqualTo(configuration.getProjectName());
         assertThat(context.get("build_number")).isEqualTo(configuration.getBuildNumber());
+        assertThat(context.get("build_url")).isEqualTo(configuration.getBuildUrl());
+        assertThat(context.get("build_name")).isEqualTo(configuration.getBuildName());
+    }
+
+    @Test
+    public void buildGeneralParameters_FallsBackToDefaultBuildName() {
+
+        // given
+        configuration.addReducingMethod(ReducingMethod.HIDE_EMPTY_HOOKS);
+        configuration.addPresentationModes(PresentationMode.EXPAND_ALL_STEPS);
+        configuration.setBuildUrl("http://some/build/url");
+        configuration.setBuildNumber("12");
+        page = new TagsOverviewPage(reportResult, configuration);
+
+        // when
+        // buildGeneralParameters() already called by constructor
+
+        // then
+        VelocityContext context = page.context;
+        assertThat(context.get("build_name")).isEqualTo("Build #" + configuration.getBuildNumber());
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/PageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/PageIntegrationTest.java
@@ -122,16 +122,17 @@ public class PageIntegrationTest extends PageTest {
         headValues.hasExactValues("Project", "Date");
 
         assertThat(buildInfo.getProjectName()).isEqualTo(configuration.getProjectName());
-        buildInfo.hasBuildDate(false);
+        buildInfo.hasBuildDate(false, false);
     }
 
     @Test
-    public void generatePage_onJenkinsConfiguration_generatesSummaryTableWithBuildNumber() {
+    public void generatePage_onJenkinsConfiguration_generatesSummaryTableWithBuildNumberAndUrl() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
         configuration.addPresentationModes(PresentationMode.RUN_WITH_JENKINS);
         configuration.setBuildNumber("123");
+        configuration.setBuildUrl("http://some/host/url");
 
         page = new StepsOverviewPage(reportResult, configuration);
 
@@ -143,11 +144,38 @@ public class PageIntegrationTest extends PageTest {
         BuildInfoAssertion buildInfo = document.getBuildInfo();
 
         TableRowAssertion headValues = buildInfo.getHeaderRow();
-        headValues.hasExactValues("Project", "Number", "Date");
+        headValues.hasExactValues("Project", "Number", "Link", "Date");
 
         assertThat(buildInfo.getProjectName()).isEqualTo(configuration.getProjectName());
         assertThat(buildInfo.getBuildNumber()).isEqualTo(configuration.getBuildNumber());
-        buildInfo.hasBuildDate(true);
+        buildInfo.hasBuildLink("http://some/host/url", "Build #123");
+        buildInfo.hasBuildDate(true, true);
+    }
+
+    @Test
+    public void generatePage_onJenkinsConfiguration_generatesSummaryTableWithBuildNameAndUrl() {
+
+        // given
+        setUpWithJson(SAMPLE_JSON);
+        configuration.addPresentationModes(PresentationMode.RUN_WITH_JENKINS);
+        configuration.setBuildName("My awesome build");
+        configuration.setBuildUrl("http://some/host/url");
+
+        page = new StepsOverviewPage(reportResult, configuration);
+
+        // when
+        page.generatePage();
+
+        // then
+        DocumentAssertion document = documentFrom(page.getWebPage());
+        BuildInfoAssertion buildInfo = document.getBuildInfo();
+
+        TableRowAssertion headValues = buildInfo.getHeaderRow();
+        headValues.hasExactValues("Project", "Link", "Date");
+
+        assertThat(buildInfo.getProjectName()).isEqualTo(configuration.getProjectName());
+        buildInfo.hasBuildLink("http://some/host/url", "My awesome build");
+        buildInfo.hasBuildDate(false, true);
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/PageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/PageIntegrationTest.java
@@ -148,7 +148,7 @@ public class PageIntegrationTest extends PageTest {
 
         assertThat(buildInfo.getProjectName()).isEqualTo(configuration.getProjectName());
         assertThat(buildInfo.getBuildNumber()).isEqualTo(configuration.getBuildNumber());
-        buildInfo.hasBuildLink("http://some/host/url", "Build #123");
+        buildInfo.hasBuildLink(true, "http://some/host/url", "Build #123");
         buildInfo.hasBuildDate(true, true);
     }
 
@@ -174,7 +174,7 @@ public class PageIntegrationTest extends PageTest {
         headValues.hasExactValues("Project", "Link", "Date");
 
         assertThat(buildInfo.getProjectName()).isEqualTo(configuration.getProjectName());
-        buildInfo.hasBuildLink("http://some/host/url", "My awesome build");
+        buildInfo.hasBuildLink(false, "http://some/host/url", "My awesome build");
         buildInfo.hasBuildDate(false, true);
     }
 

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/BuildInfoAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/BuildInfoAssertion.java
@@ -1,5 +1,8 @@
 package net.masterthought.cucumber.generators.integrations.helpers;
 
+import java.util.Locale;
+import java.util.regex.Pattern;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -19,10 +22,18 @@ public class BuildInfoAssertion extends TableAssertion {
         return cells[1].text();
     }
 
-    public void hasBuildDate(boolean withBuildNumber) {
+    public void hasBuildDate(boolean withBuildNumber, boolean withBuildLink) {
         // date format: dd MMM yyyy, HH:mm
         WebAssertion[] cells = getBodyRow().getCells();
-        assertThat(cells).hasSize(withBuildNumber ? 3 : 2);
-        assertThat(cells[withBuildNumber ? 2 : 1].text()).matches("^[0-3][0-9] \\w{3} \\d{4}, \\d{2}:\\d{2}$");
+        assertThat(cells).hasSize(withBuildNumber ? withBuildLink ? 4 : 3 : 2);
+        assertThat(cells[withBuildNumber ? withBuildLink ? 3 : 2 : 1].text())
+                .matches("^[0-3][0-9] \\w{3} \\d{4}, \\d{2}:\\d{2}$");
+    }
+
+    public void hasBuildLink(String buildUrl, String buildName) {
+        WebAssertion[] cells = getBodyRow().getCells();
+        assertThat(cells.length).isGreaterThan(2);
+        assertThat(cells[2].text())
+                .matches(String.format("href=\"%s\">%s<", Pattern.quote(buildUrl), Pattern.quote(buildName)));
     }
 }

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/BuildInfoAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/BuildInfoAssertion.java
@@ -1,8 +1,5 @@
 package net.masterthought.cucumber.generators.integrations.helpers;
 
-import java.util.Locale;
-import java.util.regex.Pattern;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -34,6 +31,6 @@ public class BuildInfoAssertion extends TableAssertion {
         WebAssertion[] cells = getBodyRow().getCells();
         assertThat(cells.length).isGreaterThan(2);
         assertThat(cells[2].text())
-                .matches(String.format("href=\"%s\">%s<", Pattern.quote(buildUrl), Pattern.quote(buildName)));
+                .contains(String.format("<a href=\"%s\">%s</a>", buildUrl, buildName));
     }
 }

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/BuildInfoAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/BuildInfoAssertion.java
@@ -22,15 +22,18 @@ public class BuildInfoAssertion extends TableAssertion {
     public void hasBuildDate(boolean withBuildNumber, boolean withBuildLink) {
         // date format: dd MMM yyyy, HH:mm
         WebAssertion[] cells = getBodyRow().getCells();
-        assertThat(cells).hasSize(withBuildNumber ? withBuildLink ? 4 : 3 : 2);
-        assertThat(cells[withBuildNumber ? withBuildLink ? 3 : 2 : 1].text())
+        int columnCount = 2;
+        if (withBuildNumber) columnCount++;
+        if (withBuildLink) columnCount++;
+        assertThat(cells).hasSize(columnCount);
+        assertThat(cells[columnCount -1].text())
                 .matches("^[0-3][0-9] \\w{3} \\d{4}, \\d{2}:\\d{2}$");
     }
 
-    public void hasBuildLink(String buildUrl, String buildName) {
+    public void hasBuildLink(boolean withBuildNumber, String buildUrl, String buildName) {
         WebAssertion[] cells = getBodyRow().getCells();
-        assertThat(cells.length).isGreaterThan(2);
-        assertThat(cells[2].text())
+        assertThat(cells).hasSize(withBuildNumber ? 4 : 3);
+        assertThat(cells[withBuildNumber ? 2 : 1].html())
                 .contains(String.format("<a href=\"%s\">%s</a>", buildUrl, buildName));
     }
 }


### PR DESCRIPTION
Add a globally configurable build name and URL that is rendered on top of every page, in the buildInfo section.

Closes #902 