### PR TITLE
allow-downloads in html embedding

### DIFF
--- a/src/main/resources/templates/macros/json/embeddings.vm
+++ b/src/main/resources/templates/macros/json/embeddings.vm
@@ -49,7 +49,7 @@
   <div id="embedding-$embeddingId" class="collapse collapsable-details #if ($expand_all_steps) in #end">
     <div class="embedding-content">
       <div class="html-content">
-        <iframe seamless="true" sandbox="allow-scripts" src="embeddings/$embedding.getFileName()" srcdoc="$embedding.getDecodedData()"></iframe>
+        <iframe seamless="true" sandbox="allow-downloads allow-scripts" src="embeddings/$embedding.getFileName()" srcdoc="$embedding.getDecodedData()"></iframe>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fix issue where download links are not accessible from within embedded HTML.