### PR TITLE
Add test for getExtension method in Embedding class

### DIFF
--- a/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
@@ -134,6 +134,23 @@ public class EmbeddingTest {
     }
 
     @Test
+    public void getExtension_UsesExtensionFromNameWhenMIMETypeIsUnknown() {
+        // Arrange
+        String mimeType = "unknown/mimetype";
+        String data = "c29tZSBkYXRh";
+        String name = "example.docx";
+
+        // Creating an embedding here with an unknown MIME type and a name containing a file extension
+        Embedding embedding = new Embedding(mimeType, data, name);
+
+        // Act
+        String actualExtension = embedding.getExtension();
+
+        // Assert
+        assertThat(actualExtension).isEqualTo("docx");
+    }
+
+    @Test
     public void getName_ReturnsNull() {
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data);


### PR DESCRIPTION
## Pull Request Summary

This pull request introduces a new test case in the `EmbeddingTest` class, specifically in the `getExtension` method. The test, named `getExtension_UsesExtensionFromNameWhenMIMETypeIsUnknown`, verifies that the method correctly retrieves the file extension from the name when the MIME type is unknown. This improvement makes sure our code handles unknown file types more effectively and adds to the overall coverage of our code tests.

Your review of the changes is appreciated. Thank you!
