### PR TITLE
Bump oss-parent to last ever version '9', add relativePath so it forces look to m2 repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>7</version>
+        <version>9</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,12 @@
         <test.integration.pattern>**/*IntegrationTest*.java</test.integration.pattern>
     </properties>
 
+    <!-- 'oss-parent' should not be used, it was deprecated years ago -->
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
         <version>7</version>
+        <relativePath />
     </parent>
 
     <distributionManagement>


### PR DESCRIPTION
note, a better longer term fix would be to stop using this parent.  Sonatype deprecated it and retired it many years ago.  They suggest just incorporating items internally.