### PR TITLE
Upgrade Jackson dependency version to address vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <maven.compile.encoding>UTF-8</maven.compile.encoding>
 
         <powermock.version>1.7.3</powermock.version>
-        <jackson.version>2.13.2.20220328</jackson.version>
+        <jackson.version>2.15.2</jackson.version>
         <jmockit.version>1.34</jmockit.version> <!-- last version that supports reflections -->
 
         <test.integration.pattern>**/*IntegrationTest*.java</test.integration.pattern>


### PR DESCRIPTION
This addresses the following CVE's:

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42003
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42004
