### PR TITLE
Sync version of jackson dependencies up to 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.1</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
Hi, @damianszczepanik !
This is a downgrade of com.fasterxml.jackson.datatype:jackson-datatype-jsr310 to 2.9.10 to avoid an issue with Enforser plugin in the following project https://github.com/jenkinsci/cucumber-reports-plugin