### PR TITLE
Provides optional ability to not render specified charts

### DIFF
--- a/src/main/java/net/masterthought/cucumber/Configuration.java
+++ b/src/main/java/net/masterthought/cucumber/Configuration.java
@@ -5,6 +5,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import net.masterthought.cucumber.chart.ChartType;
 import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.presentation.PresentationMode;
 import net.masterthought.cucumber.reducers.ReducingMethod;
@@ -36,6 +37,15 @@ public class Configuration {
     private Set<Status> notFailingStatuses = Collections.emptySet();
 
     private Map<String, String> qualifiers = new Hashtable<>();
+
+    // List of charts that can be optionally excluded from being rendered.
+    // Default behavior is to render all charts.
+    private final List<ChartType> chartsToRender = new ArrayList<>(
+        Arrays.asList(
+            ChartType.FEATURES_STATISTICS,
+            ChartType.TAGS_STATISTICS
+        )
+    );
 
     public Configuration(File reportDirectory, String projectName) {
         this.reportDirectory = reportDirectory;
@@ -341,5 +351,26 @@ public class Configuration {
      */
     public void removeQualifier(@NonNull String jsonFileName) {
         qualifiers.remove(jsonFileName);
+    }
+
+    /**
+     * Exclude the specified {@link ChartType} from being rendered.
+     *
+     * @param chartTypes charts not to be rendered
+     */
+    public void chartsNotToRender(@NonNull ChartType... chartTypes) {
+        for (ChartType chartType : chartTypes) {
+            this.chartsToRender.remove(chartType);
+        }
+    }
+
+    /**
+     * Checks if the configuration has given {@link ChartType} set for rendering.
+     *
+     * @param chartType to be checked if set in configuration
+     * @return <code>true</code> if {@link ChartType} is set for rendering, otherwise <code>false</code>
+     */
+    public boolean containsChartToRender(@NonNull ChartType chartType) {
+        return chartsToRender.contains(chartType);
     }
 }

--- a/src/main/java/net/masterthought/cucumber/Configuration.java
+++ b/src/main/java/net/masterthought/cucumber/Configuration.java
@@ -354,11 +354,11 @@ public class Configuration {
     }
 
     /**
-     * Exclude the specified {@link ChartType} from being rendered.
+     * Remove the specified {@link ChartType} from being rendered.
      *
      * @param chartTypes charts not to be rendered
      */
-    public void chartsNotToRender(@NonNull ChartType... chartTypes) {
+    public void removeChartsToRender(@NonNull ChartType... chartTypes) {
         for (ChartType chartType : chartTypes) {
             this.chartsToRender.remove(chartType);
         }

--- a/src/main/java/net/masterthought/cucumber/chart/ChartType.java
+++ b/src/main/java/net/masterthought/cucumber/chart/ChartType.java
@@ -1,0 +1,14 @@
+package net.masterthought.cucumber.chart;
+
+public enum ChartType {
+
+    /**
+     * Feature Statistics Chart rendered on overview-features page
+     */
+    FEATURES_STATISTICS,
+
+    /**
+     * Tags Statistics Chart rendered on overview-tags page
+     */
+    TAGS_STATISTICS
+}

--- a/src/main/java/net/masterthought/cucumber/generators/FeaturesOverviewPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/FeaturesOverviewPage.java
@@ -1,9 +1,11 @@
 package net.masterthought.cucumber.generators;
 
+import java.util.List;
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportBuilder;
 import net.masterthought.cucumber.ReportResult;
 import net.masterthought.cucumber.chart.ChartType;
+import net.masterthought.cucumber.json.Feature;
 import net.masterthought.cucumber.presentation.PresentationMode;
 
 public class FeaturesOverviewPage extends AbstractPage {
@@ -21,9 +23,10 @@ public class FeaturesOverviewPage extends AbstractPage {
 
     @Override
     public void prepareReport() {
-        // Check if chart is to be rendered
-        context.put("render_feature_chart", configuration.containsChartToRender(ChartType.FEATURES_STATISTICS));
-        context.put("all_features", reportResult.getAllFeatures());
+        final boolean renderFeatureChart = configuration.containsChartToRender(ChartType.FEATURES_STATISTICS);
+        final List<Feature> allFeatures = reportResult.getAllFeatures();
+        context.put("render_feature_chart", (renderFeatureChart && !allFeatures.isEmpty()));
+        context.put("all_features", allFeatures);
         context.put("report_summary", reportResult.getFeatureReport());
 
         context.put("parallel_testing", configuration.containsPresentationMode(PresentationMode.PARALLEL_TESTING));

--- a/src/main/java/net/masterthought/cucumber/generators/FeaturesOverviewPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/FeaturesOverviewPage.java
@@ -3,6 +3,7 @@ package net.masterthought.cucumber.generators;
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportBuilder;
 import net.masterthought.cucumber.ReportResult;
+import net.masterthought.cucumber.chart.ChartType;
 import net.masterthought.cucumber.presentation.PresentationMode;
 
 public class FeaturesOverviewPage extends AbstractPage {
@@ -20,6 +21,8 @@ public class FeaturesOverviewPage extends AbstractPage {
 
     @Override
     public void prepareReport() {
+        // Check if chart is to be rendered
+        context.put("render_feature_chart", configuration.containsChartToRender(ChartType.FEATURES_STATISTICS));
         context.put("all_features", reportResult.getAllFeatures());
         context.put("report_summary", reportResult.getFeatureReport());
 

--- a/src/main/java/net/masterthought/cucumber/generators/TagsOverviewPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/TagsOverviewPage.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportResult;
+import net.masterthought.cucumber.chart.ChartType;
 import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.TagObject;
 import net.masterthought.cucumber.util.Util;
@@ -27,6 +28,8 @@ public class TagsOverviewPage extends AbstractPage {
     @Override
     public void prepareReport() {
         List<TagObject> tags = reportResult.getAllTags();
+        // Check if chart is to be rendered
+        context.put("render_tags_chart", configuration.containsChartToRender(ChartType.TAGS_STATISTICS));
         context.put("all_tags", tags);
         context.put("report_summary", reportResult.getTagReport());
 

--- a/src/main/java/net/masterthought/cucumber/generators/TagsOverviewPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/TagsOverviewPage.java
@@ -27,9 +27,9 @@ public class TagsOverviewPage extends AbstractPage {
 
     @Override
     public void prepareReport() {
+        final boolean renderTagsChart = configuration.containsChartToRender(ChartType.TAGS_STATISTICS);
         List<TagObject> tags = reportResult.getAllTags();
-        // Check if chart is to be rendered
-        context.put("render_tags_chart", configuration.containsChartToRender(ChartType.TAGS_STATISTICS));
+        context.put("render_tags_chart", (renderTagsChart && !tags.isEmpty()));
         context.put("all_tags", tags);
         context.put("report_summary", reportResult.getTagReport());
 

--- a/src/main/resources/templates/generators/overviewFeatures.vm
+++ b/src/main/resources/templates/generators/overviewFeatures.vm
@@ -17,7 +17,7 @@
 
 #includeReportInfo()
 
-#if($render_feature_chart && !$all_features.isEmpty())
+#if($render_feature_chart)
 
   #includeLead("Features Statistics", "The following graphs show passing and failing statistics for features")
 

--- a/src/main/resources/templates/generators/overviewFeatures.vm
+++ b/src/main/resources/templates/generators/overviewFeatures.vm
@@ -17,10 +17,10 @@
 
 #includeReportInfo()
 
-#includeLead("Features Statistics", "The following graphs show passing and failing statistics for features")
+#if($render_feature_chart && !$all_features.isEmpty())
 
+  #includeLead("Features Statistics", "The following graphs show passing and failing statistics for features")
 
-#if(!$all_features.isEmpty())
   <div class="container-fluid" id="charts">
     <div class="row">
       <div class="col-md-6 col-md-offset-3">
@@ -60,10 +60,11 @@
       </div>
     </div>
   </div>
-  <br/>
+#else
+  #includeLead("Features Overview")
 #end
 
-
+<br/>
 <div class="container-fluid" id="report">
   <div class="row">
     <div class="col-md-10 col-md-offset-1">

--- a/src/main/resources/templates/generators/overviewTags.vm
+++ b/src/main/resources/templates/generators/overviewTags.vm
@@ -14,10 +14,10 @@
 
 #includeReportInfo()
 
-#includeLead("Tags Statistics", "The following graph shows passing and failing statistics for tags")
+#if($render_tags_chart && !$all_tags.isEmpty())
 
+  #includeLead("Tags Statistics", "The following graph shows passing and failing statistics for tags")
 
-#if(!$all_tags.isEmpty())
   <div class="container-fluid" id="charts">
     <div class="row">
       <div class="col-md-10 col-md-offset-1">
@@ -25,6 +25,8 @@
       </div>
     </div>
   </div>
+#else
+  #includeLead("Tags Overview")
 #end
 
 <br/>

--- a/src/main/resources/templates/generators/overviewTags.vm
+++ b/src/main/resources/templates/generators/overviewTags.vm
@@ -14,7 +14,7 @@
 
 #includeReportInfo()
 
-#if($render_tags_chart && !$all_tags.isEmpty())
+#if($render_tags_chart)
 
   #includeLead("Tags Statistics", "The following graph shows passing and failing statistics for tags")
 

--- a/src/test/java/net/masterthought/cucumber/ConfigurationTest.java
+++ b/src/test/java/net/masterthought/cucumber/ConfigurationTest.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import net.masterthought.cucumber.chart.ChartType;
 import org.junit.Test;
 
 import net.masterthought.cucumber.json.support.Status;
@@ -419,5 +420,53 @@ public class ConfigurationTest {
 
         // then
         assertThat(configuration.getNotFailingStatuses()).containsExactly(notFailingStatus);
+    }
+
+    @Test
+    public void chartsNotToRender_FEATURES_STATISTICS() {
+
+        // given
+        Configuration configuration = new Configuration(outputDirectory, projectName);
+        assertThat(configuration.containsChartToRender(ChartType.FEATURES_STATISTICS)).isTrue();
+        assertThat(configuration.containsChartToRender(ChartType.TAGS_STATISTICS)).isTrue();
+
+        // when
+        configuration.chartsNotToRender(ChartType.FEATURES_STATISTICS);
+
+        // then
+        assertThat(configuration.containsChartToRender(ChartType.FEATURES_STATISTICS)).isFalse();
+        assertThat(configuration.containsChartToRender(ChartType.TAGS_STATISTICS)).isTrue();
+    }
+
+    @Test
+    public void chartsNotToRender_TAGS_STATISTICS() {
+
+        // given
+        Configuration configuration = new Configuration(outputDirectory, projectName);
+        assertThat(configuration.containsChartToRender(ChartType.FEATURES_STATISTICS)).isTrue();
+        assertThat(configuration.containsChartToRender(ChartType.TAGS_STATISTICS)).isTrue();
+
+        // when
+        configuration.chartsNotToRender(ChartType.TAGS_STATISTICS);
+
+        // then
+        assertThat(configuration.containsChartToRender(ChartType.FEATURES_STATISTICS)).isTrue();
+        assertThat(configuration.containsChartToRender(ChartType.TAGS_STATISTICS)).isFalse();
+    }
+
+    @Test
+    public void chartsNotToRender_All() {
+
+        // given
+        Configuration configuration = new Configuration(outputDirectory, projectName);
+        assertThat(configuration.containsChartToRender(ChartType.FEATURES_STATISTICS)).isTrue();
+        assertThat(configuration.containsChartToRender(ChartType.TAGS_STATISTICS)).isTrue();
+
+        // when
+        configuration.chartsNotToRender(ChartType.FEATURES_STATISTICS, ChartType.TAGS_STATISTICS);
+
+        // then
+        assertThat(configuration.containsChartToRender(ChartType.FEATURES_STATISTICS)).isFalse();
+        assertThat(configuration.containsChartToRender(ChartType.TAGS_STATISTICS)).isFalse();
     }
 }

--- a/src/test/java/net/masterthought/cucumber/ConfigurationTest.java
+++ b/src/test/java/net/masterthought/cucumber/ConfigurationTest.java
@@ -423,15 +423,13 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void chartsNotToRender_FEATURES_STATISTICS() {
+    public void removeChartsToRender_RemoveFeaturesChart() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
-        assertThat(configuration.containsChartToRender(ChartType.FEATURES_STATISTICS)).isTrue();
-        assertThat(configuration.containsChartToRender(ChartType.TAGS_STATISTICS)).isTrue();
 
         // when
-        configuration.chartsNotToRender(ChartType.FEATURES_STATISTICS);
+        configuration.removeChartsToRender(ChartType.FEATURES_STATISTICS);
 
         // then
         assertThat(configuration.containsChartToRender(ChartType.FEATURES_STATISTICS)).isFalse();
@@ -439,15 +437,13 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void chartsNotToRender_TAGS_STATISTICS() {
+    public void removeChartsToRender_RemoveTagsChart() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
-        assertThat(configuration.containsChartToRender(ChartType.FEATURES_STATISTICS)).isTrue();
-        assertThat(configuration.containsChartToRender(ChartType.TAGS_STATISTICS)).isTrue();
 
         // when
-        configuration.chartsNotToRender(ChartType.TAGS_STATISTICS);
+        configuration.removeChartsToRender(ChartType.TAGS_STATISTICS);
 
         // then
         assertThat(configuration.containsChartToRender(ChartType.FEATURES_STATISTICS)).isTrue();
@@ -455,15 +451,13 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void chartsNotToRender_All() {
+    public void removeChartsToRender_RemoveFeaturesAndTagsCharts() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
-        assertThat(configuration.containsChartToRender(ChartType.FEATURES_STATISTICS)).isTrue();
-        assertThat(configuration.containsChartToRender(ChartType.TAGS_STATISTICS)).isTrue();
 
         // when
-        configuration.chartsNotToRender(ChartType.FEATURES_STATISTICS, ChartType.TAGS_STATISTICS);
+        configuration.removeChartsToRender(ChartType.FEATURES_STATISTICS, ChartType.TAGS_STATISTICS);
 
         // then
         assertThat(configuration.containsChartToRender(ChartType.FEATURES_STATISTICS)).isFalse();

--- a/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageTest.java
@@ -43,8 +43,9 @@ public class FeaturesOverviewPageTest extends PageTest {
 
         // then
         VelocityContext context = page.context;
-        assertThat(context.getKeys()).hasSize(15);
+        assertThat(context.getKeys()).hasSize(16);
 
+        assertThat(context.get("render_feature_chart")).isEqualTo(true);
         assertThat(context.get("all_features")).isEqualTo(features);
         assertThat(context.get("report_summary")).isEqualTo(reportResult.getFeatureReport());
     }

--- a/src/test/java/net/masterthought/cucumber/generators/TagsOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TagsOverviewPageTest.java
@@ -44,8 +44,9 @@ public class TagsOverviewPageTest extends PageTest {
 
         // then
         VelocityContext context = page.context;
-        assertThat(context.getKeys()).hasSize(15);
+        assertThat(context.getKeys()).hasSize(16);
 
+        assertThat(context.get("render_tags_chart")).isEqualTo(true);
         assertThat(context.get("all_tags")).isEqualTo(tags);
         assertThat(context.get("report_summary")).isEqualTo(reportResult.getTagReport());
         assertThat(context.get("chart_categories")).isEqualTo(TagsOverviewPage.generateTagLabels(tags));


### PR DESCRIPTION
Provides optional ability to **_not_** render specified charts (i.e Feature Statistics, Tags Statistics) on overview web pages. By default, charts are rendered and must be _specifically_ identified to not be rendered via

`Configuration.chartsNotToRender(@NonNull ChartType... chartTypes)`

call.

Recently presented utilization of `cucumber-reporting` with existing Karate tests to Engr Mgmt and several Mgrs commented how they liked the reports but asked "Can the Charts could be removed?" They felt, although nice, that they didn't provide as much meaningful info as the below tables do and that they take up too much real estate on the page.

Thanks, in advance, for taking this change/feature in to consideration.