### PR TITLE
Fix error messages + tests

### DIFF
--- a/src/main/java/net/masterthought/cucumber/ReportParser.java
+++ b/src/main/java/net/masterthought/cucumber/ReportParser.java
@@ -58,7 +58,7 @@ public class ReportParser {
      */
     public List<Feature> parseJsonFiles(List<String> jsonFiles) {
         if (jsonFiles.isEmpty()) {
-            throw new ValidationException("None report file was added!");
+            throw new ValidationException("No report file was added!");
         }
 
         List<Feature> featureResults = new ArrayList<>();
@@ -70,7 +70,7 @@ public class ReportParser {
                 continue;
             }
             Feature[] features = parseForFeature(jsonFile);
-            LOG.log(Level.INFO, () -> String.format("File '%s' contains %d features", jsonFile, features.length));
+            LOG.log(Level.INFO, () -> String.format("File '%s' contains %d feature(s)", jsonFile, features.length));
             featureResults.addAll(Arrays.asList(features));
         }
 
@@ -101,7 +101,7 @@ public class ReportParser {
 
             return features;
         } catch (JsonMappingException e) {
-            throw new ValidationException(String.format("File '%s' is not proper Cucumber report!", jsonFile), e.getCause());
+            throw new ValidationException(String.format("File '%s' is not a valid Cucumber report!", jsonFile), e.getCause());
         } catch (IOException e) {
             // IO problem - stop generating and re-throw the problem
             throw new ValidationException(e);

--- a/src/test/java/net/masterthought/cucumber/ReportParserTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportParserTest.java
@@ -81,7 +81,7 @@ public class ReportParserTest extends ReportGenerator {
         // when & then
         assertThatThrownBy(() -> reportParser.parseJsonFiles(jsonReports))
                 .isInstanceOf(ValidationException.class)
-                .hasMessage("None report file was added!");
+                .hasMessage("No report file was added!");
     }
 
     @Test
@@ -94,7 +94,7 @@ public class ReportParserTest extends ReportGenerator {
         // when & then
         assertThatThrownBy(() -> reportParser.parseJsonFiles(jsonReports))
                 .isInstanceOf(ValidationException.class)
-                .hasMessageEndingWith("is not proper Cucumber report!");
+                .hasMessageMatching("^File '.+' is not a valid Cucumber report!$");
     }
 
     @Test


### PR DESCRIPTION
Not quite sure what happened, as the PR appears to have been still open but then had unresolved history with master. Updating https://github.com/damianszczepanik/cucumber-reporting/pull/1046 forced it to close itself.

This amends the tests from the aforementioned PR, anyway.