### PR TITLE
Remove dependency to commons-collections4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,11 +234,6 @@
             <version>2.3</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <version>4.4</version>
-        </dependency>
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.12.2</version>

--- a/src/main/java/net/masterthought/cucumber/ReportParser.java
+++ b/src/main/java/net/masterthought/cucumber/ReportParser.java
@@ -1,7 +1,5 @@
 package net.masterthought.cucumber;
 
-import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -126,7 +124,7 @@ public class ReportParser {
      * @param propertiesFiles property files to read
      */
     public void parseClassificationsFiles(List<String> propertiesFiles) {
-        if (isNotEmpty(propertiesFiles)) {
+        if (propertiesFiles != null && !propertiesFiles.isEmpty()) {
             for (String propertyFile : propertiesFiles) {
                 if (StringUtils.isNotEmpty(propertyFile)) {
                     processClassificationFile(propertyFile);


### PR DESCRIPTION
When the commons-colllections dependency was updated to v4 the only(!) used import was updated wrongly.
This resulted in `NoSuchMethods` exception in certain classpath configurations.
```
[...]
Caused by: java.lang.NoSuchMethodError: 'boolean org.apache.commons.lang3.ObjectUtils.isNotEmpty(java.lang.Object)'
        at net.masterthought.cucumber.ReportParser.parseClassificationsFiles(ReportParser.java:129)
        at net.masterthought.cucumber.ReportBuilder.generateReports(ReportBuilder.java:94)
[...]
```

I suggest to simply drop the dependency completely, as it is only used a single time.