### PR TITLE
Allow builds to run with java 17 or 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '11' ]
+        java: [ '11', '17', '21' ]
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
 
     runs-on: ${{ matrix.os }}

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,16 @@
             </build>
 
         </profile>
+
+        <profile>
+            <id>jdk17on</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <properties>
+                <argLine>--add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
+            </properties>
+        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
The profile needs are to allow java 17 or higher.  To test, remove them, run build with java 17, see first issue, then add back until working.

Added GHA to matrix for java 17 and 21.  This should also work with jdk 22 as well now.