### PR TITLE
Embedding support for Excel files (xlsx and xls) added

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/Embedding.java
+++ b/src/main/java/net/masterthought/cucumber/json/Embedding.java
@@ -91,6 +91,10 @@ public class Embedding {
                 return "bz2";
             case "application/gzip":
                 return "gz";
+            case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+                return "xlsx";
+            case "application/vnd.ms-excel":
+                return "xls";
             default:
                 return "unknown";
         }

--- a/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
@@ -194,6 +194,30 @@ public class EmbeddingTest {
     }
 
     @Test
+    public void getExtension__OnApplicationOpenXMLFormatsOfficeDocumentSpreadsheetMimeType_ReturnsXlsx() {
+        // given
+        Embedding embedding = new Embedding("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "");
+
+        // when
+        String extension = embedding.getExtension();
+
+        // then
+        assertThat(extension).isEqualTo("xlsx");
+    }
+
+    @Test
+    public void getExtension__OnApplicationVNDMsExcelMimeType_ReturnsXls() {
+        // given
+        Embedding embedding = new Embedding("application/vnd.ms-excel", "");
+
+        // when
+        String extension = embedding.getExtension();
+
+        // then
+        assertThat(extension).isEqualTo("xls");
+    }
+
+    @Test
     public void getExtension__OnUnknownType_ReturnsUnknown() {
 
         // given


### PR DESCRIPTION
Support for following mime type and returning it's file extension added in `Embedding.java`

| Document Kind | Extension | Mime Type |
| ----------------- | ----------- | ------------ |
| Microsoft Excel | `.xls` | `application/vnd.ms-excel` |
| Microsoft Excel (OpenXML) | `.xlsx` | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` |

Following `Tests` Added for above changes.

| File | Test Function |
| ---- | -------------- |
| `EmbeddingTest.java` | `getExtension__OnApplicationOpenXMLFormatsOfficeDocumentSpreadsheetMimeType_ReturnsXlsx()` |
| `EmbeddingTest.java` | `getExtension__OnApplicationVNDMsExcelMimeType_ReturnsXls()` |


