### PR TITLE
[io] Update commons io to 2.11.0 and fix code to handle illegal argument exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -175,7 +175,7 @@ public class ReportBuilder {
         } catch (FileNotFoundException e) {
             LOG.log(Level.WARNING, "File not found: {0}", srcFile.getAbsolutePath());
             LOG.log(Level.FINE, "", e);
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new ValidationException(e);
         }
     }


### PR DESCRIPTION
mainly due to test sending incredibly wrong value on purpose that old version just stated io exception on but now is illegal argument exception.