### PR TITLE
add reducing method MERGE_FEATURES_WITH_RETEST_MARKING_FLACKY

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/Element.java
+++ b/src/main/java/net/masterthought/cucumber/json/Element.java
@@ -1,7 +1,5 @@
 package net.masterthought.cucumber.json;
 
-import java.time.LocalDateTime;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import net.masterthought.cucumber.Configuration;
@@ -11,6 +9,8 @@ import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.StatusCounter;
 import net.masterthought.cucumber.util.Util;
 import org.apache.commons.lang.StringUtils;
+
+import java.time.LocalDateTime;
 
 public class Element implements Durationable {
 
@@ -31,11 +31,11 @@ public class Element implements Durationable {
      */
     @JsonProperty("start_timestamp")
     private final LocalDateTime startTime = null;
-    private final Step[] steps = new Step[0];
-    private final Hook[] before = new Hook[0];
-    private final Hook[] after = new Hook[0];
+    private Step[] steps = new Step[0];
+    private Hook[] before = new Hook[0];
+    private Hook[] after = new Hook[0];
     @JsonDeserialize(using = TagsDeserializer.class)
-    private final Tag[] tags = new Tag[0];
+    private Tag[] tags = new Tag[0];
     // End: attributes from JSON file report
 
     private static final String SCENARIO_TYPE = "scenario";
@@ -63,6 +63,10 @@ public class Element implements Durationable {
 
     public Tag[] getTags() {
         return tags;
+    }
+
+    public void setTags(Tag[] tags) {
+        this.tags = tags;
     }
 
     public Status getStatus() {
@@ -129,6 +133,18 @@ public class Element implements Durationable {
     @Override
     public String getFormattedDuration() {
         return Util.formatDuration(duration);
+    }
+
+    public boolean isStatus(Status status) {
+        for (Step step : steps) {
+            step.setMetaData();
+        }
+
+        beforeStatus = new StatusCounter(before).getFinalStatus();
+        afterStatus = new StatusCounter(after).getFinalStatus();
+        stepsStatus = new StatusCounter(steps).getFinalStatus();
+        elementStatus = calculateElementStatus();
+        return elementStatus == status;
     }
 
     public void setMetaData(Feature feature, Configuration configuration) {

--- a/src/main/java/net/masterthought/cucumber/json/Hook.java
+++ b/src/main/java/net/masterthought/cucumber/json/Hook.java
@@ -2,12 +2,12 @@ package net.masterthought.cucumber.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import net.masterthought.cucumber.json.deserializers.OutputsDeserializer;
+import net.masterthought.cucumber.json.support.Embedded;
+import net.masterthought.cucumber.json.support.Resultsable;
 import org.apache.commons.lang.StringUtils;
 
-import net.masterthought.cucumber.json.deserializers.OutputsDeserializer;
-import net.masterthought.cucumber.json.support.Resultsable;
-
-public class Hook implements Resultsable {
+public class Hook implements Resultsable, Embedded {
 
     // Start: attributes from JSON file report
     private final Result result = null;
@@ -18,7 +18,7 @@ public class Hook implements Resultsable {
     private final Output[] outputs = new Output[0];
 
     // foe Ruby reports
-    private final Embedding[] embeddings = new Embedding[0];
+    private Embedding[] embeddings = new Embedding[0];
     // End: attributes from JSON file report
 
     @Override
@@ -36,8 +36,14 @@ public class Hook implements Resultsable {
         return outputs;
     }
 
+    @Override
     public Embedding[] getEmbeddings() {
         return embeddings;
+    }
+
+    @Override
+    public void setEmbeddings(Embedding[] embeddings) {
+        this.embeddings = embeddings;
     }
 
     /**
@@ -46,7 +52,7 @@ public class Hook implements Resultsable {
      * @return <code>true</code> if the hook has content otherwise <code>false</code>
      */
     public boolean hasContent() {
-        if (embeddings.length > 0) {
+        if (hasEmbeddings()) {
             // assuming that if the embedding exists then it is not empty
             return true;
         }
@@ -55,5 +61,10 @@ public class Hook implements Resultsable {
         }
         // TODO: hook with 'output' should be treated as empty or not?
         return false;
+    }
+
+    @Override
+    public boolean hasEmbeddings() {
+        return embeddings.length > 0;
     }
 }

--- a/src/main/java/net/masterthought/cucumber/json/Result.java
+++ b/src/main/java/net/masterthought/cucumber/json/Result.java
@@ -14,7 +14,7 @@ public class Result implements Durationable {
     // for all cases where Result is not present or completed
     private final Status status = Status.UNDEFINED;
     @JsonProperty("error_message")
-    private final String errorMessage = null;
+    private String errorMessage = null;
     private final Long duration = 0L;
     // End: attributes from JSON file report
 
@@ -34,6 +34,10 @@ public class Result implements Durationable {
 
     public String getErrorMessage() {
         return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
     }
 
     public final String getErrorMessageTitle() {

--- a/src/main/java/net/masterthought/cucumber/json/Step.java
+++ b/src/main/java/net/masterthought/cucumber/json/Step.java
@@ -2,15 +2,15 @@ package net.masterthought.cucumber.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.apache.commons.lang3.ArrayUtils;
-
 import net.masterthought.cucumber.json.deserializers.OutputsDeserializer;
 import net.masterthought.cucumber.json.support.Argument;
+import net.masterthought.cucumber.json.support.Embedded;
 import net.masterthought.cucumber.json.support.Resultsable;
 import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.StatusCounter;
+import org.apache.commons.lang3.ArrayUtils;
 
-public class Step implements Resultsable {
+public class Step implements Resultsable, Embedded {
 
     // Start: attributes from JSON file report
     private String name = null;
@@ -23,8 +23,8 @@ public class Step implements Resultsable {
     // protractor-cucumber-framework - mapping arguments to rows
     @JsonProperty("arguments")
     private final Argument[] arguments = new Argument[0];
-    private final Match match = null;
-    private final Embedding[] embeddings = new Embedding[0];
+    private Match match = null;
+    private Embedding[] embeddings = new Embedding[0];
 
     @JsonDeserialize(using = OutputsDeserializer.class)
     @JsonProperty("output")
@@ -34,8 +34,8 @@ public class Step implements Resultsable {
     private final DocString docString = null;
 
     // hooks are supported since Cucumber-JVM 3.x.x
-    private final Hook[] before = new Hook[0];
-    private final Hook[] after = new Hook[0];
+    private Hook[] before = new Hook[0];
+    private Hook[] after = new Hook[0];
     // End: attributes from JSON file report
 
     private Status beforeStatus;
@@ -76,8 +76,14 @@ public class Step implements Resultsable {
         return match;
     }
 
+    @Override
     public Embedding[] getEmbeddings() {
         return embeddings;
+    }
+
+    @Override
+    public void setEmbeddings(Embedding[] embeddings) {
+        this.embeddings = embeddings;
     }
 
     @Override
@@ -113,4 +119,10 @@ public class Step implements Resultsable {
         beforeStatus = new StatusCounter(before).getFinalStatus();
         afterStatus = new StatusCounter(after).getFinalStatus();
     }
+
+    @Override
+    public boolean hasEmbeddings() {
+        return embeddings.length > 0;
+    }
+
 }

--- a/src/main/java/net/masterthought/cucumber/json/support/Embedded.java
+++ b/src/main/java/net/masterthought/cucumber/json/support/Embedded.java
@@ -1,0 +1,18 @@
+package net.masterthought.cucumber.json.support;
+
+import net.masterthought.cucumber.json.Embedding;
+
+/**
+ * Ensures that class delivers method for embeddings.
+ *
+ * @author Vitaliya Ryabchuk (aqaexplorer@github)
+ */
+public interface Embedded {
+
+    Embedding[] getEmbeddings();
+
+    void setEmbeddings(Embedding[] embeddings);
+
+    boolean hasEmbeddings();
+
+}

--- a/src/main/java/net/masterthought/cucumber/json/support/Status.java
+++ b/src/main/java/net/masterthought/cucumber/json/support/Status.java
@@ -6,7 +6,7 @@ import net.masterthought.cucumber.json.deserializers.StatusDeserializer;
 
 /**
  * Defines all possible statuses provided by cucumber library.
- * 
+ *
  * @author Damian Szczepanik (damianszczepanik@github)
  */
 @JsonDeserialize(using = StatusDeserializer.class)
@@ -43,4 +43,5 @@ public enum Status {
     public boolean isPassed() {
         return this == PASSED;
     }
+
 }

--- a/src/main/java/net/masterthought/cucumber/reducers/ReducingMethod.java
+++ b/src/main/java/net/masterthought/cucumber/reducers/ReducingMethod.java
@@ -64,6 +64,16 @@ public enum ReducingMethod {
     MERGE_FEATURES_WITH_RETEST,
 
     /**
+     * Works as MERGE_FEATURES_WITH_RETEST plus marking as FLACKY tests that after rerun were passed
+     * Before merging it checks that scenario was failed and now it's passed and mark it as flacky (add @flacky tag).
+     * Also it gets an exception from firstly failed scenario and sets it to passed scenario in the same step/hook so
+     * you can analyze the reason but not to fail test suite.
+     * Plus it will also move any attachments to passed scenario in the same step/hook from firstly failed scenario AFTER HOOK
+     * (The common cucumber solution to embed screenshot in after hook if scenario failed)
+     */
+    MERGE_FEATURES_WITH_RETEST_MARKING_FLACKY,
+
+    /**
      * Skip empty JSON reports. If this flag is not selected then report generation fails on empty file.
      */
     SKIP_EMPTY_JSON_FILES,

--- a/src/main/java/net/masterthought/cucumber/reducers/ReportFeatureMergerFactory.java
+++ b/src/main/java/net/masterthought/cucumber/reducers/ReportFeatureMergerFactory.java
@@ -10,7 +10,8 @@ public final class ReportFeatureMergerFactory {
 
     private List<ReportFeatureMerger> mergers = Arrays.asList(
             new ReportFeatureByIdMerger(),
-            new ReportFeatureWithRetestMerger()
+            new ReportFeatureWithRetestMerger(),
+            new ReportFeatureWithRetestMarkingFlackyMerger()
     );
 
     /**

--- a/src/main/java/net/masterthought/cucumber/reducers/ReportFeatureWithRetestMarkingFlackyMerger.java
+++ b/src/main/java/net/masterthought/cucumber/reducers/ReportFeatureWithRetestMarkingFlackyMerger.java
@@ -1,0 +1,101 @@
+package net.masterthought.cucumber.reducers;
+
+import static java.util.Arrays.stream;
+import static java.util.stream.Stream.concat;
+import static net.masterthought.cucumber.json.support.Status.FAILED;
+import static net.masterthought.cucumber.json.support.Status.PASSED;
+import static org.apache.commons.lang3.ArrayUtils.add;
+import static org.apache.commons.lang3.ArrayUtils.addAll;
+
+import net.masterthought.cucumber.json.Element;
+import net.masterthought.cucumber.json.Feature;
+import net.masterthought.cucumber.json.Hook;
+import net.masterthought.cucumber.json.Tag;
+import net.masterthought.cucumber.json.support.Resultsable;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Stream;
+
+/**
+ * Merge list of given features in the same way as ReportFeatureWithRetestMerger plus marking flacky tests
+ * (that were failed and after rerun are passed) not failing the last one and moves exception and attachments from
+ * previously failed scenario for better analyzing
+ * <p>
+ * Uses when need to generate a report with rerun results analyzing flacky tests.
+ */
+final class ReportFeatureWithRetestMarkingFlackyMerger extends ReportFeatureWithRetestMerger {
+
+    @Override
+    public boolean test(List<ReducingMethod> reducingMethods) {
+        return reducingMethods != null
+                && reducingMethods.contains(ReducingMethod.MERGE_FEATURES_WITH_RETEST_MARKING_FLACKY);
+    }
+
+    @Override
+    protected void replace(Feature feature, Element[] elements, int i, Element current, int indexOfPreviousResult,
+                           boolean hasBackground) {
+        if (ifFlacky(feature.getElements()[indexOfPreviousResult], current)) {
+            addFlackyTag(current);
+            addExceptionWithEmbeddings(feature.getElements()[indexOfPreviousResult], current);
+        }
+        super.replace(feature, elements, i, current, indexOfPreviousResult, hasBackground);
+
+    }
+
+    boolean ifFlacky(Element target, Element candidate) {
+        return target.isStatus(FAILED) && candidate.isStatus(PASSED);
+    }
+
+    void addFlackyTag(Element candidate) {
+        Tag[] tags = add(candidate.getTags(), new Tag("@flacky"));
+        candidate.setTags(tags);
+    }
+
+    void addExceptionWithEmbeddings(Element target, Element candidate) {
+        Resultsable targetFailed = getFailedResultsable(mergeResultsable(target));
+        setErrorMessage(targetFailed, mergeResultsable(candidate));
+        setEmbeddingsInAfterHookIfPresent(target, candidate, targetFailed);
+    }
+
+    void setErrorMessage(Resultsable targetFailed, Stream<Resultsable> candidateResultsableStream) {
+        candidateResultsableStream.filter(resultsable -> resultsable.getMatch().getLocation()
+                .equals(targetFailed.getMatch().getLocation()))
+                .findFirst().ifPresent(step
+                -> step.getResult().setErrorMessage(targetFailed.getResult().getErrorMessage()));
+    }
+
+    Resultsable getFailedResultsable(Stream<Resultsable> resultsableStream) {
+        return resultsableStream.filter(resultsable -> resultsable.getResult().getStatus() == FAILED)
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException("No hook or step with failed status was found"));
+    }
+
+    Stream<Resultsable> mergeResultsable(Element element) {
+        Stream<Hook> candidateHooks = concat(stream(element.getBefore()), stream(element.getAfter()));
+        return concat(candidateHooks, getStepsWithStepHooks(element));
+    }
+
+    Stream<Resultsable> getStepsWithStepHooks(Element previous) {
+        Stream<Resultsable> stream = stream(previous.getSteps());
+
+        for (int i = 0; i <= previous.getSteps().length - 1; i++) {
+            Resultsable[] before = previous.getSteps()[i].getBefore();
+            Resultsable[] after = previous.getSteps()[i].getAfter();
+            Stream<Resultsable> hooks = concat(stream(before), stream(after));
+            stream = Stream.concat(stream, hooks);
+        }
+        return stream;
+    }
+
+    void setEmbeddingsInAfterHookIfPresent(Element previous, Element current, Resultsable previousFailed) {
+        stream(previous.getAfter())
+                .filter(Hook::hasEmbeddings)
+                .findFirst().ifPresent(previousEmbeddedAfter ->
+                stream(current.getSteps())
+                        .filter(hook -> hook.getMatch().getLocation().equals(previousFailed.getMatch().getLocation()))
+                        .findFirst().ifPresent(hook
+                        -> hook.setEmbeddings(addAll(hook.getEmbeddings(), previousEmbeddedAfter.getEmbeddings()))));
+    }
+
+}

--- a/src/main/java/net/masterthought/cucumber/reducers/ReportFeatureWithRetestMerger.java
+++ b/src/main/java/net/masterthought/cucumber/reducers/ReportFeatureWithRetestMerger.java
@@ -16,7 +16,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  *
  * Uses when need to generate a report with rerun results of failed tests.
  */
-final class ReportFeatureWithRetestMerger implements ReportFeatureMerger {
+class ReportFeatureWithRetestMerger implements ReportFeatureMerger {
 
     private static final String ERROR = "You are not able to use this type of results merge. The start_timestamp field" +
             " should be part of element object. Please, update the cucumber-jvm version.";
@@ -63,10 +63,7 @@ final class ReportFeatureWithRetestMerger implements ReportFeatureMerger {
                 }
                 else {
                     if (replaceIfExists(feature.getElements()[indexOfPreviousResult], current)) {
-                        feature.getElements()[indexOfPreviousResult] = current;
-                        if (hasBackground && isBackground(indexOfPreviousResult - 1, feature.getElements())) {
-                            feature.getElements()[indexOfPreviousResult - 1] = elements[i - 1];
-                        }
+                        replace(feature, elements, i, current, indexOfPreviousResult, hasBackground);
                     }
                 }
             }
@@ -109,4 +106,13 @@ final class ReportFeatureWithRetestMerger implements ReportFeatureMerger {
     public boolean test(List<ReducingMethod> reducingMethods) {
         return reducingMethods != null && reducingMethods.contains(ReducingMethod.MERGE_FEATURES_WITH_RETEST);
     }
+
+    protected void replace(Feature feature, Element[] elements, int i, Element current, int indexOfPreviousResult,
+                           boolean hasBackground) {
+        feature.getElements()[indexOfPreviousResult] = current;
+        if (hasBackground && isBackground(indexOfPreviousResult - 1, feature.getElements())) {
+            feature.getElements()[indexOfPreviousResult - 1] = elements[i - 1];
+        }
+    }
+
 }

--- a/src/test/java/net/masterthought/cucumber/json/StepTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/StepTest.java
@@ -1,12 +1,12 @@
 package net.masterthought.cucumber.json;
 
+import static org.apache.commons.lang3.ArrayUtils.add;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.Before;
-import org.junit.Test;
 
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.support.Status;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -113,6 +113,36 @@ public class StepTest extends PageTest {
         assertThat(embeddings).hasSize(1);
         assertThat(embeddings[0].getMimeType()).isEqualTo("application/json");
     }
+
+    @Test
+    public void hasEmbeddings() {
+
+        // given
+
+        // when
+        Step step = features.get(1).getElements()[0].getSteps()[6];
+
+        // then
+        assertThat(step.hasEmbeddings()).isTrue();
+    }
+
+    @Test
+    public void setEmbeddings() {
+
+        // given
+        Step step = features.get(1).getElements()[0].getSteps()[6];
+        Embedding[] embeddings = step.getEmbeddings();
+        Embedding[] updatedEmbeddings = add(embeddings, new Embedding("mime/type", "your data"));
+
+        // when
+        step.setEmbeddings(updatedEmbeddings);
+
+        // then
+        assertThat(updatedEmbeddings).hasSize(2);
+        assertThat(updatedEmbeddings[1].getMimeType()).isEqualTo("mime/type");
+        assertThat(updatedEmbeddings[1].getData()).isEqualTo("your data");
+    }
+
 
     @Test
     public void getResult_ReturnResult() {

--- a/src/test/java/net/masterthought/cucumber/json/TagTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/TagTest.java
@@ -1,5 +1,6 @@
 package net.masterthought.cucumber.json;
 
+import static org.apache.commons.lang3.ArrayUtils.add;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import net.masterthought.cucumber.generators.integrations.PageTest;
@@ -40,6 +41,20 @@ public class TagTest extends PageTest {
 
         // then
         assertThat(tagName).isEqualTo("@checkout");
+    }
+
+    @Test
+    public void setTag_ReturnsNewElementTagName() {
+
+        // given
+        Element element = features.get(0).getElements()[1];
+        Tag[] tags = add(element.getTags(), new Tag("@newTag"));
+
+        // when
+        element.setTags(tags);
+
+        // then
+        assertThat(element.getTags()).contains(new Tag("@newTag"));
     }
 
     @Test

--- a/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureWithRetestMarkingFlackyMergerTest.java
+++ b/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureWithRetestMarkingFlackyMergerTest.java
@@ -1,0 +1,338 @@
+package net.masterthought.cucumber.reducers;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.util.Collections.singletonList;
+import static net.masterthought.cucumber.json.support.Status.FAILED;
+import static net.masterthought.cucumber.json.support.Status.PASSED;
+import static net.masterthought.cucumber.reducers.ReducingMethod.MERGE_FEATURES_WITH_RETEST_MARKING_FLACKY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import net.masterthought.cucumber.json.Element;
+import net.masterthought.cucumber.json.Embedding;
+import net.masterthought.cucumber.json.Feature;
+import net.masterthought.cucumber.json.Hook;
+import net.masterthought.cucumber.json.Match;
+import net.masterthought.cucumber.json.Result;
+import net.masterthought.cucumber.json.Step;
+import net.masterthought.cucumber.json.Tag;
+import net.masterthought.cucumber.json.support.Resultsable;
+import net.masterthought.cucumber.json.support.Status;
+import org.junit.Test;
+import org.powermock.api.support.membermodification.MemberModifier;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+public class ReportFeatureWithRetestMarkingFlackyMergerTest {
+
+    private ReportFeatureWithRetestMarkingFlackyMerger merger = new ReportFeatureWithRetestMarkingFlackyMerger();
+
+    private Element buildElement(String id) {
+        try {
+            Element result = new Element();
+            MemberModifier.field(Element.class, "id").set(result, id);
+            MemberModifier.field(Element.class, "type").set(result, "scenario");
+            MemberModifier.field(Element.class, "startTime").set(result, LocalDateTime.now());
+            return result;
+        }
+        catch (IllegalAccessException e) {
+            return null;
+        }
+    }
+
+    private Step buildStep(String location, Status status) {
+        try {
+            Step step = new Step();
+
+            Result result = new Result();
+            MemberModifier.field(Step.class, "result").set(step, result);
+            MemberModifier.field(Result.class, "status").set(result, status);
+
+            Match match = new Match();
+            MemberModifier.field(Step.class, "match").set(step, match);
+            MemberModifier.field(Match.class, "location").set(match, location);
+
+            MemberModifier.field(Step.class, "before").set(step,
+                    new Hook[]{buildHook("beforeHook", PASSED)});
+            MemberModifier.field(Step.class, "after").set(step,
+                    new Hook[]{buildHook("afterHook", PASSED)});
+            return step;
+        }
+        catch (IllegalAccessException e) {
+            return null;
+        }
+    }
+
+    private Step buildFailedStep() {
+        Step step = buildStep("failedStep", FAILED);
+        Result result = new Result();
+        try {
+            MemberModifier.field(Step.class, "result").set(step, result);
+            MemberModifier.field(Result.class, "status").set(result, FAILED);
+            MemberModifier.field(Result.class, "errorMessage").set(result, "exception");
+        }
+        catch (IllegalAccessException e) {
+            return null;
+        }
+        return step;
+    }
+
+    private Hook buildHook(String location, Status status) {
+        Hook hook = new Hook();
+        Result result = new Result();
+        try {
+            MemberModifier.field(Hook.class, "result").set(hook, result);
+            MemberModifier.field(Result.class, "status").set(result, status);
+
+            Match match = new Match();
+            MemberModifier.field(Hook.class, "match").set(hook, match);
+            MemberModifier.field(Match.class, "location").set(match, location);
+        }
+        catch (IllegalAccessException e) {
+            return null;
+        }
+        return hook;
+    }
+
+    private Hook buildFailedHook() {
+        Hook hook = buildHook("failedHook", FAILED);
+        Result result = new Result();
+        try {
+            MemberModifier.field(Hook.class, "result").set(hook, result);
+            MemberModifier.field(Result.class, "status").set(result, FAILED);
+            MemberModifier.field(Result.class, "errorMessage").set(result, "exception");
+        }
+        catch (IllegalAccessException e) {
+            return null;
+        }
+        return hook;
+    }
+
+    private Hook buildHookWithEmbedding() {
+        Hook hook = buildHook("hookWithEmbedding", PASSED);
+        Embedding[] embeddings = new Embedding[]{new Embedding("mime/type", "your data")};
+        try {
+            MemberModifier.field(Hook.class, "embeddings").set(hook, embeddings);
+        }
+        catch (IllegalAccessException e) {
+            return null;
+        }
+        return hook;
+    }
+
+    private Element buildScenario() {
+        return buildElement(UUID.randomUUID().toString());
+    }
+
+    private Element buildScenario(boolean failStep, boolean failHook) {
+        Element element = buildScenario();
+        Step[] steps = {
+                buildStep("firstStep", PASSED),
+                buildStep("secondStep", PASSED),
+                buildStep("thirdStep", PASSED),
+                failStep ? buildFailedStep() : buildStep("failedStep", PASSED)};
+
+        try {
+            MemberModifier.field(Element.class, "steps").set(element, steps);
+            MemberModifier.field(Element.class, "before").set(element,
+                    new Hook[]{buildHook("beforeHook", PASSED),
+                            failHook ? buildFailedHook() : buildHook("beforeHook", PASSED)});
+            MemberModifier.field(Element.class, "after").set(element,
+                    new Hook[]{buildHook("afterHook", PASSED),
+                            failStep ? buildHookWithEmbedding() : buildHook("afterHook", PASSED)});
+        }
+        catch (IllegalAccessException e) {
+            return null;
+        }
+        return element;
+    }
+
+    @Test
+    public void test_ifFlacky() {
+        // given
+        Element element = buildScenario(TRUE, FALSE);
+        Element newElement = buildScenario(FALSE, FALSE);
+
+        // when
+        boolean result = merger.ifFlacky(element, newElement);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void test_isStatus() {
+        // given
+        Element element = buildScenario(TRUE, FALSE);
+        Element newElement = buildScenario(FALSE, FALSE);
+
+        // when
+        boolean result = element.isStatus(FAILED);
+        boolean result1 = newElement.isStatus(PASSED);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(result).isTrue();
+            softAssertions.assertThat(result1).isTrue();
+        });
+    }
+
+    @Test
+    public void test_addFlackyTag() {
+        // given
+        Element element = buildScenario();
+
+        // when
+        merger.addFlackyTag(element);
+
+        // then
+        assertThat(element.getTags()).contains(new Tag("@flacky"));
+    }
+
+    @Test
+    public void test_mergeResultsable() {
+        // given
+        Element element = buildScenario(FALSE, FALSE);
+
+        // when
+        Stream<Resultsable> resultsableStream = merger.mergeResultsable(element);
+
+        // then
+        assertThat(resultsableStream).hasSize(16);
+    }
+
+    @Test
+    public void test_getFailedResultsable() {
+        // given
+        Step step = buildStep("secondStep", FAILED);
+
+        // when
+        Resultsable failedResultsable = merger.getFailedResultsable(Stream.of(step));
+
+        // then
+        assertThat(failedResultsable).isNotNull();
+    }
+
+    @Test
+    public void test_setEmbeddingsInAfterHookIfPresent() {
+        // given
+        Element element = buildScenario(TRUE, FALSE);
+        Element newElement = buildScenario(FALSE, FALSE);
+
+        // when
+        merger.setEmbeddingsInAfterHookIfPresent(element, newElement, element.getSteps()[0]);
+
+        // then
+        assertThat(newElement.getSteps()[0].getEmbeddings()).isNotEmpty();
+    }
+
+    @Test
+    public void test_addExceptionWithEmbeddingsFailedStep() {
+        // given
+        Element element = buildScenario(TRUE, FALSE);
+        Element newElement = buildScenario(FALSE, FALSE);
+
+        // when
+        merger.addExceptionWithEmbeddings(element, newElement);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(newElement.getSteps()[3].getResult().getErrorMessage()).isNotEmpty();
+            softAssertions.assertThat(newElement.getSteps()[3].hasEmbeddings()).isTrue();
+        });
+
+    }
+
+    @Test
+    public void test_addExceptionWithEmbeddingsFailedHook() {
+        // given
+        Element element = buildScenario(TRUE, FALSE);
+        Element newElement = buildScenario(TRUE, FALSE);
+
+        // when
+        merger.addExceptionWithEmbeddings(element, newElement);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(newElement.getSteps()[3].getResult().getErrorMessage()).isNotEmpty();
+            softAssertions.assertThat(newElement.getSteps()[3].hasEmbeddings()).isTrue();
+        });
+
+    }
+
+    @Test
+    public void test_replaceIfFlacky() throws IllegalAccessException {
+        // given
+        Element[] elements = {buildScenario(TRUE, FALSE)};
+
+        Feature feature = new Feature();
+        MemberModifier
+                .field(Feature.class, "elements")
+                .set(feature, elements);
+
+        Element newElement = buildScenario(FALSE, FALSE);
+
+        // when
+        merger.replace(feature, elements, 0, newElement, 0, FALSE);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(newElement.getSteps()[3].getResult().getErrorMessage()).isNotEmpty();
+            softAssertions.assertThat(newElement.getSteps()[3].hasEmbeddings()).isTrue();
+            softAssertions.assertThat(newElement.getTags()).contains(new Tag("@flacky"));
+            softAssertions.assertThat(elements[0].getStatus().isPassed()).isTrue();
+            softAssertions.assertThat(elements[0].getSteps()[3].getResult().getErrorMessage()).isNotEmpty();
+            softAssertions.assertThat(elements[0].getSteps()[3].hasEmbeddings()).isTrue();
+            softAssertions.assertThat(elements[0].getTags()).contains(new Tag("@flacky"));
+        });
+
+    }
+
+    @Test
+    public void test_setErrorMessage() {
+        // given
+        Step step = buildFailedStep();
+        Step secondStep = buildStep("failedStep", PASSED);
+
+        // when
+        merger.setErrorMessage(step, Stream.of(secondStep));
+
+        // then
+        assertThat(secondStep.getResult().getErrorMessage()).isEqualTo("exception");
+    }
+
+    @Test
+    public void test_getStepWithHooks() {
+        // given
+        Element element = buildScenario(FALSE, FALSE);
+
+        // when
+        Stream<Resultsable> stepWithHooks = merger.getStepsWithStepHooks(element);
+
+        // then
+        assertThat(stepWithHooks).hasSize(12);
+    }
+
+    @Test
+    public void check_MergerIsApplicableByType_NullParam() {
+        // given
+        // when
+        boolean isApplicable = merger.test(null);
+
+        // then
+        assertThat(isApplicable).isFalse();
+    }
+
+    @Test
+    public void check_MergerIsApplicableByType_CorrectParam() {
+        // given
+        // when
+        boolean isApplicableByType = merger.test(singletonList(MERGE_FEATURES_WITH_RETEST_MARKING_FLACKY));
+
+        // then
+        assertThat(isApplicableByType).isTrue();
+    }
+}

--- a/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureWithRetestMergerTest.java
+++ b/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureWithRetestMergerTest.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.UUID;
 
+import static java.lang.Boolean.FALSE;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static net.masterthought.cucumber.reducers.ReducingMethod.MERGE_FEATURES_WITH_RETEST;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,6 +73,25 @@ public class ReportFeatureWithRetestMergerTest {
 
         // when
         merger.updateElements(feature, newElements);
+
+        // then
+        assertThat(feature.getElements()).hasSize(3);
+        assertThat(feature.getElements()[0]).isSameAs(newElements[0]);
+    }
+
+    @Test
+    public void replace() throws IllegalAccessException {
+        // given
+        Feature feature = new Feature();
+        Element[] elements = {buildScenario(), buildBackground(), buildScenario()};
+        MemberModifier
+                .field(Feature.class, "elements")
+                .set(feature, elements);
+
+        Element[] newElements = {buildElement(elements[0].getId(), false)};
+
+        // when
+        merger.replace(feature, elements, 0, newElements[0], 0, FALSE);
 
         // then
         assertThat(feature.getElements()).hasSize(3);


### PR DESCRIPTION
Works as MERGE_FEATURES_WITH_RETEST reducing method plus marking as FLACKY tests that after rerun were passed. Before merging it checks that scenario was failed and now it's passed and mark it as flacky (add @flacky tag). Also it gets an exception from firstly failed scenario and sets it to passed scenario in the same step/hook so you can analyze the reason but not to fail test suite. Plus it will also move any attachments to passed scenario in the same step/hook as in firstly failed scenario from firstly failed scenario AFTER HOOK (The common cucumber solution to embed screenshot in after hook if scenario failed)