### PR TITLE
Migrate to JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,8 +116,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
@@ -138,6 +138,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Partially reverts commit 09a6968451c009e1f031b9e6d7b760efe0af1fef.
Leave support for JDK11 and compatibility with JDK8