### PR TITLE
[tests] Replace jmockit with powermock whitebox and use version 2.0.9 of powermock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,8 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <maven.compile.encoding>UTF-8</maven.compile.encoding>
 
-        <powermock.version>1.7.3</powermock.version>
         <jackson.version>2.16.0</jackson.version>
-        <jmockit.version>1.34</jmockit.version> <!-- last version that supports reflections -->
+        <powermock.version>2.0.9</powermock.version>
 
         <test.integration.pattern>**/*IntegrationTest*.java</test.integration.pattern>
     </properties>
@@ -272,20 +271,20 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-            <version>${jmockit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-reflect</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -15,13 +15,13 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import mockit.Deencapsulation;
 import net.masterthought.cucumber.generators.OverviewReport;
 import net.masterthought.cucumber.json.Feature;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.junit.Before;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -56,8 +56,8 @@ public class ReportBuilderTest extends ReportGenerator {
         ReportBuilder builder = new ReportBuilder(jsonFiles, configuration);
 
         // then
-        List<String> assignedJsonReports = Deencapsulation.getField(builder, "jsonFiles");
-        Configuration assignedConfiguration = Deencapsulation.getField(builder, "configuration");
+        List<String> assignedJsonReports = Whitebox.getInternalState(builder, "jsonFiles");
+        Configuration assignedConfiguration = Whitebox.getInternalState(builder, "configuration");
 
         assertThat(assignedJsonReports).isSameAs(jsonFiles);
         assertThat(assignedConfiguration).isSameAs(configuration);
@@ -99,7 +99,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void generateReports_OnException_AppendsBuildToTrends() {
+    public void generateReports_OnException_AppendsBuildToTrends() throws Exception {
 
         // given
         List<String> jsonReports = Arrays.asList(ReportGenerator.reportFromResource(ReportGenerator.SAMPLE_JSON));
@@ -121,7 +121,7 @@ public class ReportBuilderTest extends ReportGenerator {
         assertPageExists(reportDirectory, configuration.getDirectorySuffixWithSeparator(), ReportBuilder.HOME_PAGE);
         assertThat(countHtmlFiles()).hasSize(1);
 
-        Trends trends = Deencapsulation.invoke(reportBuilder, "loadTrends", trendsFileTmp);
+        Trends trends = Whitebox.invokeMethod(reportBuilder, "loadTrends", trendsFileTmp);
         assertThat(trends.getBuildNumbers()).hasSize(4);
     }
 
@@ -150,7 +150,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void copyStaticResources_CopiesRequiredFiles() {
+    public void copyStaticResources_CopiesRequiredFiles() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -158,7 +158,7 @@ public class ReportBuilderTest extends ReportGenerator {
         Logger.getLogger(ReportBuilder.class.getName()).setLevel(Level.OFF);
 
         // when
-        Deencapsulation.invoke(builder, "copyStaticResources");
+        Whitebox.invokeMethod(builder, "copyStaticResources");
 
         // then
         Collection<File> files = FileUtils.listFiles(reportDirectory, null, true);
@@ -166,7 +166,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void createEmbeddingsDirectory_CreatesDirectory() {
+    public void createEmbeddingsDirectory_CreatesDirectory() throws Exception {
 
         // given
         File subDirectory = new File(reportDirectory, "sub");
@@ -175,14 +175,14 @@ public class ReportBuilderTest extends ReportGenerator {
         ReportBuilder builder = new ReportBuilder(Collections.<String>emptyList(), configuration);
 
         // when
-        Deencapsulation.invoke(builder, "createEmbeddingsDirectory");
+        Whitebox.invokeMethod(builder, "createEmbeddingsDirectory");
 
         // then
         assertThat(subDirectory).exists();
     }
 
     @Test
-    public void copyResources_OnInvalidPath_ThrowsException() {
+    public void copyResources_OnInvalidPath_ThrowsException() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -191,7 +191,7 @@ public class ReportBuilderTest extends ReportGenerator {
 
         // then
         try {
-            Deencapsulation.invoke(builder, "copyResources", dir.getAbsolutePath(), new String[]{"someFile"});
+            Whitebox.invokeMethod(builder, "copyResources", dir.getAbsolutePath(), new String[]{"someFile"});
             fail("Copying should fail!");
             // exception depends of operating system
         } catch (ValidationException | NullPointerException e) {
@@ -200,23 +200,23 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void copyCustomResources_OnInvalidPath_DoesNotThrowsException() {
+    public void copyCustomResources_OnInvalidPath_DoesNotThrowsException() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
         ReportBuilder builder = new ReportBuilder(Collections.emptyList(), configuration);
         File srcFile = new File("non-existent.file");
-        File dstFile = Deencapsulation.invoke(builder, "createTempFile", "js", srcFile.getName());
+        File dstFile = Whitebox.invokeMethod(builder, "createTempFile", "js", srcFile.getName());
 
         // when
-        Deencapsulation.invoke(builder, "copyCustomResources", "js", srcFile);
+        Whitebox.invokeMethod(builder, "copyCustomResources", "js", srcFile);
 
         // then
         assertThat(dstFile).doesNotExist();
     }
 
     @Test
-    public void copyCustomResources_OnDirAsFile_ThrowsIOException() {
+    public void copyCustomResources_OnDirAsFile_ThrowsIOException() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -225,7 +225,7 @@ public class ReportBuilderTest extends ReportGenerator {
 
         // then
         try {
-            Deencapsulation.invoke(builder, "copyCustomResources", "js", dir);
+            Whitebox.invokeMethod(builder, "copyCustomResources", "js", dir);
             fail("Copying should fail!");
             // exception depends of operating system
         } catch (ValidationException e) {
@@ -234,7 +234,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void copyCustomResources_CheckCopiedFiles() {
+    public void copyCustomResources_CheckCopiedFiles() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -243,7 +243,7 @@ public class ReportBuilderTest extends ReportGenerator {
         ReportBuilder builder = new ReportBuilder(Collections.<String>emptyList(), configuration);
 
         // when
-        Deencapsulation.invoke(builder, "copyCustomJsAndCssResources");
+        Whitebox.invokeMethod(builder, "copyCustomJsAndCssResources");
 
         // then
         assertPageExists(reportDirectory, configuration.getDirectorySuffixWithSeparator(), "/js/test.js");
@@ -251,40 +251,40 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void collectPages_CollectsPages() {
+    public void collectPages_CollectsPages() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
 
         ReportBuilder builder = new ReportBuilder(jsonReports, configuration);
-        Deencapsulation.setField(builder, "reportResult", new ReportResult(features, configuration));
+        Whitebox.setInternalState(builder, "reportResult", new ReportResult(features, configuration));
 
         // when
-        Deencapsulation.invoke(builder, "generatePages", new Trends());
+        Whitebox.invokeMethod(builder, "generatePages", new Trends());
 
         // then
         assertThat(countHtmlFiles(configuration)).hasSize(9);
     }
 
     @Test
-    public void collectPages_OnExistingTrendsFile_CollectsPages() {
+    public void collectPages_OnExistingTrendsFile_CollectsPages() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
         configuration.setTrendsStatsFile(trendsFileTmp);
 
         ReportBuilder builder = new ReportBuilder(jsonReports, configuration);
-        Deencapsulation.setField(builder, "reportResult", new ReportResult(features, configuration));
+        Whitebox.setInternalState(builder, "reportResult", new ReportResult(features, configuration));
 
         // when
-        Deencapsulation.invoke(builder, "generatePages", new Trends());
+        Whitebox.invokeMethod(builder, "generatePages", new Trends());
 
         // then
         assertThat(countHtmlFiles(configuration)).hasSize(10);
     }
 
     @Test
-    public void updateAndSaveTrends_ReturnsUpdatedTrends() {
+    public void updateAndSaveTrends_ReturnsUpdatedTrends() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -292,10 +292,10 @@ public class ReportBuilderTest extends ReportGenerator {
         configuration.setBuildNumber(buildNumber);
         configuration.setTrendsStatsFile(trendsFileTmp);
         ReportBuilder builder = new ReportBuilder(jsonReports, configuration);
-        Deencapsulation.setField(builder, "reportResult", reportResult);
+        Whitebox.setInternalState(builder, "reportResult", reportResult);
 
         // when
-        Trends trends = Deencapsulation.invoke(builder, "updateAndSaveTrends", reportResult.getFeatureReport());
+        Trends trends = Whitebox.invokeMethod(builder, "updateAndSaveTrends", reportResult.getFeatureReport());
 
         // then
         assertThat(trends.getBuildNumbers()).hasSize(4);
@@ -305,7 +305,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void updateAndSaveTrends_OnTrendsLimit_ReturnsUpdatedTrends() {
+    public void updateAndSaveTrends_OnTrendsLimit_ReturnsUpdatedTrends() throws Exception {
 
         // given
         final int trendsLimit = 2;
@@ -314,10 +314,10 @@ public class ReportBuilderTest extends ReportGenerator {
         configuration.setBuildNumber(buildNumber);
         configuration.setTrends(trendsFileTmp, trendsLimit);
         ReportBuilder builder = new ReportBuilder(jsonReports, configuration);
-        Deencapsulation.setField(builder, "reportResult", reportResult);
+        Whitebox.setInternalState(builder, "reportResult", reportResult);
 
         // when
-        Trends trends = Deencapsulation.invoke(builder, "updateAndSaveTrends", reportResult.getFeatureReport());
+        Trends trends = Whitebox.invokeMethod(builder, "updateAndSaveTrends", reportResult.getFeatureReport());
 
         // then
         assertThat(trends.getBuildNumbers()).hasSize(trendsLimit);
@@ -327,10 +327,10 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void loadTrends_ReturnsTrends() {
+    public void loadTrends_ReturnsTrends() throws Exception {
 
         // when
-        Trends trends = Deencapsulation.invoke(ReportBuilder.class, "loadTrends", TRENDS_FILE);
+        Trends trends = Whitebox.invokeMethod(ReportBuilder.class, "loadTrends", TRENDS_FILE);
 
         // then
         assertThat(trends.getBuildNumbers()).containsExactly("01_first", "other build", "05last");
@@ -358,12 +358,12 @@ public class ReportBuilderTest extends ReportGenerator {
         File noExistingTrendsFile = new File("anyNoExisting?File");
 
         // when & then
-        assertThatThrownBy(() -> Deencapsulation.invoke(ReportBuilder.class, "loadTrends", noExistingTrendsFile))
+        assertThatThrownBy(() -> Whitebox.invokeMethod(ReportBuilder.class, "loadTrends", noExistingTrendsFile))
                 .isInstanceOf(ValidationException.class);
     }
 
     @Test
-    public void loadOrCreateTrends_ReturnsLoadedTrends() {
+    public void loadOrCreateTrends_ReturnsLoadedTrends() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -371,14 +371,14 @@ public class ReportBuilderTest extends ReportGenerator {
         ReportBuilder builder = new ReportBuilder(jsonReports, configuration);
 
         // when
-        Trends trends = Deencapsulation.invoke(builder, "loadOrCreateTrends");
+        Trends trends = Whitebox.invokeMethod(builder, "loadOrCreateTrends");
 
         // then
         assertThat(trends.getBuildNumbers()).containsExactly("01_first", "other build", "05last");
     }
 
     @Test
-    public void loadOrCreateTrends_OnMissingTrendsFile_ReturnsEmptyTrends() {
+    public void loadOrCreateTrends_OnMissingTrendsFile_ReturnsEmptyTrends() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -386,21 +386,21 @@ public class ReportBuilderTest extends ReportGenerator {
         configuration.setTrendsStatsFile(new File("missing?file"));
 
         // when
-        Trends trends = Deencapsulation.invoke(builder, "loadOrCreateTrends");
+        Trends trends = Whitebox.invokeMethod(builder, "loadOrCreateTrends");
 
         // then
         assertThat(trends.getBuildNumbers()).isEmpty();
     }
 
     @Test
-    public void loadOrCreateTrends_OnInvalidTrendsFile_ReturnsEmptyTrends() {
+    public void loadOrCreateTrends_OnInvalidTrendsFile_ReturnsEmptyTrends() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
         ReportBuilder builder = new ReportBuilder(jsonReports, configuration);
 
         // when
-        Trends trends = Deencapsulation.invoke(builder, "loadOrCreateTrends");
+        Trends trends = Whitebox.invokeMethod(builder, "loadOrCreateTrends");
 
         // then
         assertThat(trends.getBuildNumbers()).isEmpty();
@@ -413,7 +413,7 @@ public class ReportBuilderTest extends ReportGenerator {
         File notTrendJsonFile = new File(reportFromResource(SAMPLE_JSON));
 
         // when & then
-        assertThatThrownBy(() -> Deencapsulation.invoke(ReportBuilder.class, "loadTrends", notTrendJsonFile))
+        assertThatThrownBy(() -> Whitebox.invokeMethod(ReportBuilder.class, "loadTrends", notTrendJsonFile))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageEndingWith("could not be parsed as file with trends!");
     }
@@ -425,13 +425,13 @@ public class ReportBuilderTest extends ReportGenerator {
         File directoryFile = new File(".");
 
         // when & then
-        assertThatThrownBy(() -> Deencapsulation.invoke(ReportBuilder.class, "loadTrends", directoryFile))
+        assertThatThrownBy(() -> Whitebox.invokeMethod(ReportBuilder.class, "loadTrends", directoryFile))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("java.io.FileNotFoundException");
     }
 
     @Test
-    public void appendToTrends_AppendsDataToTrends() {
+    public void appendToTrends_AppendsDataToTrends() throws Exception {
 
         // given
         final String buildNumber = "1";
@@ -484,11 +484,11 @@ public class ReportBuilderTest extends ReportGenerator {
         };
 
         ReportBuilder reportBuilder = new ReportBuilder(null, configuration);
-        Deencapsulation.setField(reportBuilder, "reportResult", reportResult);
+        Whitebox.setInternalState(reportBuilder, "reportResult", reportResult);
         Trends trends = new Trends();
 
         // when
-        Deencapsulation.invoke(reportBuilder, "appendToTrends", trends, reportable);
+        Whitebox.invokeMethod(reportBuilder, "appendToTrends", trends, reportable);
 
         // then
         assertThat(trends.getBuildNumbers()).containsExactly(buildNumber);
@@ -510,13 +510,13 @@ public class ReportBuilderTest extends ReportGenerator {
         File directoryFile = new File(".");
 
         // when & then
-        assertThatThrownBy(() -> Deencapsulation.invoke(builder, "saveTrends", trends, directoryFile))
+        assertThatThrownBy(() -> Whitebox.invokeMethod(builder, "saveTrends", trends, directoryFile))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageStartingWith("Could not save updated trends ");
     }
 
     @Test
-    public void generateErrorPage_GeneratesErrorPage() {
+    public void generateErrorPage_GeneratesErrorPage() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -524,7 +524,7 @@ public class ReportBuilderTest extends ReportGenerator {
         Logger.getLogger(ReportBuilder.class.getName()).setLevel(Level.OFF);
 
         // when
-        Deencapsulation.invoke(builder, "generateErrorPage", new Exception());
+        Whitebox.invokeMethod(builder, "generateErrorPage", new Exception());
 
         // then
         assertPageExists(reportDirectory, configuration.getDirectorySuffixWithSeparator(), ReportBuilder.HOME_PAGE);

--- a/src/test/java/net/masterthought/cucumber/ReportParserTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportParserTest.java
@@ -8,13 +8,13 @@ import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 
-import mockit.Deencapsulation;
 import net.masterthought.cucumber.json.Element;
 import net.masterthought.cucumber.json.Feature;
 import net.masterthought.cucumber.reducers.ReducingMethod;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.data.Index;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -127,7 +127,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void extractTarget_ReturnsFileNameWithoutExtension() {
+    public void extractTarget_ReturnsFileNameWithoutExtension() throws Exception {
 
         // given
         String jsonFile = SAMPLE_JSON;
@@ -135,7 +135,7 @@ public class ReportParserTest extends ReportGenerator {
         ReportParser reportParser = new ReportParser(configuration);
 
         // when
-        String qualifier = Deencapsulation.invoke(reportParser, "extractQualifier", jsonFile);
+        String qualifier = Whitebox.invokeMethod(reportParser, "extractQualifier", jsonFile);
 
 
         // then
@@ -143,7 +143,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void extractTarget_OnNoJSONFile_ReturnsFileName() {
+    public void extractTarget_OnNoJSONFile_ReturnsFileName() throws Exception {
 
         // given
         String jsonFile = SAMPLE_JSON + ".txt";
@@ -151,7 +151,7 @@ public class ReportParserTest extends ReportGenerator {
         ReportParser reportParser = new ReportParser(configuration);
 
         // when
-        String qualifier = Deencapsulation.invoke(reportParser, "extractQualifier", jsonFile);
+        String qualifier = Whitebox.invokeMethod(reportParser, "extractQualifier", jsonFile);
 
 
         // then

--- a/src/test/java/net/masterthought/cucumber/TrendsTest.java
+++ b/src/test/java/net/masterthought/cucumber/TrendsTest.java
@@ -2,8 +2,8 @@ package net.masterthought.cucumber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import mockit.Deencapsulation;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -54,7 +54,7 @@ public class TrendsTest {
         Reportable result = ReportableBuilder.buildSample();
         trends.addBuild("buildName", result);
         final String[] buildNumbers = new String[]{"a", "b", "e"};
-        Deencapsulation.setField(trends, "buildNumbers", buildNumbers);
+        Whitebox.setInternalState(trends, "buildNumbers", buildNumbers);
         
         // when
         trends.addBuild("the build!", result);
@@ -112,49 +112,49 @@ public class TrendsTest {
     }
 
     @Test
-    public void copyLastElements_OnBigLimit_ReturnsPassedIntArray() {
+    public void copyLastElements_OnBigLimit_ReturnsPassedIntArray() throws Exception {
 
         // given
         final int[] array = new int[]{3, 4, 5, 6, 7, 8};
         final int limit = array.length + 1;
 
         // when
-        int[] limitedArray = Deencapsulation.invoke(Trends.class, "copyLastElements", array, limit);
+        int[] limitedArray = Whitebox.invokeMethod(Trends.class, "copyLastElements", array, limit);
 
         // then
         assertThat(limitedArray).isSameAs(array);
     }
 
     @Test
-    public void copyLastElements_OnBigLimit_ReturnsPassedLongArray() {
+    public void copyLastElements_OnBigLimit_ReturnsPassedLongArray() throws Exception {
 
         // given
         final long[] array = new long[]{3, 4, 5, 6, 7, 8};
         final int limit = array.length + 1;
 
         // when
-        long[] limitedArray = Deencapsulation.invoke(Trends.class, "copyLastElements", array, limit);
+        long[] limitedArray = Whitebox.invokeMethod(Trends.class, "copyLastElements", array, limit);
 
         // then
         assertThat(limitedArray).isSameAs(array);
     }
 
     @Test
-    public void copyLastElements_OnBigLimit_ReturnsPassedStringArray() {
+    public void copyLastElements_OnBigLimit_ReturnsPassedStringArray() throws Exception {
 
         // given
         final String[] array = new String[]{"3", "4", "5", "6", "7", "8"};
         final int limit = array.length + 1;
 
         // when
-        String[] limitedArray = Deencapsulation.invoke(Trends.class, "copyLastElements", array, limit);
+        String[] limitedArray = Whitebox.invokeMethod(Trends.class, "copyLastElements", array, limit);
 
         // then
         assertThat(limitedArray).isSameAs(array);
     }
 
     @Test
-    public void applyPatchForFeatures_OnFailedGreaterThanTotal_ChangesTotalFeatureAndFailed() {
+    public void applyPatchForFeatures_OnFailedGreaterThanTotal_ChangesTotalFeatureAndFailed() throws Exception {
 
         // given
         final int totalFeatures = 1000;
@@ -164,7 +164,7 @@ public class TrendsTest {
         trends.addBuild("buildNumber", result);
 
         // when
-        Deencapsulation.invoke(trends, "applyPatchForFeatures");
+        Whitebox.invokeMethod(trends, "applyPatchForFeatures");
 
         // then
         assertThat(trends.getTotalFeatures()[0]).isGreaterThan(trends.getFailedFeatures()[0]);

--- a/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
@@ -6,11 +6,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.File;
 import java.util.Properties;
 
-import mockit.Deencapsulation;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.velocity.VelocityContext;
 import org.junit.Before;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 import net.masterthought.cucumber.ReportBuilder;
 import net.masterthought.cucumber.Trends;
@@ -91,18 +91,18 @@ public class AbstractPageTest extends PageTest {
         };
 
         // when & then
-        assertThatThrownBy(() -> Deencapsulation.invoke(page, "generatePage"))
+        assertThatThrownBy(() -> Whitebox.invokeMethod(page, "generatePage"))
                 .isInstanceOf(ValidationException.class);
     }
 
     @Test
-    public void buildProperties_ReturnsProperties() {
+    public void buildProperties_ReturnsProperties() throws Exception {
 
         // given
         page = new FeaturesOverviewPage(reportResult, configuration);
 
         // when
-        Properties props = Deencapsulation.invoke(page, "buildProperties");
+        Properties props = Whitebox.invokeMethod(page, "buildProperties");
 
         // then
         assertThat(props).hasSize(3);
@@ -213,11 +213,11 @@ public class AbstractPageTest extends PageTest {
     }
 
     @Test
-    public void buildGeneralParameters_OnTrendsStatsFile_AddsTrendsFlag() {
+    public void buildGeneralParameters_OnTrendsStatsFile_AddsTrendsFlag() throws Exception {
 
         // given
         configuration.setTrendsStatsFile(TRENDS_FILE);
-        Trends trends = Deencapsulation.invoke(ReportBuilder.class, "loadTrends", TRENDS_FILE);
+        Trends trends = Whitebox.invokeMethod(ReportBuilder.class, "loadTrends", TRENDS_FILE);
         page = new TrendsOverviewPage(reportResult, configuration, trends);
 
         // when

--- a/src/test/java/net/masterthought/cucumber/generators/TrendsOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TrendsOverviewPageTest.java
@@ -3,7 +3,6 @@ package net.masterthought.cucumber.generators;
 import java.io.File;
 import java.io.IOException;
 
-import mockit.Deencapsulation;
 import net.masterthought.cucumber.ReportBuilder;
 import net.masterthought.cucumber.ReportResult;
 import net.masterthought.cucumber.Trends;
@@ -12,6 +11,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.velocity.VelocityContext;
 import org.junit.Before;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,14 +44,14 @@ public class TrendsOverviewPageTest extends PageTest {
     }
 
     @Test
-    public void prepareReport_AddsCustomProperties() {
+    public void prepareReport_AddsCustomProperties() throws Exception {
 
         // given
         configuration.setBuildNumber("myBuild");
-        Trends trends = Deencapsulation.invoke(ReportBuilder.class, "loadTrends", new File(TRENDS_TMP_FILE));
+        Trends trends = Whitebox.invokeMethod(ReportBuilder.class, "loadTrends", new File(TRENDS_TMP_FILE));
         page = new TrendsOverviewPage(reportResult, configuration, trends);
 
-        Deencapsulation.setField(page, "reportResult", new ReportResult(features, configuration));
+        Whitebox.setInternalState(page, "reportResult", new ReportResult(features, configuration));
 
         // when
         page.prepareReport();

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/TrendsOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/TrendsOverviewPageIntegrationTest.java
@@ -2,8 +2,8 @@ package net.masterthought.cucumber.generators.integrations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import mockit.Deencapsulation;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 import net.masterthought.cucumber.ReportBuilder;
 import net.masterthought.cucumber.Trends;
@@ -18,11 +18,11 @@ import net.masterthought.cucumber.generators.integrations.helpers.WebAssertion;
 public class TrendsOverviewPageIntegrationTest extends PageTest {
 
     @Test
-    public void generatePage_generatesTitle() {
+    public void generatePage_generatesTitle() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
-        Trends trends = Deencapsulation.invoke(ReportBuilder.class, "loadTrends", TRENDS_FILE);
+        Trends trends = Whitebox.invokeMethod(ReportBuilder.class, "loadTrends", TRENDS_FILE);
         page = new TrendsOverviewPage(reportResult, configuration, trends);
         final String titleValue = String.format("Cucumber Reports  - Trends Overview",
                 configuration.getBuildNumber());
@@ -38,11 +38,11 @@ public class TrendsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesLead() {
+    public void generatePage_generatesLead() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
-        Trends trends = Deencapsulation.invoke(ReportBuilder.class, "loadTrends", TRENDS_FILE);
+        Trends trends = Whitebox.invokeMethod(ReportBuilder.class, "loadTrends", TRENDS_FILE);
         page = new TrendsOverviewPage(reportResult, configuration, trends);
 
         // when
@@ -57,11 +57,11 @@ public class TrendsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesCharts() {
+    public void generatePage_generatesCharts() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
-        Trends trends = Deencapsulation.invoke(ReportBuilder.class, "loadTrends", TRENDS_FILE);
+        Trends trends = Whitebox.invokeMethod(ReportBuilder.class, "loadTrends", TRENDS_FILE);
         page = new TrendsOverviewPage(reportResult, configuration, trends);
 
         // when
@@ -77,11 +77,11 @@ public class TrendsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_insertsChartData() {
+    public void generatePage_insertsChartData() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
-        Trends trends = Deencapsulation.invoke(ReportBuilder.class, "loadTrends", TRENDS_FILE);
+        Trends trends = Whitebox.invokeMethod(ReportBuilder.class, "loadTrends", TRENDS_FILE);
         page = new TrendsOverviewPage(reportResult, configuration, trends);
 
         // when

--- a/src/test/java/net/masterthought/cucumber/json/ArgumentTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/ArgumentTest.java
@@ -2,9 +2,9 @@ package net.masterthought.cucumber.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import mockit.Deencapsulation;
 import org.junit.Before;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.support.Argument;
@@ -24,7 +24,7 @@ public class ArgumentTest extends PageTest {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[5];
-        Argument[] arguments = Deencapsulation.getField(step, "arguments");
+        Argument[] arguments = Whitebox.getInternalState(step, "arguments");
 
         // when
         Row[] rows = arguments[0].getRows();

--- a/src/test/java/net/masterthought/cucumber/json/FeatureTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/FeatureTest.java
@@ -2,11 +2,11 @@ package net.masterthought.cucumber.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import mockit.Deencapsulation;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.support.Status;
 import org.junit.Before;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
@@ -61,14 +61,14 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void calculateReportFileName_ReturnsFileName() {
+    public void calculateReportFileName_ReturnsFileName() throws Exception {
 
         // given
         Feature feature = features.get(1);
         final int jsonFileNo = 3;
 
         // when
-        String reportFileName = Deencapsulation.invoke(feature, "calculateReportFileName", jsonFileNo);
+        String reportFileName = Whitebox.invokeMethod(feature, "calculateReportFileName", jsonFileNo);
 
         // then
         assertThat(reportFileName).isEqualTo("report-feature_3_1515379431.html");

--- a/src/test/java/net/masterthought/cucumber/json/support/ResultsableBuilder.java
+++ b/src/test/java/net/masterthought/cucumber/json/support/ResultsableBuilder.java
@@ -1,6 +1,6 @@
 package net.masterthought.cucumber.json.support;
 
-import mockit.Deencapsulation;
+import org.powermock.reflect.Whitebox;
 
 import net.masterthought.cucumber.json.Match;
 import net.masterthought.cucumber.json.Output;
@@ -29,7 +29,7 @@ public class ResultsableBuilder {
 
         ResultsableMock(Status status) {
             this.result = new Result();
-            Deencapsulation.setField(this.result, "status", status);
+            Whitebox.setInternalState(this.result, "status", status);
         }
 
         @Override

--- a/src/test/java/net/masterthought/cucumber/sorting/FeaturesAlphabeticalComparatorTest.java
+++ b/src/test/java/net/masterthought/cucumber/sorting/FeaturesAlphabeticalComparatorTest.java
@@ -4,9 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Comparator;
 
-import mockit.Deencapsulation;
 import org.junit.Before;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.Feature;
@@ -81,9 +81,9 @@ public class FeaturesAlphabeticalComparatorTest extends PageTest {
 
     private static Feature buildFeature(final String name, final String id, final String reportFileName) {
         Feature feature = new Feature();
-        Deencapsulation.setField(feature, "name", name);
-        Deencapsulation.setField(feature, "id", id);
-        Deencapsulation.setField(feature, "reportFileName", reportFileName);
+        Whitebox.setInternalState(feature, "name", name);
+        Whitebox.setInternalState(feature, "id", id);
+        Whitebox.setInternalState(feature, "reportFileName", reportFileName);
 
         return feature;
     }

--- a/src/test/java/net/masterthought/cucumber/sorting/SortingFactoryTest.java
+++ b/src/test/java/net/masterthought/cucumber/sorting/SortingFactoryTest.java
@@ -5,9 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
-import mockit.Deencapsulation;
 import org.junit.Before;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.Feature;
@@ -148,14 +148,14 @@ public class SortingFactoryTest extends PageTest {
     }
 
     @Test
-    public void createUnknownMethodException_CreatesException() {
+    public void createUnknownMethodException_CreatesException() throws Exception {
 
         // given
         SortingMethod invalidSorthingMethod = SortingMethod.ALPHABETICAL;
         SortingFactory sortingFactory = new SortingFactory(SortingMethod.ALPHABETICAL);
 
         // when
-        Exception e = Deencapsulation.invoke(sortingFactory, "createUnknownMethodException", invalidSorthingMethod);
+        Exception e = Whitebox.invokeMethod(sortingFactory, "createUnknownMethodException", invalidSorthingMethod);
 
         // then
         assertThat(e).isExactlyInstanceOf(IllegalArgumentException.class).hasMessage("Unsupported sorting method: " + invalidSorthingMethod);


### PR DESCRIPTION
As the current maintainer of jmockit, I highly advice not using jmockit any more.  The original author vanished back in 2020 and its a considerable mess thus your own comment stuck on old.  While deencapsulation is now added back in current release, its native replacement is whiteboxing and this project already used powermock.  Switching was trivial.