### PR TITLE
[GHA] Do not run sonarcloud on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: adopt

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: adopt
@@ -25,4 +25,4 @@ jobs:
       - name: Generate code coverage
         run: mvn --batch-mode test
 
-      - uses: codecov/codecov-action@v3.1.0
+      - uses: codecov/codecov-action@v3

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    # Do not run on forks as unnecessary
+    if: github.repository_owner == 'damianszczepanik'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: adopt
@@ -21,7 +21,7 @@ jobs:
       - name: Generate demo report
         run: mvn --batch-mode test
 
-      - uses: peaceiris/actions-gh-pages@v3.7.3
+      - uses: peaceiris/actions-gh-pages@v3
         with:
           external_repository: damianszczepanik/damianszczepanik.github.io
           personal_token: ${{ secrets.GH_PAGES_UPLOAD }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - master
-  # do not validate pull requests because SONAR_TOKEN is available only for project owner
+  # Run against master only to not overwhelm sonar given master branch is the base used branch
 
 jobs:
   build:
+    # Do not run sonar on forks because SONAR_TOKEN is available only for project owner
     if: github.repository_owner == 'damianszczepanik'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: github.repository_owner == 'damianszczepanik'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  # Run against master only to not overwhelm sonar given master branch is the base used branch
+  # Community version only allows running against 'main' branch, see https://docs.sonarsource.com/sonarqube/latest/devops-platform-integration/github-integration/
 
 jobs:
   build:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: adopt


### PR DESCRIPTION
Noticed on my fork that sonar cloud was trying to run and of course failing, add line to prevent it from running on anyone but owner of repository.  You may want this partially in other cases such as gh-pages but that one was not failing for me.