### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
     - ~/.m2
 
 git:
-  depth: false # remove the --depth to support full git blame by Sonarqube
+  depth: 3 # remove the --depth to support full git blame by Sonarqube
 
 env:
   global:


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.