### PR TITLE
Scan sonar with JDK 17

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - master
   # do not validate pull requests because SONAR_TOKEN is available only for project owner
-
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,7 +21,7 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: adopt
 
       - name: Build with Maven


### PR DESCRIPTION
- Starting from 15 Jan 2024, SonarCloud will stop accepting scans that are started with Java 11. We highly recommend moving your configuration to Java 17+.