### PR TITLE
Migrate to junit5 jupiter / moderize test library usage / enable all the paramertized tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,20 +282,26 @@
 
         <!-- for testing -->
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -282,9 +282,9 @@
 
         <!-- for testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <maven.compile.encoding>UTF-8</maven.compile.encoding>
 
         <jackson.version>2.16.0</jackson.version>
+        <junit.version>5.10.1</junit.version>
 
         <test.integration.pattern>**/*IntegrationTest*.java</test.integration.pattern>
     </properties>
@@ -283,13 +284,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.10.1</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.10.1</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -186,10 +186,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.3</version>
                 <configuration>
-                    <systemPropertyVariables>
-                        <!-- JaCoCo runtime must know where to dump coverage: -->
-                        <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
-                    </systemPropertyVariables>
                     <excludes>
                         <!-- Integration tests should not be counted by code coverage -->
                         <exclude>${test.integration.pattern}</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
         <maven.compile.encoding>UTF-8</maven.compile.encoding>
 
         <jackson.version>2.16.0</jackson.version>
-        <powermock.version>2.0.9</powermock.version>
 
         <test.integration.pattern>**/*IntegrationTest*.java</test.integration.pattern>
     </properties>
@@ -301,14 +300,8 @@
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
             <artifactId>powermock-reflect</artifactId>
-            <version>${powermock.version}</version>
+            <version>2.0.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/LiveDemoTest.java
+++ b/src/test/java/LiveDemoTest.java
@@ -5,23 +5,22 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
-
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportBuilder;
 import net.masterthought.cucumber.presentation.PresentationMode;
 import net.masterthought.cucumber.sorting.SortingMethod;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class LiveDemoTest {
+class LiveDemoTest {
 
     // test annotation only to make sure it is generated during "mvn test"
     // what is needed to publish generated report via github.com
     // http://damianszczepanik.github.io/cucumber-html-reports/overview-features.html
     @Test
-    public void generateDemoReport() throws IOException {
+    void generateDemoReport() throws IOException {
         File reportOutputDirectory = new File("target/demo");
         List<String> jsonFiles = new ArrayList<>();
         jsonFiles.add("src/test/resources/json/sample.json");

--- a/src/test/java/net/masterthought/cucumber/ConfigurationTest.java
+++ b/src/test/java/net/masterthought/cucumber/ConfigurationTest.java
@@ -16,19 +16,19 @@ import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.presentation.PresentationMode;
 import net.masterthought.cucumber.reducers.ReducingMethod;
 import net.masterthought.cucumber.sorting.SortingMethod;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class ConfigurationTest {
+class ConfigurationTest {
 
     private static final File outputDirectory = new File("abc");
 
     private final String projectName = "123";
 
     @Test
-    public void getReportDirectory_ReturnsOutputDirectory() {
+    void getReportDirectory_ReturnsOutputDirectory() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -41,7 +41,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getTrendsStatsFile_ReturnsTrendsFile() {
+    void getTrendsStatsFile_ReturnsTrendsFile() {
 
         // given
         File file = new File("ble");
@@ -55,7 +55,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void isTrendsStatsFile_ChecksIfTrendsFileWasSet() {
+    void isTrendsStatsFile_ChecksIfTrendsFileWasSet() {
 
         // given
         File file = new File("ble");
@@ -69,7 +69,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getTrendsLimit_ReturnsLimitForTrends() {
+    void getTrendsLimit_ReturnsLimitForTrends() {
 
         // given
         final int limit = 123;
@@ -83,7 +83,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void isTrendsAvailable_OnNoTrendsPage_ReturnsFalse() {
+    void isTrendsAvailable_OnNoTrendsPage_ReturnsFalse() {
 
         // given
         final int limit = -1;
@@ -98,7 +98,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void isTrendsAvailable_OnNoTrendsFile_ReturnsFalse() {
+    void isTrendsAvailable_OnNoTrendsFile_ReturnsFalse() {
 
         // given
         final int limit = 10;
@@ -112,7 +112,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getBuildNumber_ReturnsBuildNumber() {
+    void getBuildNumber_ReturnsBuildNumber() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -127,7 +127,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getProjectName_ReturnsProjectName() {
+    void getProjectName_ReturnsProjectName() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -140,7 +140,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getTagsToExcludeFromChart_ReturnsEmptyList() {
+    void getTagsToExcludeFromChart_ReturnsEmptyList() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -153,7 +153,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getDirectorySuffix_ReturnsDirectorySuffix() {
+    void getDirectorySuffix_ReturnsDirectorySuffix() {
 
         // given
         String directorySuffix = "test";
@@ -167,7 +167,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getDirectorySuffixWithSeparator_ReturnsDirectorySuffixWithSeparator() {
+    void getDirectorySuffixWithSeparator_ReturnsDirectorySuffixWithSeparator() {
 
         // given
         String directorySuffix = "test";
@@ -181,7 +181,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getDirectorySuffixWithSeparatorForEmptySuffix_ReturnsEmptyString() {
+    void getDirectorySuffixWithSeparatorForEmptySuffix_ReturnsEmptyString() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -191,7 +191,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getQualifier_ReturnsQualifierWhenSet() {
+    void getQualifier_ReturnsQualifierWhenSet() {
 
         // given
         String jsonFile = "test";
@@ -206,7 +206,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getQualifier_ReturnsNullWhenNotSet() {
+    void getQualifier_ReturnsNullWhenNotSet() {
 
         // given
         String jsonFile = "test";
@@ -217,7 +217,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getQualifier_ReturnsNullWhenSetThenRemoved() {
+    void getQualifier_ReturnsNullWhenSetThenRemoved() {
 
         // given
         String jsonFile = "test";
@@ -233,7 +233,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void isQualifierSet_ReturnsTrueWhenSet() {
+    void isQualifierSet_ReturnsTrueWhenSet() {
 
         // given
         String jsonFile = "test";
@@ -248,7 +248,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void isQualifierSet_ReturnsTrueWhenNotSet() {
+    void isQualifierSet_ReturnsTrueWhenNotSet() {
 
         // given
         String jsonFile = "test";
@@ -259,7 +259,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void isQualifierSet_ReturnsTrueWhenSetThenRemoved() {
+    void isQualifierSet_ReturnsTrueWhenSetThenRemoved() {
 
         // given
         String jsonFile = "test";
@@ -275,7 +275,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getTagsToExcludeFromChart_addPatterns_ReturnsListWithAllPatterns() {
+    void getTagsToExcludeFromChart_addPatterns_ReturnsListWithAllPatterns() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -291,7 +291,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void setTagsToExcludeFromChart_OnInvalidRegexPattern_ThrowsValidationException() {
+    void setTagsToExcludeFromChart_OnInvalidRegexPattern_ThrowsValidationException() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -301,7 +301,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void addClassifications_AddsClassification() {
+    void addClassifications_AddsClassification() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -319,7 +319,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void setSortingMethod_SetsSortingMethod() {
+    void setSortingMethod_SetsSortingMethod() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -333,7 +333,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void addReducingMethod_AddsReducingMethod() {
+    void addReducingMethod_AddsReducingMethod() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -347,7 +347,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void containsReducingMethod_ChecksExistenceOfReducingMethod() {
+    void containsReducingMethod_ChecksExistenceOfReducingMethod() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -361,7 +361,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void addPresentationMode_AddsPresentationMode() {
+    void addPresentationMode_AddsPresentationMode() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -375,7 +375,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void addClassificationFiles_addsPropertyFiles() {
+    void addClassificationFiles_addsPropertyFiles() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -396,7 +396,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void getNotFailingStatuses_ReturnsNotFailingStatuses() {
+    void getNotFailingStatuses_ReturnsNotFailingStatuses() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -411,7 +411,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void setNotFailingStatuses_SkipsNullValues() {
+    void setNotFailingStatuses_SkipsNullValues() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -426,7 +426,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void addCustomCssFiles_addsPropertyFiles() {
+    void addCustomCssFiles_addsPropertyFiles() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);
@@ -443,7 +443,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void addCustomJsFiles_addsPropertyFiles() {
+    void addCustomJsFiles_addsPropertyFiles() {
 
         // given
         Configuration configuration = new Configuration(outputDirectory, projectName);

--- a/src/test/java/net/masterthought/cucumber/EmptyReportableTest.java
+++ b/src/test/java/net/masterthought/cucumber/EmptyReportableTest.java
@@ -2,15 +2,15 @@ package net.masterthought.cucumber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class EmptyReportableTest {
+class EmptyReportableTest {
 
     @Test
-    public void allMethods_ReturnsDefaultValues() {
+    void allMethods_ReturnsDefaultValues() {
 
         // given
         EmptyReportable reportable = new EmptyReportable();

--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -19,20 +19,20 @@ import net.masterthought.cucumber.generators.OverviewReport;
 import net.masterthought.cucumber.json.Feature;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class ReportBuilderTest extends ReportGenerator {
+class ReportBuilderTest extends ReportGenerator {
 
     private File reportDirectory;
     private File trendsFileTmp;
 
-    @Before
-    public void setUp() throws IOException {
+    @BeforeEach
+    void setUp() throws IOException {
         reportDirectory = new File("target", String.valueOf(System.currentTimeMillis()));
         // random temp directory
         reportDirectory.mkdirs();
@@ -46,7 +46,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void ReportBuilder_storesFilesAndConfiguration() {
+    void ReportBuilder_storesFilesAndConfiguration() {
 
         // given
         final List<String> jsonFiles = new ArrayList<>();
@@ -64,7 +64,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void generateReports_GeneratesPages() {
+    void generateReports_GeneratesPages() {
 
         // given
         List<String> jsonReports = Arrays.asList(ReportGenerator.reportFromResource(ReportGenerator.SAMPLE_JSON));
@@ -81,7 +81,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void generateReports_WithTrendsFile_GeneratesPages() {
+    void generateReports_WithTrendsFile_GeneratesPages() {
 
         // given
         List<String> jsonReports = Arrays.asList(ReportGenerator.reportFromResource(ReportGenerator.SAMPLE_JSON));
@@ -99,7 +99,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void generateReports_OnException_AppendsBuildToTrends() throws Exception {
+    void generateReports_OnException_AppendsBuildToTrends() throws Exception {
 
         // given
         List<String> jsonReports = Arrays.asList(ReportGenerator.reportFromResource(ReportGenerator.SAMPLE_JSON));
@@ -126,7 +126,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void generateReports_OnException_StoresEmptyTrendsFile() {
+    void generateReports_OnException_StoresEmptyTrendsFile() {
 
         // given
         List<String> jsonReports = Arrays.asList(ReportGenerator.reportFromResource(ReportGenerator.SAMPLE_JSON));
@@ -150,7 +150,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void copyStaticResources_CopiesRequiredFiles() throws Exception {
+    void copyStaticResources_CopiesRequiredFiles() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -166,7 +166,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void createEmbeddingsDirectory_CreatesDirectory() throws Exception {
+    void createEmbeddingsDirectory_CreatesDirectory() throws Exception {
 
         // given
         File subDirectory = new File(reportDirectory, "sub");
@@ -182,7 +182,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void copyResources_OnInvalidPath_ThrowsException() throws Exception {
+    void copyResources_OnInvalidPath_ThrowsException() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -200,7 +200,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void copyCustomResources_OnInvalidPath_DoesNotThrowsException() throws Exception {
+    void copyCustomResources_OnInvalidPath_DoesNotThrowsException() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -216,7 +216,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void copyCustomResources_OnDirAsFile_ThrowsIOException() throws Exception {
+    void copyCustomResources_OnDirAsFile_ThrowsIOException() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -234,7 +234,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void copyCustomResources_CheckCopiedFiles() throws Exception {
+    void copyCustomResources_CheckCopiedFiles() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -251,7 +251,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void collectPages_CollectsPages() throws Exception {
+    void collectPages_CollectsPages() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -267,7 +267,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void collectPages_OnExistingTrendsFile_CollectsPages() throws Exception {
+    void collectPages_OnExistingTrendsFile_CollectsPages() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -284,7 +284,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void updateAndSaveTrends_ReturnsUpdatedTrends() throws Exception {
+    void updateAndSaveTrends_ReturnsUpdatedTrends() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -305,7 +305,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void updateAndSaveTrends_OnTrendsLimit_ReturnsUpdatedTrends() throws Exception {
+    void updateAndSaveTrends_OnTrendsLimit_ReturnsUpdatedTrends() throws Exception {
 
         // given
         final int trendsLimit = 2;
@@ -327,7 +327,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void loadTrends_ReturnsTrends() throws Exception {
+    void loadTrends_ReturnsTrends() throws Exception {
 
         // when
         Trends trends = Whitebox.invokeMethod(ReportBuilder.class, "loadTrends", TRENDS_FILE);
@@ -352,7 +352,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void loadTrends_OnMissingTrendsFile_ThrowsException() {
+    void loadTrends_OnMissingTrendsFile_ThrowsException() {
 
         // given
         File noExistingTrendsFile = new File("anyNoExisting?File");
@@ -363,7 +363,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void loadOrCreateTrends_ReturnsLoadedTrends() throws Exception {
+    void loadOrCreateTrends_ReturnsLoadedTrends() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -378,7 +378,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void loadOrCreateTrends_OnMissingTrendsFile_ReturnsEmptyTrends() throws Exception {
+    void loadOrCreateTrends_OnMissingTrendsFile_ReturnsEmptyTrends() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -393,7 +393,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void loadOrCreateTrends_OnInvalidTrendsFile_ReturnsEmptyTrends() throws Exception {
+    void loadOrCreateTrends_OnInvalidTrendsFile_ReturnsEmptyTrends() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
@@ -407,7 +407,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void loadTrends_OnInvalidTrendsFormatFile_ThrowsExceptions() {
+    void loadTrends_OnInvalidTrendsFormatFile_ThrowsExceptions() {
 
         // given
         File notTrendJsonFile = new File(reportFromResource(SAMPLE_JSON));
@@ -419,7 +419,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void loadTrends_OnInvalidTrendsFile_ThrowsExceptions() {
+    void loadTrends_OnInvalidTrendsFile_ThrowsExceptions() {
 
         // given
         File directoryFile = new File(".");
@@ -431,7 +431,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void appendToTrends_AppendsDataToTrends() throws Exception {
+    void appendToTrends_AppendsDataToTrends() throws Exception {
 
         // given
         final String buildNumber = "1";
@@ -501,7 +501,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void saveTrends_OnInvalidFile_ThrowsException() {
+    void saveTrends_OnInvalidFile_ThrowsException() {
 
         // given
         ReportBuilder builder = new ReportBuilder(jsonReports, configuration);
@@ -516,7 +516,7 @@ public class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    public void generateErrorPage_GeneratesErrorPage() throws Exception {
+    void generateErrorPage_GeneratesErrorPage() throws Exception {
 
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");

--- a/src/test/java/net/masterthought/cucumber/ReportParserTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportParserTest.java
@@ -13,16 +13,16 @@ import net.masterthought.cucumber.json.Feature;
 import net.masterthought.cucumber.reducers.ReducingMethod;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.data.Index;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class ReportParserTest extends ReportGenerator {
+class ReportParserTest extends ReportGenerator {
 
     @Test
-    public void parseJsonFiles_ReturnsFeatureFiles() {
+    void parseJsonFiles_ReturnsFeatureFiles() {
 
         // given
         initWithJson(SAMPLE_JSON, SIMPLE_JSON);
@@ -36,7 +36,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseJsonFiles_Timestamp() {
+    void parseJsonFiles_Timestamp() {
         // given
         initWithJson(CUCUMBER_TIMESTAMPED_JSON);
         ReportParser reportParser = new ReportParser(configuration);
@@ -59,7 +59,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseJsonFiles_OnNoFeatures_ThrowsException() {
+    void parseJsonFiles_OnNoFeatures_ThrowsException() {
 
         // given
         initWithJson(EMPTY_JSON);
@@ -72,7 +72,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseJsonFiles_OnNoReport_ThrowsException() {
+    void parseJsonFiles_OnNoReport_ThrowsException() {
         // given
         initWithJson();
         ReportParser reportParser = new ReportParser(configuration);
@@ -84,7 +84,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseJsonFiles_OnInvalidReport_ThrowsException() {
+    void parseJsonFiles_OnInvalidReport_ThrowsException() {
 
         // given
         initWithJson(INVALID_REPORT_JSON);
@@ -97,7 +97,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseJsonFiles_OnNoExistingFile_ThrowsException() {
+    void parseJsonFiles_OnNoExistingFile_ThrowsException() {
 
         // given
         final String invalidFile = "?no-existing%file.json";
@@ -112,7 +112,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseJsonFiles_OnEmptyFile_SkipsJSONReport() {
+    void parseJsonFiles_OnEmptyFile_SkipsJSONReport() {
 
         // given
         initWithJson(EMPTY_FILE_JSON, SAMPLE_JSON);
@@ -127,7 +127,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void extractTarget_ReturnsFileNameWithoutExtension() throws Exception {
+    void extractTarget_ReturnsFileNameWithoutExtension() throws Exception {
 
         // given
         String jsonFile = SAMPLE_JSON;
@@ -143,7 +143,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void extractTarget_OnNoJSONFile_ReturnsFileName() throws Exception {
+    void extractTarget_OnNoJSONFile_ReturnsFileName() throws Exception {
 
         // given
         String jsonFile = SAMPLE_JSON + ".txt";
@@ -159,7 +159,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseClassificationsFiles_EmptyProperties() {
+    void parseClassificationsFiles_EmptyProperties() {
 
         // given
         initWithProperties(EMPTY_PROPERTIES);
@@ -173,7 +173,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseClassificationsFiles_Populates_One_File() {
+    void parseClassificationsFiles_Populates_One_File() {
 
         // given
         initWithProperties(SAMPLE_ONE_PROPERTIES);
@@ -187,7 +187,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseClassificationsFiles_Populates_Two_Files() {
+    void parseClassificationsFiles_Populates_Two_Files() {
 
         // given
         initWithProperties(SAMPLE_ONE_PROPERTIES, SAMPLE_TWO_PROPERTIES);
@@ -207,7 +207,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseClassificationsFiles_Populates_Two_Files_One_Empty() {
+    void parseClassificationsFiles_Populates_Two_Files_One_Empty() {
 
         // given
         initWithProperties(SAMPLE_ONE_PROPERTIES);
@@ -226,7 +226,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseClassificationsFiles_Populates_Check_Content_Integrity_And_Order() {
+    void parseClassificationsFiles_Populates_Check_Content_Integrity_And_Order() {
 
         // given
         initWithProperties(SAMPLE_TWO_PROPERTIES);
@@ -246,7 +246,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseClassificationsFiles_Populates_Check_Duplicates() {
+    void parseClassificationsFiles_Populates_Check_Duplicates() {
 
         // given
         initWithProperties(DUPLICATE_PROPERTIES);
@@ -264,7 +264,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseClassificationsFiles_Populates_Check_Special_Characters() {
+    void parseClassificationsFiles_Populates_Check_Special_Characters() {
 
         // given
         initWithProperties(SPECIAL_CHARACTERS_PROPERTIES);
@@ -287,7 +287,7 @@ public class ReportParserTest extends ReportGenerator {
     }
 
     @Test
-    public void parseClassificationsFiles_OnInvalidFilePath_ThrowsException() {
+    void parseClassificationsFiles_OnInvalidFilePath_ThrowsException() {
 
         // given
         final String invalidFile = "?on-invalid-file-path.properties";

--- a/src/test/java/net/masterthought/cucumber/ReportResultMergeTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportResultMergeTest.java
@@ -1,12 +1,13 @@
 package net.masterthought.cucumber;
 
 import net.masterthought.cucumber.json.Feature;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static net.masterthought.cucumber.reducers.ReducingMethod.MERGE_FEATURES_WITH_RETEST;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Expected conditions:
@@ -36,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   Scenario: Open Home page
  *     Given Open Home page
  */
-public class ReportResultMergeTest extends ReportGenerator {
+class ReportResultMergeTest extends ReportGenerator {
 
     private static final String TIMESTAMPED = "timestamped/";
     private static final String ALL_FAILED = TIMESTAMPED + "all-last-failed.json";
@@ -53,18 +54,20 @@ public class ReportResultMergeTest extends ReportGenerator {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void unsupportedReportFormat() {
-        // given
-        configuration.addReducingMethod(MERGE_FEATURES_WITH_RETEST);
+    @Test
+    void unsupportedReportFormat() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            // given
+            configuration.addReducingMethod(MERGE_FEATURES_WITH_RETEST);
 
-        // when
-        // then
-        setUpWithJson(SAMPLE_FAILED_JSON, SAMPLE_JSON);
+            // when
+            // then
+            setUpWithJson(SAMPLE_FAILED_JSON, SAMPLE_JSON);
+        });
     }
 
     @Test
-    public void test_checkAllFailedFileIsValidReport() {
+    void checkAllFailedFileIsValidReport() {
         // given
         // when
         setUpWithJson(ALL_FAILED);
@@ -74,7 +77,7 @@ public class ReportResultMergeTest extends ReportGenerator {
     }
 
     @Test
-    public void test_checkPartOneIsValidReport() {
+    void checkPartOneIsValidReport() {
         // given
         // when
         setUpWithJson(PART_ONE);
@@ -83,7 +86,7 @@ public class ReportResultMergeTest extends ReportGenerator {
     }
 
     @Test
-    public void test_checkPartTwoIsValidReport() {
+    void checkPartTwoIsValidReport() {
         // given
         // when
         setUpWithJson(PART_TWO);
@@ -93,7 +96,7 @@ public class ReportResultMergeTest extends ReportGenerator {
     }
 
     @Test
-    public void parsePartOneTwo_WithFailedRerun() {
+    void parsePartOneTwo_WithFailedRerun() {
         // given
         configuration.addReducingMethod(MERGE_FEATURES_WITH_RETEST);
         setUpWithJson(PART_ONE, PART_TWO, PART_TWO_RERUN_FAILED);
@@ -107,7 +110,7 @@ public class ReportResultMergeTest extends ReportGenerator {
     }
 
     @Test
-    public void merge_PartOneTwo_WithFailedRerun_Equals_AllInOneFailed() {
+    void merge_PartOneTwo_WithFailedRerun_Equals_AllInOneFailed() {
         // given
         configuration.addReducingMethod(MERGE_FEATURES_WITH_RETEST);
         setUpWithJson(PART_ONE, PART_TWO, PART_TWO_RERUN_FAILED);
@@ -123,7 +126,7 @@ public class ReportResultMergeTest extends ReportGenerator {
     }
 
     @Test
-    public void merge_PartOneTwo_WithPassedRerun_Equals_AllInOnePassed() {
+    void merge_PartOneTwo_WithPassedRerun_Equals_AllInOnePassed() {
         // given
         configuration.addReducingMethod(MERGE_FEATURES_WITH_RETEST);
         setUpWithJson(PART_ONE, PART_TWO, PART_TWO_RERUN_PASSED);

--- a/src/test/java/net/masterthought/cucumber/ReportResultTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportResultTest.java
@@ -5,9 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import net.masterthought.cucumber.json.Feature;
 import net.masterthought.cucumber.json.support.StepObject;
 import net.masterthought.cucumber.json.support.TagObject;
@@ -15,15 +14,15 @@ import net.masterthought.cucumber.json.support.TagObject;
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class ReportResultTest extends ReportGenerator {
+class ReportResultTest extends ReportGenerator {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getAllFeatures_ReturnsFeatures() {
+    void getAllFeatures_ReturnsFeatures() {
 
         // given
         // from @Before
@@ -36,7 +35,7 @@ public class ReportResultTest extends ReportGenerator {
     }
 
     @Test
-    public void getTags_ReturnsTags() {
+    void getTags_ReturnsTags() {
 
         // given
         // from @Before
@@ -49,7 +48,7 @@ public class ReportResultTest extends ReportGenerator {
     }
 
     @Test
-    public void getAllSteps_ReturnsSteps() {
+    void getAllSteps_ReturnsSteps() {
 
         // given
         // from @Before
@@ -62,7 +61,7 @@ public class ReportResultTest extends ReportGenerator {
     }
 
     @Test
-    public void getTagReport_ReturnsTagReport() {
+    void getTagReport_ReturnsTagReport() {
 
         // given
         // from @Before
@@ -75,7 +74,7 @@ public class ReportResultTest extends ReportGenerator {
     }
 
     @Test
-    public void getAllXXXFeatures_ReturnsFeaturesByStatus() {
+    void getAllXXXFeatures_ReturnsFeaturesByStatus() {
 
         // given
         // from @Before
@@ -90,7 +89,7 @@ public class ReportResultTest extends ReportGenerator {
     }
 
     @Test
-    public void getBuildTime_ReturnsFormattedBuildTime() {
+    void getBuildTime_ReturnsFormattedBuildTime() {
 
         // given
         // from @Before

--- a/src/test/java/net/masterthought/cucumber/TrendsTest.java
+++ b/src/test/java/net/masterthought/cucumber/TrendsTest.java
@@ -2,16 +2,16 @@ package net.masterthought.cucumber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class TrendsTest {
+class TrendsTest {
 
     @Test
-    public void addBuild_AddsNewResultAtTheLastPosition() {
+    void addBuild_AddsNewResultAtTheLastPosition() {
 
         // given
         Trends trends = new Trends();
@@ -46,7 +46,7 @@ public class TrendsTest {
     }
 
     @Test
-    public void addBuild_OnMissingDataForSteps_FillsMissingDataForSteps() {
+    void addBuild_OnMissingDataForSteps_FillsMissingDataForSteps() {
 
         // given
         Trends trends = new Trends();
@@ -75,7 +75,7 @@ public class TrendsTest {
     }
 
     @Test
-    public void limitItems_ReducesNumberOfItems() {
+    void limitItems_ReducesNumberOfItems() {
 
         // given
         final int limit = 1;
@@ -112,7 +112,7 @@ public class TrendsTest {
     }
 
     @Test
-    public void copyLastElements_OnBigLimit_ReturnsPassedIntArray() throws Exception {
+    void copyLastElements_OnBigLimit_ReturnsPassedIntArray() throws Exception {
 
         // given
         final int[] array = new int[]{3, 4, 5, 6, 7, 8};
@@ -126,7 +126,7 @@ public class TrendsTest {
     }
 
     @Test
-    public void copyLastElements_OnBigLimit_ReturnsPassedLongArray() throws Exception {
+    void copyLastElements_OnBigLimit_ReturnsPassedLongArray() throws Exception {
 
         // given
         final long[] array = new long[]{3, 4, 5, 6, 7, 8};
@@ -140,7 +140,7 @@ public class TrendsTest {
     }
 
     @Test
-    public void copyLastElements_OnBigLimit_ReturnsPassedStringArray() throws Exception {
+    void copyLastElements_OnBigLimit_ReturnsPassedStringArray() throws Exception {
 
         // given
         final String[] array = new String[]{"3", "4", "5", "6", "7", "8"};
@@ -154,7 +154,7 @@ public class TrendsTest {
     }
 
     @Test
-    public void applyPatchForFeatures_OnFailedGreaterThanTotal_ChangesTotalFeatureAndFailed() throws Exception {
+    void applyPatchForFeatures_OnFailedGreaterThanTotal_ChangesTotalFeatureAndFailed() throws Exception {
 
         // given
         final int totalFeatures = 1000;

--- a/src/test/java/net/masterthought/cucumber/ValidationExceptionTest.java
+++ b/src/test/java/net/masterthought/cucumber/ValidationExceptionTest.java
@@ -2,15 +2,15 @@ package net.masterthought.cucumber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class ValidationExceptionTest {
+class ValidationExceptionTest {
 
     @Test
-    public void constructor_PassesCause() {
+    void constructor_PassesCause() {
 
         // given
         Exception cause = new Exception();
@@ -23,7 +23,7 @@ public class ValidationExceptionTest {
     }
 
     @Test
-    public void constructor_PassesMessage() {
+    void constructor_PassesMessage() {
 
         // given
         String message = "ups...";
@@ -36,7 +36,7 @@ public class ValidationExceptionTest {
     }
 
     @Test
-    public void constructor_PassesMessageAndCause() {
+    void constructor_PassesMessageAndCause() {
 
         // given
         Exception cause = new Exception();

--- a/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/AbstractPageTest.java
@@ -8,8 +8,8 @@ import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.velocity.VelocityContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import net.masterthought.cucumber.ReportBuilder;
@@ -23,21 +23,18 @@ import net.masterthought.cucumber.util.Counter;
 import net.masterthought.cucumber.util.StepNameFormatter;
 import net.masterthought.cucumber.util.Util;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class AbstractPageTest extends PageTest {
+class AbstractPageTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void generateReport_CreatesReportFile() {
+    void generateReport_CreatesReportFile() {
 
         // given
         page = new FeaturesOverviewPage(reportResult, configuration);
@@ -53,7 +50,7 @@ public class AbstractPageTest extends PageTest {
 
 
     @Test
-    public void generateReport_DisplaysContentAsEscapedText() {
+    void generateReport_DisplaysContentAsEscapedText() {
 
         // given
         page = new FeatureReportPage(reportResult, configuration, features.get(1));
@@ -79,7 +76,7 @@ public class AbstractPageTest extends PageTest {
     }
 
     @Test
-    public void generateReport_OnInvalidPath_ThrowsException() {
+    void generateReport_OnInvalidPath_ThrowsException() {
 
         // given
         page = new FeaturesOverviewPage(reportResult, configuration) {
@@ -96,7 +93,7 @@ public class AbstractPageTest extends PageTest {
     }
 
     @Test
-    public void buildProperties_ReturnsProperties() throws Exception {
+    void buildProperties_ReturnsProperties() throws Exception {
 
         // given
         page = new FeaturesOverviewPage(reportResult, configuration);
@@ -112,7 +109,7 @@ public class AbstractPageTest extends PageTest {
     }
 
     @Test
-    public void buildGeneralParameters_AddsCommonProperties() {
+    void buildGeneralParameters_AddsCommonProperties() {
 
         // given
         configuration.addReducingMethod(ReducingMethod.HIDE_EMPTY_HOOKS);
@@ -147,7 +144,7 @@ public class AbstractPageTest extends PageTest {
     }
 
     @Test
-    public void buildGeneralParameters_OnInvalidBuildNumber_SkipsBuildPreviousNumberProperty() {
+    void buildGeneralParameters_OnInvalidBuildNumber_SkipsBuildPreviousNumberProperty() {
 
         // given
         configuration.setBuildNumber("notAnumber");
@@ -164,7 +161,7 @@ public class AbstractPageTest extends PageTest {
     }
 
     @Test
-    public void buildGeneralParameters_OnBuildNumber_AddsBuildPreviousNumberProperty() {
+    void buildGeneralParameters_OnBuildNumber_AddsBuildPreviousNumberProperty() {
 
         // given
         configuration.setBuildNumber("12");
@@ -180,7 +177,7 @@ public class AbstractPageTest extends PageTest {
     }
 
     @Test
-    public void buildGeneralParameters_OnErrorPage_AddsExtraProperties() {
+    void buildGeneralParameters_OnErrorPage_AddsExtraProperties() {
 
         // given
         configuration.setBuildNumber("3@");
@@ -196,7 +193,7 @@ public class AbstractPageTest extends PageTest {
     }
 
     @Test
-    public void buildGeneralParameters_OnInvalidBuildNumber_DoesNotAddPreviousBuildNumberProperty() {
+    void buildGeneralParameters_OnInvalidBuildNumber_DoesNotAddPreviousBuildNumberProperty() {
 
         // given
         configuration.setBuildNumber("34");
@@ -213,7 +210,7 @@ public class AbstractPageTest extends PageTest {
     }
 
     @Test
-    public void buildGeneralParameters_OnTrendsStatsFile_AddsTrendsFlag() throws Exception {
+    void buildGeneralParameters_OnTrendsStatsFile_AddsTrendsFlag() throws Exception {
 
         // given
         configuration.setTrendsStatsFile(TRENDS_FILE);

--- a/src/test/java/net/masterthought/cucumber/generators/ErrorPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/ErrorPageTest.java
@@ -5,23 +5,23 @@ import java.util.List;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.velocity.VelocityContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class ErrorPageTest extends PageTest {
+class ErrorPageTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void prepareReport_AddsCustomProperties() {
+    void prepareReport_AddsCustomProperties() {
 
         // give
         Exception exception = new Exception();

--- a/src/test/java/net/masterthought/cucumber/generators/EscapeHtmlReferenceTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/EscapeHtmlReferenceTest.java
@@ -1,7 +1,7 @@
 package net.masterthought.cucumber.generators;
 
 import org.apache.velocity.app.event.ReferenceInsertionEventHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,13 +9,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author M.P. Korstanje (mpkorstanje@github)
  */
-public class EscapeHtmlReferenceTest {
+class EscapeHtmlReferenceTest {
 
     private static final String SOME_REFERENCE = "someReference";
     private final ReferenceInsertionEventHandler insertionEventHandler = new EscapeHtmlReference();
 
     @Test
-    public void referenceInsert_returnNormalText(){
+    void referenceInsert_returnNormalText(){
         // given
         String normalText = "a plain statement";
 
@@ -27,7 +27,7 @@ public class EscapeHtmlReferenceTest {
     }
 
     @Test
-    public void referenceInsert_shouldEscapeHtmlForAnyLabel(){
+    void referenceInsert_shouldEscapeHtmlForAnyLabel(){
         // given
         String html = "<b>a bold statement</b>";
 
@@ -39,7 +39,7 @@ public class EscapeHtmlReferenceTest {
     }
 
     @Test
-    public void referenceInsert_shouldNotEscapeWithSpecialTag(){
+    void referenceInsert_shouldNotEscapeWithSpecialTag(){
         // given
         String html = "<b>a bold statement</b>";
 
@@ -51,7 +51,7 @@ public class EscapeHtmlReferenceTest {
     }
 
     @Test
-    public void referenceInsert_shouldReturnNullForNull(){
+    void referenceInsert_shouldReturnNullForNull(){
         // given
         String html = null;
 
@@ -63,7 +63,7 @@ public class EscapeHtmlReferenceTest {
     }
 
     @Test
-    public void referenceInsert_shouldSanitize(){
+    void referenceInsert_shouldSanitize(){
         // given
         String html = "<a href=\"www.example.com\" rel=\"nofollow noopener noreferrer\">a hyper web reference</a>";
 

--- a/src/test/java/net/masterthought/cucumber/generators/FailuresOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FailuresOverviewPageTest.java
@@ -7,23 +7,23 @@ import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.Element;
 import net.masterthought.cucumber.json.Feature;
 import org.apache.velocity.VelocityContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class FailuresOverviewPageTest extends PageTest {
+class FailuresOverviewPageTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getWebPage_ReturnsFailureReportFileName() {
+    void getWebPage_ReturnsFailureReportFileName() {
 
         // given
         page = new FailuresOverviewPage(reportResult, configuration);
@@ -36,7 +36,7 @@ public class FailuresOverviewPageTest extends PageTest {
     }
 
     @Test
-    public void prepareReport_AddsCustomProperties() {
+    void prepareReport_AddsCustomProperties() {
 
         // given
         page = new FailuresOverviewPage(reportResult, configuration);

--- a/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeatureReportPageTest.java
@@ -6,23 +6,23 @@ import net.masterthought.cucumber.json.Embedding;
 import net.masterthought.cucumber.json.Feature;
 import net.masterthought.cucumber.json.Step;
 import org.apache.velocity.VelocityContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class FeatureReportPageTest extends PageTest {
+class FeatureReportPageTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getWebPage_ReturnsFeatureFileName() {
+    void getWebPage_ReturnsFeatureFileName() {
 
         // given
         Feature feature = features.get(1);
@@ -36,7 +36,7 @@ public class FeatureReportPageTest extends PageTest {
     }
 
     @Test
-    public void prepareReport_AddsCustomProperties() {
+    void prepareReport_AddsCustomProperties() {
 
         // given
         Feature feature = features.get(1);
@@ -52,7 +52,7 @@ public class FeatureReportPageTest extends PageTest {
     }
 
     @Test
-    public void getMimeType_OnEmbeddingFromV2CucumberReportFile_SupportsScreenshots() {
+    void getMimeType_OnEmbeddingFromV2CucumberReportFile_SupportsScreenshots() {
         // given
         Feature feature = features.get(0);
         Element element = feature.getElements()[0];
@@ -66,7 +66,7 @@ public class FeatureReportPageTest extends PageTest {
     }
 
     @Test
-    public void getMimeType_OnEmbeddingFromV3CucumberReportFile_SupportsScreenshots() {
+    void getMimeType_OnEmbeddingFromV3CucumberReportFile_SupportsScreenshots() {
         // given
         Feature feature = features.get(0);
         Element element = feature.getElements()[0];

--- a/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/FeaturesOverviewPageTest.java
@@ -3,24 +3,23 @@ package net.masterthought.cucumber.generators;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.velocity.VelocityContext;
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import net.masterthought.cucumber.ReportBuilder;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class FeaturesOverviewPageTest extends PageTest {
+class FeaturesOverviewPageTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getWebPage_ReturnsFeatureFileName() {
+    void getWebPage_ReturnsFeatureFileName() {
 
         // given
         page = new FeaturesOverviewPage(reportResult, configuration);
@@ -33,7 +32,7 @@ public class FeaturesOverviewPageTest extends PageTest {
     }
 
     @Test
-    public void prepareReport_AddsCustomProperties() {
+    void prepareReport_AddsCustomProperties() {
 
         // given
         page = new FeaturesOverviewPage(reportResult, configuration);

--- a/src/test/java/net/masterthought/cucumber/generators/OverviewReportTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/OverviewReportTest.java
@@ -5,15 +5,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import net.masterthought.cucumber.json.support.Status;
 import org.apache.commons.lang3.NotImplementedException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class OverviewReportTest {
+class OverviewReportTest {
 
     @Test
-    public void incFeaturesFor_AddsFeatures() {
+    void incFeaturesFor_AddsFeatures() {
 
         // given
         OverviewReport refReport = buildSampleReport();
@@ -29,7 +29,7 @@ public class OverviewReportTest {
     }
 
     @Test
-    public void incScenarioFor_AddsScenario() {
+    void incScenarioFor_AddsScenario() {
 
         // given
         OverviewReport refReport = buildSampleReport();
@@ -45,7 +45,7 @@ public class OverviewReportTest {
     }
 
     @Test
-    public void getFeatures_ReturnsFeaturesCount() {
+    void getFeatures_ReturnsFeaturesCount() {
 
         // given
         OverviewReport report = buildSampleReport();
@@ -57,7 +57,7 @@ public class OverviewReportTest {
     }
 
     @Test
-    public void getPassedFeatures_ReturnsPassedFeaturesCount() {
+    void getPassedFeatures_ReturnsPassedFeaturesCount() {
 
         // given
         OverviewReport report = buildSampleReport();
@@ -70,7 +70,7 @@ public class OverviewReportTest {
 
 
     @Test
-    public void getFailedFeatures_ReturnsFAiledFeaturesCount() {
+    void getFailedFeatures_ReturnsFAiledFeaturesCount() {
 
         // given
         OverviewReport report = buildSampleReport();
@@ -83,7 +83,7 @@ public class OverviewReportTest {
 
 
     @Test
-    public void getScenarios_ReturnsNumberOfScenarios() {
+    void getScenarios_ReturnsNumberOfScenarios() {
 
         // given
         OverviewReport report = buildSampleReport();
@@ -93,7 +93,7 @@ public class OverviewReportTest {
     }
 
     @Test
-    public void getXXXScenarios_ReturnsNumberOfScenariosForStatus() {
+    void getXXXScenarios_ReturnsNumberOfScenariosForStatus() {
 
         // given
         OverviewReport report = buildSampleReport();
@@ -104,7 +104,7 @@ public class OverviewReportTest {
     }
 
     @Test
-    public void incStepsFor_AddsScenario() {
+    void incStepsFor_AddsScenario() {
 
         // given
         OverviewReport refReport = buildSampleReport();
@@ -120,7 +120,7 @@ public class OverviewReportTest {
     }
 
     @Test
-    public void getSteps_ReturnsNumberOfSteps() {
+    void getSteps_ReturnsNumberOfSteps() {
 
         // given
         OverviewReport report = buildSampleReport();
@@ -130,7 +130,7 @@ public class OverviewReportTest {
     }
 
     @Test
-    public void getXXXSteps_ReturnsNumberOfStepsForStatus() {
+    void getXXXSteps_ReturnsNumberOfStepsForStatus() {
 
         // given
         OverviewReport report = buildSampleReport();
@@ -144,7 +144,7 @@ public class OverviewReportTest {
     }
 
     @Test
-    public void incDuration_AddsDuration() {
+    void incDuration_AddsDuration() {
 
         // given
         long offset = 5555555;
@@ -159,7 +159,7 @@ public class OverviewReportTest {
     }
 
     @Test
-    public void getDuration_ReturnsDuration() {
+    void getDuration_ReturnsDuration() {
 
         // given
         OverviewReport report = buildSampleReport();
@@ -169,7 +169,7 @@ public class OverviewReportTest {
     }
 
     @Test
-    public void getFormattedDuration_ReturnsFormattedDuration() {
+    void getFormattedDuration_ReturnsFormattedDuration() {
 
         // given
         OverviewReport report = buildSampleReport();
@@ -179,7 +179,7 @@ public class OverviewReportTest {
     }
 
     @Test
-    public void getName_ThrowsException() {
+    void getName_ThrowsException() {
 
         // given
         OverviewReport report = buildSampleReport();
@@ -190,7 +190,7 @@ public class OverviewReportTest {
     }
 
     @Test
-    public void getStatus_ThrowsException() {
+    void getStatus_ThrowsException() {
 
         // given
         OverviewReport report = buildSampleReport();

--- a/src/test/java/net/masterthought/cucumber/generators/StepsOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/StepsOverviewPageTest.java
@@ -4,23 +4,23 @@ import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.support.StepObject;
 import net.masterthought.cucumber.util.Util;
 import org.apache.velocity.VelocityContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class StepsOverviewPageTest extends PageTest {
+class StepsOverviewPageTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getWebPage_ReturnsStepsOverviewFileName() {
+    void getWebPage_ReturnsStepsOverviewFileName() {
 
         // given
         page = new StepsOverviewPage(reportResult, configuration);
@@ -33,7 +33,7 @@ public class StepsOverviewPageTest extends PageTest {
     }
 
     @Test
-    public void prepareReport_AddsCustomProperties() {
+    void prepareReport_AddsCustomProperties() {
 
         // given
         page = new StepsOverviewPage(reportResult, configuration);

--- a/src/test/java/net/masterthought/cucumber/generators/TagReportPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TagReportPageTest.java
@@ -3,23 +3,23 @@ package net.masterthought.cucumber.generators;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.support.TagObject;
 import org.apache.velocity.VelocityContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class TagReportPageTest extends PageTest {
+class TagReportPageTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getWebPage_ReturnsTagReportFileName() {
+    void getWebPage_ReturnsTagReportFileName() {
 
         // given
         TagObject tag = tags.get(0);
@@ -33,7 +33,7 @@ public class TagReportPageTest extends PageTest {
     }
 
     @Test
-    public void prepareReport_AddsCustomProperties() {
+    void prepareReport_AddsCustomProperties() {
 
         // given
         TagObject tag = tags.get(1);

--- a/src/test/java/net/masterthought/cucumber/generators/TagsOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TagsOverviewPageTest.java
@@ -7,21 +7,21 @@ import java.util.List;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.support.TagObject;
 import org.apache.velocity.VelocityContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class TagsOverviewPageTest extends PageTest {
+class TagsOverviewPageTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getWebPage_ReturnsTagOverviewReportFileName() {
+    void getWebPage_ReturnsTagOverviewReportFileName() {
 
         // given
         page = new TagsOverviewPage(reportResult, configuration);
@@ -34,7 +34,7 @@ public class TagsOverviewPageTest extends PageTest {
     }
 
     @Test
-    public void prepareReport_AddsCustomProperties() {
+    void prepareReport_AddsCustomProperties() {
 
         // given
         page = new TagsOverviewPage(reportResult, configuration);
@@ -53,7 +53,7 @@ public class TagsOverviewPageTest extends PageTest {
     }
 
     @Test
-    public void generateTagLabels_ReturnsTags() {
+    void generateTagLabels_ReturnsTags() {
 
         // given
         List<TagObject> allTags = this.tags;
@@ -66,7 +66,7 @@ public class TagsOverviewPageTest extends PageTest {
     }
 
     @Test
-    public void generateTagValues_ReturnsTagValues() {
+    void generateTagValues_ReturnsTagValues() {
 
         // given
         List<TagObject> allTags = this.tags;

--- a/src/test/java/net/masterthought/cucumber/generators/TrendsOverviewPageTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/TrendsOverviewPageTest.java
@@ -9,8 +9,8 @@ import net.masterthought.cucumber.Trends;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import org.apache.commons.io.FileUtils;
 import org.apache.velocity.VelocityContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,20 +18,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class TrendsOverviewPageTest extends PageTest {
+class TrendsOverviewPageTest extends PageTest {
 
     private final String TRENDS_FILE = pathToSampleFile("cucumber-trends.json");
     private final String TRENDS_TMP_FILE = TRENDS_FILE + "-tmp";
 
-    @Before
-    public void setUp() throws IOException {
+    @BeforeEach
+    void setUp() throws IOException {
         setUpWithJson(SAMPLE_JSON);
         // refresh the file if it was already copied by another/previous test
         FileUtils.copyFile(new File(TRENDS_FILE), new File(TRENDS_TMP_FILE));
     }
 
     @Test
-    public void getWebPage_ReturnsTrendsOverviewFileName() {
+    void getWebPage_ReturnsTrendsOverviewFileName() {
 
         // given
         page = new TrendsOverviewPage(reportResult, configuration, null);
@@ -44,7 +44,7 @@ public class TrendsOverviewPageTest extends PageTest {
     }
 
     @Test
-    public void prepareReport_AddsCustomProperties() throws Exception {
+    void prepareReport_AddsCustomProperties() throws Exception {
 
         // given
         configuration.setBuildNumber("myBuild");

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/ErrorPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/ErrorPageIntegrationTest.java
@@ -6,17 +6,17 @@ import net.masterthought.cucumber.generators.ErrorPage;
 import net.masterthought.cucumber.generators.integrations.helpers.DocumentAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.LeadAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.WebAssertion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class ErrorPageIntegrationTest extends PageTest {
+class ErrorPageIntegrationTest extends PageTest {
 
     private final Exception cause = new IllegalArgumentException("Help me!");
 
     @Test
-    public void generatePage_generatesTitle() {
+    void generatePage_generatesTitle() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -34,7 +34,7 @@ public class ErrorPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesLead() {
+    void generatePage_generatesLead() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -54,7 +54,7 @@ public class ErrorPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesErrorMessage() {
+    void generatePage_generatesErrorMessage() {
 
         // given
         setUpWithJson(SAMPLE_JSON);

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FailuresOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FailuresOverviewPageIntegrationTest.java
@@ -2,22 +2,21 @@ package net.masterthought.cucumber.generators.integrations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-
 import net.masterthought.cucumber.generators.FailuresOverviewPage;
 import net.masterthought.cucumber.generators.integrations.helpers.DocumentAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.ElementAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.LeadAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.SummaryAssertion;
 import net.masterthought.cucumber.presentation.PresentationMode;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class FailuresOverviewPageIntegrationTest extends PageTest {
+class FailuresOverviewPageIntegrationTest extends PageTest {
 
     @Test
-    public void generatePage_generatesTitle() {
+    void generatePage_generatesTitle() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -38,7 +37,7 @@ public class FailuresOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesLead() {
+    void generatePage_generatesLead() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -56,7 +55,7 @@ public class FailuresOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_onJsonWithoutFailedSteps_generatesProperMessage() {
+    void generatePage_onJsonWithoutFailedSteps_generatesProperMessage() {
 
         // given
         setUpWithJson(SIMPLE_JSON);
@@ -72,7 +71,7 @@ public class FailuresOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesSummary() {
+    void generatePage_generatesSummary() {
 
         // given
         setUpWithJson(SAMPLE_JSON);

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FeatureReportPageIntegrationTest.java
@@ -28,17 +28,17 @@ import net.masterthought.cucumber.json.Row;
 import net.masterthought.cucumber.json.Step;
 import net.masterthought.cucumber.presentation.PresentationMode;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class FeatureReportPageIntegrationTest extends PageTest {
+class FeatureReportPageIntegrationTest extends PageTest {
 
     @Test
-    public void generatePage_generatesTitle() {
+    void generatePage_generatesTitle() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -57,7 +57,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_addsCustomJsFiles() {
+    void generatePage_addsCustomJsFiles() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -75,7 +75,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_addsCustomCssFiles() {
+    void generatePage_addsCustomCssFiles() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -94,7 +94,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesStatsTableBody() {
+    void generatePage_generatesStatsTableBody() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -113,7 +113,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_OnParallelTesting_generatesQualifierColumn() {
+    void generatePage_OnParallelTesting_generatesQualifierColumn() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -133,7 +133,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesFeatureDetails() {
+    void generatePage_generatesFeatureDetails() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -159,7 +159,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesScenarioDetails() {
+    void generatePage_generatesScenarioDetails() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -193,7 +193,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesHooks() {
+    void generatePage_generatesHooks() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -226,7 +226,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesSteps() {
+    void generatePage_generatesSteps() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -260,7 +260,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_OnBiDimentionalArray_generatesOutput() {
+    void generatePage_OnBiDimentionalArray_generatesOutput() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -279,7 +279,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_OnSingleArray_generatesOutput() {
+    void generatePage_OnSingleArray_generatesOutput() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -298,7 +298,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesArguments() {
+    void generatePage_generatesArguments() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -325,7 +325,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesDocString() {
+    void generatePage_generatesDocString() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -345,7 +345,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesEmbedding() {
+    void generatePage_generatesEmbedding() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -376,7 +376,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_OnRubyFormat_ForAfterHook_generatesEmbedding() {
+    void generatePage_OnRubyFormat_ForAfterHook_generatesEmbedding() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -399,7 +399,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_ForAfterElementHook_generatesOutputs() {
+    void generatePage_ForAfterElementHook_generatesOutputs() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -421,7 +421,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_ForBeforeStepHook_generatesHooks() {
+    void generatePage_ForBeforeStepHook_generatesHooks() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -443,7 +443,7 @@ public class FeatureReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_ForAfterStepHook_generatesHooks() {
+    void generatePage_ForAfterStepHook_generatesHooks() {
 
         // given
         setUpWithJson(SAMPLE_JSON);

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/FeaturesOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/FeaturesOverviewPageIntegrationTest.java
@@ -7,17 +7,17 @@ import net.masterthought.cucumber.generators.integrations.helpers.TableRowAssert
 import net.masterthought.cucumber.generators.integrations.helpers.WebAssertion;
 import net.masterthought.cucumber.presentation.PresentationMode;
 import org.apache.commons.io.FilenameUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class FeaturesOverviewPageIntegrationTest extends PageTest {
+class FeaturesOverviewPageIntegrationTest extends PageTest {
 
     @Test
-    public void generatePage_generatesTitle() {
+    void generatePage_generatesTitle() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -38,7 +38,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesLead() {
+    void generatePage_generatesLead() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -56,7 +56,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesClassifications() {
+    void generatePage_generatesClassifications() {
 
         // given
         final String[] names = {"Platform", "Browser", "Branch", "Repository"};
@@ -82,7 +82,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesCharts() {
+    void generatePage_generatesCharts() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -98,7 +98,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesStatsTableHeader() {
+    void generatePage_generatesStatsTableHeader() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -122,7 +122,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesStatsTableBody() {
+    void generatePage_generatesStatsTableBody() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -151,7 +151,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_WithSpecifiedQualifier_generatesStatsTableBody() {
+    void generatePage_WithSpecifiedQualifier_generatesStatsTableBody() {
 
         // given
         String testQualifier = "testQualifier";
@@ -174,7 +174,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_OnParallelTesting_generatesStatsTableBody() {
+    void generatePage_OnParallelTesting_generatesStatsTableBody() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -204,7 +204,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesStatsTableFooter() {
+    void generatePage_generatesStatsTableFooter() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -223,7 +223,7 @@ public class FeaturesOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_OnParallelTesting_generatesStatsTableFooter() {
+    void generatePage_OnParallelTesting_generatesStatsTableFooter() {
 
         // given
         setUpWithJson(SAMPLE_JSON);

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/PageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/PageIntegrationTest.java
@@ -5,9 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.util.Locale;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import net.masterthought.cucumber.generators.FailuresOverviewPage;
 import net.masterthought.cucumber.generators.FeaturesOverviewPage;
 import net.masterthought.cucumber.generators.StepsOverviewPage;
@@ -24,15 +23,15 @@ import net.masterthought.cucumber.presentation.PresentationMode;
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class PageIntegrationTest extends PageTest {
+class PageIntegrationTest extends PageTest {
 
-    @Before
-    public void prepare() {
+    @BeforeEach
+    void prepare() {
         Locale.setDefault(Locale.ENGLISH);
     }
 
     @Test
-    public void generatePage_onDefaultConfiguration_generatesDefaultItemsInNaviBar() {
+    void generatePage_onDefaultConfiguration_generatesDefaultItemsInNaviBar() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -56,7 +55,7 @@ public class PageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_onJenkinsConfiguration_generatesAllItemsInNaviBar() {
+    void generatePage_onJenkinsConfiguration_generatesAllItemsInNaviBar() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -82,7 +81,7 @@ public class PageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_onTrendsStatsFile_generatesAllItemsInNaviBar() {
+    void generatePage_onTrendsStatsFile_generatesAllItemsInNaviBar() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -105,7 +104,7 @@ public class PageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_onDefaultConfiguration_generatesSummaryTable() {
+    void generatePage_onDefaultConfiguration_generatesSummaryTable() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -126,7 +125,7 @@ public class PageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_onJenkinsConfiguration_generatesSummaryTableWithBuildNumber() {
+    void generatePage_onJenkinsConfiguration_generatesSummaryTableWithBuildNumber() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -151,7 +150,7 @@ public class PageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesFooter() {
+    void generatePage_generatesFooter() {
 
         // given
         setUpWithJson(SAMPLE_JSON);

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/StepsOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/StepsOverviewPageIntegrationTest.java
@@ -2,21 +2,20 @@ package net.masterthought.cucumber.generators.integrations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-
 import net.masterthought.cucumber.generators.StepsOverviewPage;
 import net.masterthought.cucumber.generators.integrations.helpers.DocumentAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.LeadAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.TableRowAssertion;
 import net.masterthought.cucumber.presentation.PresentationMode;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class StepsOverviewPageIntegrationTest extends PageTest {
+class StepsOverviewPageIntegrationTest extends PageTest {
 
     @Test
-    public void generatePage_generatesTitle() {
+    void generatePage_generatesTitle() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -37,7 +36,7 @@ public class StepsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesLead() {
+    void generatePage_generatesLead() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -57,7 +56,7 @@ public class StepsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesStatsTableHeader() {
+    void generatePage_generatesStatsTableHeader() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -77,7 +76,7 @@ public class StepsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesStatsTableBody() {
+    void generatePage_generatesStatsTableBody() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -103,7 +102,7 @@ public class StepsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesStatsTableFooter() {
+    void generatePage_generatesStatsTableFooter() {
 
         // given
         setUpWithJson(SAMPLE_JSON);

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/TagReportPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/TagReportPageIntegrationTest.java
@@ -2,8 +2,6 @@ package net.masterthought.cucumber.generators.integrations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-
 import net.masterthought.cucumber.generators.TagReportPage;
 import net.masterthought.cucumber.generators.integrations.helpers.BriefAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.DocumentAssertion;
@@ -12,14 +10,15 @@ import net.masterthought.cucumber.generators.integrations.helpers.LinkAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.TableRowAssertion;
 import net.masterthought.cucumber.json.Step;
 import net.masterthought.cucumber.json.support.TagObject;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class TagReportPageIntegrationTest extends PageTest {
+class TagReportPageIntegrationTest extends PageTest {
 
     @Test
-    public void generatePage_generatesTitle() {
+    void generatePage_generatesTitle() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -38,7 +37,7 @@ public class TagReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesStatsTableBody() {
+    void generatePage_generatesStatsTableBody() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -57,7 +56,7 @@ public class TagReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesFeatureNames() {
+    void generatePage_generatesFeatureNames() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -76,7 +75,7 @@ public class TagReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesTagsList() {
+    void generatePage_generatesTagsList() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -94,7 +93,7 @@ public class TagReportPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesSteps() {
+    void generatePage_generatesSteps() {
 
         // given
         setUpWithJson(SAMPLE_JSON);

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/TagsOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/TagsOverviewPageIntegrationTest.java
@@ -8,15 +8,15 @@ import net.masterthought.cucumber.generators.integrations.helpers.LeadAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.SummaryAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.TableRowAssertion;
 import net.masterthought.cucumber.generators.integrations.helpers.WebAssertion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class TagsOverviewPageIntegrationTest extends PageTest {
+class TagsOverviewPageIntegrationTest extends PageTest {
 
     @Test
-    public void generatePage_generatesTitle() {
+    void generatePage_generatesTitle() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -35,7 +35,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesLead() {
+    void generatePage_generatesLead() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -53,7 +53,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesCharts() {
+    void generatePage_generatesCharts() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -69,7 +69,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_insertsChartData() {
+    void generatePage_insertsChartData() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -93,7 +93,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesStatsTableHeader() {
+    void generatePage_generatesStatsTableHeader() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -117,7 +117,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesStatsTableBody() {
+    void generatePage_generatesStatsTableBody() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -152,7 +152,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_WithExculedTags_generatesStatsTableBody() {
+    void generatePage_WithExculedTags_generatesStatsTableBody() {
 
         // given
         configuration.setTagsToExcludeFromChart("@checkout", "@feature.*");
@@ -176,7 +176,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesStatsTableFooter() {
+    void generatePage_generatesStatsTableFooter() {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -195,7 +195,7 @@ public class TagsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_onJsonWithoutTags_generatesProperMessage() {
+    void generatePage_onJsonWithoutTags_generatesProperMessage() {
 
         // given
         setUpWithJson(SIMPLE_JSON);

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/TrendsOverviewPageIntegrationTest.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/TrendsOverviewPageIntegrationTest.java
@@ -1,8 +1,7 @@
 package net.masterthought.cucumber.generators.integrations;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import net.masterthought.cucumber.ReportBuilder;
@@ -15,10 +14,10 @@ import net.masterthought.cucumber.generators.integrations.helpers.WebAssertion;
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class TrendsOverviewPageIntegrationTest extends PageTest {
+class TrendsOverviewPageIntegrationTest extends PageTest {
 
     @Test
-    public void generatePage_generatesTitle() throws Exception {
+    void generatePage_generatesTitle() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -38,7 +37,7 @@ public class TrendsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesLead() throws Exception {
+    void generatePage_generatesLead() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -57,7 +56,7 @@ public class TrendsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_generatesCharts() throws Exception {
+    void generatePage_generatesCharts() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);
@@ -77,7 +76,7 @@ public class TrendsOverviewPageIntegrationTest extends PageTest {
     }
 
     @Test
-    public void generatePage_insertsChartData() throws Exception {
+    void generatePage_insertsChartData() throws Exception {
 
         // given
         setUpWithJson(SAMPLE_JSON);

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/HeadAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/HeadAssertion.java
@@ -1,13 +1,8 @@
 package net.masterthought.cucumber.generators.integrations.helpers;
 
-import org.apache.commons.lang3.StringUtils;
-import org.assertj.core.api.filter.NotInFilter;
-
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/WebAssertion.java
+++ b/src/test/java/net/masterthought/cucumber/generators/integrations/helpers/WebAssertion.java
@@ -39,7 +39,7 @@ public class WebAssertion {
         if (inners.size() > 1) {
             TextStringBuilder sb = new TextStringBuilder();
             for (Element inner : inners) {
-                sb.append(inners).append("\n");
+                sb.append(inner).append("\n");
             }
             throw new IllegalArgumentException(String.format("Expected one but found %d elements with class '%s': %s",
                     inners.size(), cssClass, sb.toString()));

--- a/src/test/java/net/masterthought/cucumber/json/ArgumentTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/ArgumentTest.java
@@ -2,8 +2,8 @@ package net.masterthought.cucumber.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import net.masterthought.cucumber.generators.integrations.PageTest;
@@ -12,15 +12,15 @@ import net.masterthought.cucumber.json.support.Argument;
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class ArgumentTest extends PageTest {
+class ArgumentTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getRows_ReturnsRows() {
+    void getRows_ReturnsRows() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[5];
@@ -33,8 +33,9 @@ public class ArgumentTest extends PageTest {
         assertThat(rows).hasSize(2);
         assertThat(rows[0].getCells()).containsOnlyOnce("max", "min");
     }
+
     @Test
-    public void getVal_ReturnsVal() {
+    void getVal_ReturnsVal() {
 
         // given
         Argument matchArgument = features.get(0).getElements()[1].getSteps()[0].getMatch().getArguments()[0];
@@ -47,7 +48,7 @@ public class ArgumentTest extends PageTest {
     }
 
     @Test
-    public void getArguments_ReturnsArguments() {
+    void getArguments_ReturnsArguments() {
 
         // given
         Argument matchArgument = features.get(0).getElements()[1].getSteps()[0].getMatch().getArguments()[0];

--- a/src/test/java/net/masterthought/cucumber/json/DocStringTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/DocStringTest.java
@@ -2,23 +2,22 @@ package net.masterthought.cucumber.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class DocStringTest extends PageTest {
+class DocStringTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getName_ReturnsFeatureTagName() {
+    void getName_ReturnsFeatureTagName() {
 
         // give
         DocString docString = features.get(0).getElements()[0].getSteps()[1].getDocString();

--- a/src/test/java/net/masterthought/cucumber/json/ElementTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/ElementTest.java
@@ -2,24 +2,23 @@ package net.masterthought.cucumber.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.support.Status;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class ElementTest extends PageTest {
+class ElementTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getSteps_ReturnsSteps() {
+    void getSteps_ReturnsSteps() {
 
         // given
         Element element = features.get(0).getElements()[1];
@@ -33,7 +32,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getBefore_ReturnsHooks() {
+    void getBefore_ReturnsHooks() {
 
         // given
         Element element = features.get(1).getElements()[0];
@@ -47,7 +46,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getAfter_ReturnsHooks() {
+    void getAfter_ReturnsHooks() {
 
         // given
         Element element = features.get(1).getElements()[0];
@@ -61,7 +60,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getTags_ReturnsTags() {
+    void getTags_ReturnsTags() {
 
         // given
         Element element = features.get(1).getElements()[0];
@@ -75,7 +74,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getStatus_ReturnsStatus() {
+    void getStatus_ReturnsStatus() {
 
         // given
         Element element = features.get(1).getElements()[0];
@@ -89,7 +88,7 @@ public class ElementTest extends PageTest {
 
 
     @Test
-    public void getBeforeStatus_ReturnsStatus() {
+    void getBeforeStatus_ReturnsStatus() {
 
         // given
         Element element = features.get(1).getElements()[0];
@@ -102,7 +101,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getBeforeStatus_OnNoExistingBefore_ReturnsStatus() {
+    void getBeforeStatus_OnNoExistingBefore_ReturnsStatus() {
 
         // given
         Element element = features.get(0).getElements()[0];
@@ -116,7 +115,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getAfterStatus_ReturnsStatus() {
+    void getAfterStatus_ReturnsStatus() {
 
         // given
         Element element = features.get(1).getElements()[0];
@@ -129,7 +128,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getAfterStatus_OnNoExistingBefore_ReturnsStatus() {
+    void getAfterStatus_OnNoExistingBefore_ReturnsStatus() {
 
         // given
         Element element = features.get(0).getElements()[0];
@@ -143,7 +142,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getStepsStatus_ReturnsStatus() {
+    void getStepsStatus_ReturnsStatus() {
 
         // given
         Element element = features.get(1).getElements()[0];
@@ -156,7 +155,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getName_ReturnsName() {
+    void getName_ReturnsName() {
 
         // given
         Element element = features.get(1).getElements()[0];
@@ -169,7 +168,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getKeyword_ReturnsName() {
+    void getKeyword_ReturnsName() {
 
         // given
         Element element = features.get(0).getElements()[0];
@@ -182,7 +181,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getType_ReturnsName() {
+    void getType_ReturnsName() {
 
         // given
         Element element = features.get(1).getElements()[0];
@@ -195,7 +194,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getDescription_ReturnsDescription() {
+    void getDescription_ReturnsDescription() {
 
         // given
         Element element = features.get(1).getElements()[0];
@@ -208,7 +207,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getDescription_OnMissingDescription_ReturnsEmptyString() {
+    void getDescription_OnMissingDescription_ReturnsEmptyString() {
 
         // given
         Element element = features.get(1).getElements()[1];
@@ -221,7 +220,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void isScenario_ReturnsTrueForScenarios() {
+    void isScenario_ReturnsTrueForScenarios() {
 
         // given
         Feature feature = features.get(0);
@@ -236,7 +235,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getFeature_ReturnsFeature() {
+    void getFeature_ReturnsFeature() {
 
         // given
         Element element = features.get(0).getElements()[0];
@@ -249,7 +248,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getDuration_ReturnsDuration() {
+    void getDuration_ReturnsDuration() {
 
         // given
         Element element = features.get(0).getElements()[0];
@@ -262,7 +261,7 @@ public class ElementTest extends PageTest {
     }
 
     @Test
-    public void getFormattedDuration_ReturnsFormattedDuration() {
+    void getFormattedDuration_ReturnsFormattedDuration() {
 
         // given
         Element element = features.get(0).getElements()[0];

--- a/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
@@ -4,24 +4,17 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  * @author <a href="https://github.com/ghostcity">Stefan Gasterstädt</a>
  */
-@RunWith(Parameterized.class)
-@Ignore // TODO: https://github.com/damianszczepanik/cucumber-reporting/pull/978/files
 public class EmbeddingTest {
 
     private static final String NO_DECODING = null;
 
-    @Parameters(name = "\"{0}\" with \"{1}\"")
     public static Iterable<Object[]> data() {
         return asList(new Object[][] {
             { "application/ecmascript", "console.log('Hello world');", NO_DECODING, ".es" },
@@ -56,21 +49,15 @@ public class EmbeddingTest {
             { "video/mp4", "c29tZSBkYXRh", "some data", "embedding_-1003041823.mp4" },
         });
     }
-
-    @Parameter(0)
     public String mimeType;
-
-    @Parameter(1)
     public String data;
-
-    @Parameter(2)
     public String decodedData;
-
-    @Parameter(3)
     public String fileName;
 
-    @Test
-    public void getMimeType_ReturnsMimeType() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
+    public void getMimeType_ReturnsMimeType(String mimeType, String data, String decodedData, String fileName) {
+        initEmbeddingTest(mimeType, data, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data);
 
@@ -81,8 +68,10 @@ public class EmbeddingTest {
         assertThat(actualMimeType).isEqualTo(this.mimeType);
     }
 
-    @Test
-    public void getData_ReturnsContent() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
+    public void getData_ReturnsContent(String mimeType, String data, String decodedData, String fileName) {
+        initEmbeddingTest(mimeType, data, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data);
 
@@ -93,8 +82,10 @@ public class EmbeddingTest {
         assertThat(actualContent).isEqualTo(data);
     }
 
-    @Test
-    public void getDecodedData_ReturnsDecodedContent() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
+    public void getDecodedData_ReturnsDecodedContent(String mimeType, String data, String decodedData, String fileName) {
+        initEmbeddingTest(mimeType, data, decodedData, fileName);
         assumeThat(this.decodedData).isNotEqualTo(NO_DECODING);
         
         // given
@@ -107,8 +98,10 @@ public class EmbeddingTest {
         assertThat(actualDecodedContent).isEqualTo(this.decodedData);
     }
 
-    @Test
-    public void getFileName_ReturnsFileName() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
+    public void getFileName_ReturnsFileName(String mimeType, String data, String decodedData, String fileName) {
+        initEmbeddingTest(mimeType, data, decodedData, fileName);
         assumeThat(this.fileName).matches("^[^\\.]+\\.[^\\.]+$");
 
         // given
@@ -121,8 +114,10 @@ public class EmbeddingTest {
         assertThat(actualFileName).isEqualTo(this.fileName);
     }
 
-    @Test
-    public void getExtension_ReturnsFileExtension() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
+    public void getExtension_ReturnsFileExtension(String mimeType, String data, String decodedData, String fileName) {
+        initEmbeddingTest(mimeType, data, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data);
 
@@ -133,11 +128,13 @@ public class EmbeddingTest {
         assertThat(actualExtension).isEqualTo(this.fileName.split("\\.")[1]);
     }
 
-    @Test
-    public void getExtension_UsesExtensionFromNameWhenMIMETypeIsUnknown() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
+    public void getExtension_UsesExtensionFromNameWhenMIMETypeIsUnknown(String mimeType, String data, String decodedData, String fileName) {
+        initEmbeddingTest(mimeType, data, decodedData, fileName);
         // Arrange
-        String mimeType = "unknown/mimetype";
-        String data = "c29tZSBkYXRh";
+        mimeType = "unknown/mimetype";
+        data = "c29tZSBkYXRh";
         String name = "example.docx";
 
         // Creating an embedding here with an unknown MIME type and a name containing a file extension
@@ -150,8 +147,10 @@ public class EmbeddingTest {
         assertThat(actualExtension).isEqualTo("docx");
     }
 
-    @Test
-    public void getName_ReturnsNull() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
+    public void getName_ReturnsNull(String mimeType, String data, String decodedData, String fileName) {
+        initEmbeddingTest(mimeType, data, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data);
 
@@ -160,6 +159,13 @@ public class EmbeddingTest {
 
         // then
         assertThat(actualName).isNull();
+    }
+
+    public void initEmbeddingTest(String mimeType, String data, String decodedData, String fileName) {
+        this.mimeType = mimeType;
+        this.data = data;
+        this.decodedData = decodedData;
+        this.fileName = fileName;
     }
 
 }

--- a/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/EmbeddingTest.java
@@ -56,7 +56,7 @@ public class EmbeddingTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
-    public void getMimeType_ReturnsMimeType(String mimeType, String data, String decodedData, String fileName) {
+    void getMimeType_ReturnsMimeType(String mimeType, String data, String decodedData, String fileName) {
         initEmbeddingTest(mimeType, data, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data);
@@ -70,7 +70,7 @@ public class EmbeddingTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
-    public void getData_ReturnsContent(String mimeType, String data, String decodedData, String fileName) {
+    void getData_ReturnsContent(String mimeType, String data, String decodedData, String fileName) {
         initEmbeddingTest(mimeType, data, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data);
@@ -84,7 +84,7 @@ public class EmbeddingTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
-    public void getDecodedData_ReturnsDecodedContent(String mimeType, String data, String decodedData, String fileName) {
+    void getDecodedData_ReturnsDecodedContent(String mimeType, String data, String decodedData, String fileName) {
         initEmbeddingTest(mimeType, data, decodedData, fileName);
         assumeThat(this.decodedData).isNotEqualTo(NO_DECODING);
         
@@ -100,7 +100,7 @@ public class EmbeddingTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
-    public void getFileName_ReturnsFileName(String mimeType, String data, String decodedData, String fileName) {
+    void getFileName_ReturnsFileName(String mimeType, String data, String decodedData, String fileName) {
         initEmbeddingTest(mimeType, data, decodedData, fileName);
         assumeThat(this.fileName).matches("^[^\\.]+\\.[^\\.]+$");
 
@@ -116,7 +116,7 @@ public class EmbeddingTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
-    public void getExtension_ReturnsFileExtension(String mimeType, String data, String decodedData, String fileName) {
+    void getExtension_ReturnsFileExtension(String mimeType, String data, String decodedData, String fileName) {
         initEmbeddingTest(mimeType, data, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data);
@@ -130,7 +130,7 @@ public class EmbeddingTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
-    public void getExtension_UsesExtensionFromNameWhenMIMETypeIsUnknown(String mimeType, String data, String decodedData, String fileName) {
+    void getExtension_UsesExtensionFromNameWhenMIMETypeIsUnknown(String mimeType, String data, String decodedData, String fileName) {
         initEmbeddingTest(mimeType, data, decodedData, fileName);
         // Arrange
         mimeType = "unknown/mimetype";
@@ -149,7 +149,7 @@ public class EmbeddingTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" with \"{1}\"")
-    public void getName_ReturnsNull(String mimeType, String data, String decodedData, String fileName) {
+    void getName_ReturnsNull(String mimeType, String data, String decodedData, String fileName) {
         initEmbeddingTest(mimeType, data, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data);

--- a/src/test/java/net/masterthought/cucumber/json/EmbeddingWithNameTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/EmbeddingWithNameTest.java
@@ -4,24 +4,17 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  * @author <a href="https://github.com/ghostcity">Stefan Gasterstädt</a>
  */
-@RunWith(Parameterized.class)
-@Ignore // TODO: https://github.com/damianszczepanik/cucumber-reporting/pull/978/files
 public class EmbeddingWithNameTest {
 
     private static final String NO_DECODING = null;
 
-    @Parameters(name = "\"{0}\" into \"{2}\"")
     public static Iterable<Object[]> data() {
         return asList(new Object[][] {
             { "application/javascript", "alert('Hello World!');", "hello-world.js", NO_DECODING, ".js" },
@@ -34,24 +27,16 @@ public class EmbeddingWithNameTest {
             { "text/php", "echo 'Hello World!';", "hello-world.php7", NO_DECODING, ".php7" },
         });
     }
-
-    @Parameter(0)
     public String mimeType;
-
-    @Parameter(1)
     public String data;
-
-    @Parameter(2)
     public String name;
-
-    @Parameter(3)
     public String decodedData;
-
-    @Parameter(4)
     public String fileName;
 
-    @Test
-    public void getMimeType_ReturnsMimeType() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
+    public void getMimeType_ReturnsMimeType(String mimeType, String data, String name, String decodedData, String fileName) {
+        initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);
 
@@ -62,8 +47,10 @@ public class EmbeddingWithNameTest {
         assertThat(actualMimeType).isEqualTo(this.mimeType);
     }
 
-    @Test
-    public void getData_ReturnsContent() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
+    public void getData_ReturnsContent(String mimeType, String data, String name, String decodedData, String fileName) {
+        initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);
 
@@ -74,8 +61,10 @@ public class EmbeddingWithNameTest {
         assertThat(actualContent).isEqualTo(data);
     }
 
-    @Test
-    public void getDecodedData_ReturnsDecodedContent() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
+    public void getDecodedData_ReturnsDecodedContent(String mimeType, String data, String name, String decodedData, String fileName) {
+        initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
         assumeThat(this.decodedData).isNotEqualTo(NO_DECODING);
         
         // given
@@ -88,8 +77,10 @@ public class EmbeddingWithNameTest {
         assertThat(actualDecodedContent).isEqualTo(this.decodedData);
     }
 
-    @Test
-    public void getFileName_ReturnsFileName() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
+    public void getFileName_ReturnsFileName(String mimeType, String data, String name, String decodedData, String fileName) {
+        initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
         assumeThat(this.fileName).matches("^[^\\.]+\\.[^\\.]+$");
 
         // given
@@ -102,8 +93,10 @@ public class EmbeddingWithNameTest {
         assertThat(actualFileName).isEqualTo(this.fileName);
     }
 
-    @Test
-    public void getExtension_ReturnsFileExtension() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
+    public void getExtension_ReturnsFileExtension(String mimeType, String data, String name, String decodedData, String fileName) {
+        initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);
 
@@ -114,8 +107,10 @@ public class EmbeddingWithNameTest {
         assertThat(actualExtension).isEqualTo(this.fileName.split("\\.")[1]);
     }
 
-    @Test
-    public void getName_ReturnsName() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
+    public void getName_ReturnsName(String mimeType, String data, String name, String decodedData, String fileName) {
+        initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);
 
@@ -124,6 +119,14 @@ public class EmbeddingWithNameTest {
 
         // then
         assertThat(actualName).isEqualTo(this.name);
+    }
+
+    public void initEmbeddingWithNameTest(String mimeType, String data, String name, String decodedData, String fileName) {
+        this.mimeType = mimeType;
+        this.data = data;
+        this.name = name;
+        this.decodedData = decodedData;
+        this.fileName = fileName;
     }
 
 }

--- a/src/test/java/net/masterthought/cucumber/json/EmbeddingWithNameTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/EmbeddingWithNameTest.java
@@ -35,7 +35,7 @@ public class EmbeddingWithNameTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
-    public void getMimeType_ReturnsMimeType(String mimeType, String data, String name, String decodedData, String fileName) {
+    void getMimeType_ReturnsMimeType(String mimeType, String data, String name, String decodedData, String fileName) {
         initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);
@@ -49,7 +49,7 @@ public class EmbeddingWithNameTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
-    public void getData_ReturnsContent(String mimeType, String data, String name, String decodedData, String fileName) {
+    void getData_ReturnsContent(String mimeType, String data, String name, String decodedData, String fileName) {
         initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);
@@ -63,7 +63,7 @@ public class EmbeddingWithNameTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
-    public void getDecodedData_ReturnsDecodedContent(String mimeType, String data, String name, String decodedData, String fileName) {
+    void getDecodedData_ReturnsDecodedContent(String mimeType, String data, String name, String decodedData, String fileName) {
         initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
         assumeThat(this.decodedData).isNotEqualTo(NO_DECODING);
         
@@ -79,7 +79,7 @@ public class EmbeddingWithNameTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
-    public void getFileName_ReturnsFileName(String mimeType, String data, String name, String decodedData, String fileName) {
+    void getFileName_ReturnsFileName(String mimeType, String data, String name, String decodedData, String fileName) {
         initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
         assumeThat(this.fileName).matches("^[^\\.]+\\.[^\\.]+$");
 
@@ -95,7 +95,7 @@ public class EmbeddingWithNameTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
-    public void getExtension_ReturnsFileExtension(String mimeType, String data, String name, String decodedData, String fileName) {
+    void getExtension_ReturnsFileExtension(String mimeType, String data, String name, String decodedData, String fileName) {
         initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);
@@ -109,7 +109,7 @@ public class EmbeddingWithNameTest {
 
     @MethodSource("data")
     @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
-    public void getName_ReturnsName(String mimeType, String data, String name, String decodedData, String fileName) {
+    void getName_ReturnsName(String mimeType, String data, String name, String decodedData, String fileName) {
         initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);

--- a/src/test/java/net/masterthought/cucumber/json/FeatureTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/FeatureTest.java
@@ -4,22 +4,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.support.Status;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class FeatureTest extends PageTest {
+class FeatureTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getId_ReturnsID() {
+    void getId_ReturnsID() {
 
         // given
         Feature feature = features.get(1);
@@ -32,7 +32,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void addElements_AddsScenarios() {
+    void addElements_AddsScenarios() {
 
         // given
         Feature feature = features.get(0);
@@ -47,7 +47,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getElements_ReturnsElements() {
+    void getElements_ReturnsElements() {
 
         // given
         Feature feature = features.get(0);
@@ -61,7 +61,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void calculateReportFileName_ReturnsFileName() throws Exception {
+    void calculateReportFileName_ReturnsFileName() throws Exception {
 
         // given
         Feature feature = features.get(1);
@@ -75,7 +75,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getReportFileName_ReturnsFileName() {
+    void getReportFileName_ReturnsFileName() {
 
         // given
         Feature feature = features.get(1);
@@ -88,7 +88,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getQualifier_ReturnsFileNameWithoutExtension() {
+    void getQualifier_ReturnsFileNameWithoutExtension() {
 
         // given
         Feature feature = features.get(1);
@@ -101,7 +101,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getTags_ReturnsTags() {
+    void getTags_ReturnsTags() {
 
         // given
         Element element = features.get(1).getElements()[0];
@@ -115,7 +115,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getStatus_ReturnsStatus() {
+    void getStatus_ReturnsStatus() {
 
         // given
         Feature feature = features.get(1);
@@ -128,7 +128,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getName_ReturnsName() {
+    void getName_ReturnsName() {
 
         // given
         Feature feature = features.get(0);
@@ -141,7 +141,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getKeyword_ReturnsKeyword() {
+    void getKeyword_ReturnsKeyword() {
 
         // given
         Feature feature = features.get(0);
@@ -154,7 +154,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getDescription_ReturnsDescription() {
+    void getDescription_ReturnsDescription() {
 
         // given
         Feature feature = features.get(0);
@@ -167,7 +167,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getFeatures_ReturnsOne() {
+    void getFeatures_ReturnsOne() {
 
         // given
         Feature feature = features.get(0);
@@ -180,7 +180,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getXXXFeatures_OnPassedFeature_ReturnsFeaturesForStatus() {
+    void getXXXFeatures_OnPassedFeature_ReturnsFeaturesForStatus() {
 
         // given
         Feature passedFeature = features.get(0);
@@ -191,7 +191,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getXXXFeatures_OnFAiledFeature_ReturnsFeaturesForStatus() {
+    void getXXXFeatures_OnFAiledFeature_ReturnsFeaturesForStatus() {
 
         // given
         Feature failedFeature = features.get(1);
@@ -202,7 +202,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getScenarios_ReturnsNumberOfScenarios() {
+    void getScenarios_ReturnsNumberOfScenarios() {
 
         // given
         Feature feature = features.get(0);
@@ -215,7 +215,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getXXXScenarios_ReturnsScenariosForStatus() {
+    void getXXXScenarios_ReturnsScenariosForStatus() {
 
         // given
         Feature feature = features.get(1);
@@ -226,7 +226,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getSteps_ReturnsNumberOfSteps() {
+    void getSteps_ReturnsNumberOfSteps() {
 
         // given
         Feature feature = features.get(0);
@@ -239,7 +239,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getXXXSteps_ReturnsStepsForStatus() {
+    void getXXXSteps_ReturnsStepsForStatus() {
 
         // given
         Feature passingFeature = features.get(0);
@@ -255,7 +255,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getDuration_ReturnsDuration() {
+    void getDuration_ReturnsDuration() {
 
         // given
         Feature feature = features.get(0);
@@ -268,7 +268,7 @@ public class FeatureTest extends PageTest {
     }
 
     @Test
-    public void getFormattedDuration_ReturnsFormattedDuration() {
+    void getFormattedDuration_ReturnsFormattedDuration() {
 
         // given
         Feature feature = features.get(1);

--- a/src/test/java/net/masterthought/cucumber/json/HookTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/HookTest.java
@@ -2,23 +2,22 @@ package net.masterthought.cucumber.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class HookTest extends PageTest {
+class HookTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getResult_ReturnsResult() {
+    void getResult_ReturnsResult() {
 
         // given
         Hook hook = features.get(0).getElements()[1].getAfter()[0];
@@ -31,7 +30,7 @@ public class HookTest extends PageTest {
     }
 
     @Test
-    public void getMatch_ReturnsMatch() {
+    void getMatch_ReturnsMatch() {
 
         // given
         Hook hook = features.get(0).getElements()[1].getAfter()[0];
@@ -44,7 +43,7 @@ public class HookTest extends PageTest {
     }
 
     @Test
-    public void getOutputs_ReturnsOutputs() {
+    void getOutputs_ReturnsOutputs() {
 
         // given
         Hook hook = features.get(1).getElements()[0].getBefore()[0];
@@ -58,7 +57,7 @@ public class HookTest extends PageTest {
     }
 
     @Test
-    public void getEmbeddings_ReturnsEmbeddings() {
+    void getEmbeddings_ReturnsEmbeddings() {
 
         // given
         Hook hook = features.get(1).getElements()[0].getAfter()[0];
@@ -72,7 +71,7 @@ public class HookTest extends PageTest {
     }
 
     @Test
-    public void hasContent_WithEmbedding_ReturnsTrue() {
+    void hasContent_WithEmbedding_ReturnsTrue() {
 
         // given
         Hook hook = features.get(1).getElements()[0].getSteps()[0].getBefore()[0];
@@ -86,7 +85,7 @@ public class HookTest extends PageTest {
     }
 
     @Test
-    public void hasContent_WithErrorMessage_ReturnsTrue() {
+    void hasContent_WithErrorMessage_ReturnsTrue() {
 
         // given
         Hook hook = features.get(0).getElements()[1].getAfter()[0];
@@ -100,7 +99,7 @@ public class HookTest extends PageTest {
     }
 
     @Test
-    public void hasContent_WithEmptyResult_ReturnsFalse() {
+    void hasContent_WithEmptyResult_ReturnsFalse() {
 
         // given
         Hook hook = features.get(1).getElements()[0].getSteps()[1].getAfter()[0];
@@ -114,7 +113,7 @@ public class HookTest extends PageTest {
     }
 
     @Test
-    public void hasContent_OnEmptyHook_ReturnsFalse() {
+    void hasContent_OnEmptyHook_ReturnsFalse() {
 
         // given
         Hook hook = features.get(1).getElements()[0].getBefore()[0];

--- a/src/test/java/net/masterthought/cucumber/json/MatchTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/MatchTest.java
@@ -3,23 +3,22 @@ package net.masterthought.cucumber.json;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import net.masterthought.cucumber.json.support.Argument;
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class MatchTest extends PageTest {
+class MatchTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getLocation_ReturnsLocation() {
+    void getLocation_ReturnsLocation() {
 
         // given
         Match match = features.get(0).getElements()[1].getSteps()[0].getMatch();
@@ -32,7 +31,7 @@ public class MatchTest extends PageTest {
     }
 
     @Test
-    public void getArguments_ReturnsArguments() {
+    void getArguments_ReturnsArguments() {
 
         // given
         Match match = features.get(0).getElements()[1].getSteps()[0].getMatch();

--- a/src/test/java/net/masterthought/cucumber/json/OutputTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/OutputTest.java
@@ -2,15 +2,15 @@ package net.masterthought.cucumber.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class OutputTest {
+class OutputTest {
 
     @Test
-    public void getMessages_ReturnsMessages() {
+    void getMessages_ReturnsMessages() {
 
         // given
         String[] messages = { "a", "b", "c", "a" };

--- a/src/test/java/net/masterthought/cucumber/json/ResultTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/ResultTest.java
@@ -2,24 +2,23 @@ package net.masterthought.cucumber.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.support.Status;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class ResultTest extends PageTest {
+class ResultTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getStatus_ReturnsStatus() {
+    void getStatus_ReturnsStatus() {
 
         // give
         Result result = features.get(0).getElements()[0].getSteps()[1].getResult();
@@ -32,7 +31,7 @@ public class ResultTest extends PageTest {
     }
 
     @Test
-    public void getDuration_ReturnsDuration() {
+    void getDuration_ReturnsDuration() {
 
         // give
         Result result = features.get(0).getElements()[0].getSteps()[3].getResult();
@@ -45,7 +44,7 @@ public class ResultTest extends PageTest {
     }
 
     @Test
-    public void getFormattedDuration_ReturnsDurationAsString() {
+    void getFormattedDuration_ReturnsDurationAsString() {
 
         // give
         Result result = features.get(0).getElements()[0].getSteps()[2].getResult();
@@ -58,7 +57,7 @@ public class ResultTest extends PageTest {
     }
 
     @Test
-    public void getErrorMessage_ReturnsErrorMessage() {
+    void getErrorMessage_ReturnsErrorMessage() {
 
         // given
         Result result = features.get(1).getElements()[0].getSteps()[5].getResult();
@@ -78,7 +77,7 @@ public class ResultTest extends PageTest {
     }
 
     @Test
-    public void getErrorMessageTitle_OnEmptyMessage_ReturnsEmptyTitle() {
+    void getErrorMessageTitle_OnEmptyMessage_ReturnsEmptyTitle() {
 
         // given
         Result result = features.get(1).getElements()[0].getBefore()[1].getResult();
@@ -91,7 +90,7 @@ public class ResultTest extends PageTest {
     }
 
     @Test
-    public void getErrorMessageTitle_OnNullMessage_ReturnsEmptyTitle() {
+    void getErrorMessageTitle_OnNullMessage_ReturnsEmptyTitle() {
 
         // given
         Result result = features.get(0).getElements()[0].getSteps()[0].getResult();

--- a/src/test/java/net/masterthought/cucumber/json/RowTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/RowTest.java
@@ -2,23 +2,22 @@ package net.masterthought.cucumber.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class RowTest extends PageTest {
+class RowTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getCells_ReturnsCells() {
+    void getCells_ReturnsCells() {
 
         // given
         Row[] rows = features.get(0).getElements()[0].getSteps()[2].getRows();

--- a/src/test/java/net/masterthought/cucumber/json/StepTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/StepTest.java
@@ -6,21 +6,21 @@ import java.util.List;
 
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.support.Status;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class StepTest extends PageTest {
+class StepTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getRows_ReturnsRows() {
+    void getRows_ReturnsRows() {
 
         // given
         Step step = features.get(0).getElements()[0].getSteps()[2];
@@ -34,7 +34,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getRows_OnArguments_ReturnsRows() {
+    void getRows_OnArguments_ReturnsRows() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[5];
@@ -48,7 +48,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getName_ReturnsName() {
+    void getName_ReturnsName() {
 
         // given
         Step step = features.get(0).getElements()[0].getSteps()[0];
@@ -61,7 +61,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getKeyword_ReturnsKeyword() {
+    void getKeyword_ReturnsKeyword() {
 
         // given
         Step step = features.get(0).getElements()[0].getSteps()[1];
@@ -74,7 +74,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getOutput_ReturnsOutput() {
+    void getOutput_ReturnsOutput() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[7];
@@ -89,7 +89,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getMatch_ReturnsMatch() {
+    void getMatch_ReturnsMatch() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[4];
@@ -102,7 +102,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getEmbeddings_ReturnsEmbeddings() {
+    void getEmbeddings_ReturnsEmbeddings() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[6];
@@ -116,7 +116,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getResult_ReturnResult() {
+    void getResult_ReturnResult() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[5];
@@ -129,7 +129,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getStatus_ReturnsStatus() {
+    void getStatus_ReturnsStatus() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[5];
@@ -142,7 +142,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getDuration_ReturnsDuration() {
+    void getDuration_ReturnsDuration() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[1];
@@ -155,7 +155,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getDuration_OnMissingDuration_ReturnsZero() {
+    void getDuration_OnMissingDuration_ReturnsZero() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[0];
@@ -168,7 +168,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getResult_OnMissingResult_ReturnsEmptyResult() {
+    void getResult_OnMissingResult_ReturnsEmptyResult() {
 
         // given
         Step step = features.get(1).getElements()[2].getSteps()[0];
@@ -183,7 +183,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getBeforeHook_ReturnsBeforeHooks() {
+    void getBeforeHook_ReturnsBeforeHooks() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[0];
@@ -197,7 +197,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getAfterHook_ReturnsAfterHooks() {
+    void getAfterHook_ReturnsAfterHooks() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[1];
@@ -211,7 +211,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getBeforeStatus_ReturnsStatusForBeforeHooks() {
+    void getBeforeStatus_ReturnsStatusForBeforeHooks() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[0];
@@ -225,7 +225,7 @@ public class StepTest extends PageTest {
 
 
     @Test
-    public void getAfterStatus_ReturnsStatusForAfterHooks() {
+    void getAfterStatus_ReturnsStatusForAfterHooks() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[2];
@@ -239,7 +239,7 @@ public class StepTest extends PageTest {
 
 
     @Test
-    public void getBeforeStatus_OnEmptyHooks_ReturnsPassed() {
+    void getBeforeStatus_OnEmptyHooks_ReturnsPassed() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[2];
@@ -252,7 +252,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getAfterStatus_OnEmptyHooks_ReturnsPassed() {
+    void getAfterStatus_OnEmptyHooks_ReturnsPassed() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[2];
@@ -265,7 +265,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getComments_ReturnsCommentsFromArrayOfString() {
+    void getComments_ReturnsCommentsFromArrayOfString() {
 
         // given
         Step step = features.get(0).getElements()[0].getSteps()[0];
@@ -278,7 +278,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getComments_ReturnsCommentsFromArrayOfCommentObject() {
+    void getComments_ReturnsCommentsFromArrayOfCommentObject() {
 
         // given
         Step step = features.get(0).getElements()[0].getSteps()[1];
@@ -291,7 +291,7 @@ public class StepTest extends PageTest {
     }
 
     @Test
-    public void getComments_ReturnsEmptyCommentList() {
+    void getComments_ReturnsEmptyCommentList() {
 
         // given
         Step step = features.get(0).getElements()[0].getSteps()[2];

--- a/src/test/java/net/masterthought/cucumber/json/TagTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/TagTest.java
@@ -3,21 +3,21 @@ package net.masterthought.cucumber.json;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import net.masterthought.cucumber.generators.integrations.PageTest;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class TagTest extends PageTest {
+class TagTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void getName_ReturnsFeatureTagName() {
+    void getName_ReturnsFeatureTagName() {
 
         // given
         Tag tag = features.get(0).getTags()[0];
@@ -30,7 +30,7 @@ public class TagTest extends PageTest {
     }
 
     @Test
-    public void getName_ReturnsElementTagName() {
+    void getName_ReturnsElementTagName() {
 
         // given
         Tag tag = features.get(0).getElements()[1].getTags()[2];
@@ -43,7 +43,7 @@ public class TagTest extends PageTest {
     }
 
     @Test
-    public void getFileName_ReturnsTagFileName() {
+    void getFileName_ReturnsTagFileName() {
 
         // given
         Tag tag = features.get(1).getElements()[0].getTags()[0];
@@ -56,7 +56,7 @@ public class TagTest extends PageTest {
     }
 
     @Test
-    public void generateFileName_OnInvalidTagName_ReturnsValidFileName() {
+    void generateFileName_OnInvalidTagName_ReturnsValidFileName() {
 
         // given
         final String[] tags = {"@up s", "?any", "9/3"};
@@ -69,7 +69,7 @@ public class TagTest extends PageTest {
     }
 
     @Test
-    public void hashCode_OnSameName_ReturnsHashCode() {
+    void hashCode_OnSameName_ReturnsHashCode() {
 
         // given
         final String tagName = "@superTaggggg";
@@ -83,7 +83,7 @@ public class TagTest extends PageTest {
     }
 
     @Test
-    public void equals_OnSameName_ReturnsTrue() {
+    void equals_OnSameName_ReturnsTrue() {
 
         // given
         final String tagName = "@superTaggggg";
@@ -98,7 +98,7 @@ public class TagTest extends PageTest {
     }
 
     @Test
-    public void equals_OnDifferentName_ReturnsFalse() {
+    void equals_OnDifferentName_ReturnsFalse() {
 
         // given
         final String tagName = "@superTaggggg";

--- a/src/test/java/net/masterthought/cucumber/json/deserializers/CommentsDeserializerTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/deserializers/CommentsDeserializerTest.java
@@ -1,27 +1,20 @@
 package net.masterthought.cucumber.json.deserializers;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import net.masterthought.cucumber.Configuration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.Test;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(value = JsonNode.class)
-@PowerMockIgnore("jdk.internal.reflect.*")
-public class CommentsDeserializerTest {
+class CommentsDeserializerTest {
 
     @Test
-    public void deserialize_returnsCommentsFromArrayOfString() {
+    void deserialize_returnsCommentsFromArrayOfString() {
         // given
         CommentsDeserializer commentsDeserializer = new CommentsDeserializer();
 
@@ -50,7 +43,7 @@ public class CommentsDeserializerTest {
     }
 
     @Test
-    public void deserialize_returnsCommentsFromArrayOfCommentObject() {
+    void deserialize_returnsCommentsFromArrayOfCommentObject() {
         // given
         CommentsDeserializer commentsDeserializer = new CommentsDeserializer();
 
@@ -75,7 +68,7 @@ public class CommentsDeserializerTest {
     }
 
     @Test
-    public void deserialize_returnsEmptyCommentsWhenOtherFormat() {
+    void deserialize_returnsEmptyCommentsWhenOtherFormat() {
         // given
         CommentsDeserializer commentsDeserializer = new CommentsDeserializer();
 

--- a/src/test/java/net/masterthought/cucumber/json/deserializers/EmbeddingDeserializerTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/deserializers/EmbeddingDeserializerTest.java
@@ -1,8 +1,8 @@
 package net.masterthought.cucumber.json.deserializers;
 
-import static org.junit.Assert.assertEquals;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -12,25 +12,18 @@ import com.fasterxml.jackson.databind.JsonNode;
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportBuilder;
 import net.masterthought.cucumber.json.Embedding;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(value = JsonNode.class)
-@PowerMockIgnore("jdk.internal.reflect.*")
-public class EmbeddingDeserializerTest {
+class EmbeddingDeserializerTest {
 
     private static final String RANDOM_DIR = "target" + File.separator + System.currentTimeMillis() + File.separator;
 
     private Configuration configuration;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         configuration = new Configuration(new File(RANDOM_DIR), "TestProject");
 
         final String directoryPath = RANDOM_DIR + ReportBuilder.BASE_DIRECTORY + configuration.getDirectorySuffixWithSeparator() + "/embeddings";
@@ -38,13 +31,13 @@ public class EmbeddingDeserializerTest {
         if (!dir.exists()) {
             final boolean created = dir.mkdirs();
             if (!created) {
-                Assert.fail("Could not create folder " + directoryPath);
+                Assertions.fail("Could not create folder " + directoryPath);
             }
         }
     }
 
     @Test
-    public void deserialize_OnEncodedData_returnsEmbeddingWithEncodedData() {
+    void deserialize_OnEncodedData_returnsEmbeddingWithEncodedData() {
 
         // given
         EmbeddingDeserializer embeddingDeserializer = new EmbeddingDeserializer();
@@ -60,11 +53,11 @@ public class EmbeddingDeserializerTest {
         Embedding embedding = embeddingDeserializer.deserialize(node, configuration);
 
         // then
-        assertEquals("The Decoded Data should be the same as the input Data", data, embedding.getDecodedData());
+        assertEquals(data, embedding.getDecodedData(), "The Decoded Data should be the same as the input Data");
     }
 
     @Test
-    public void deserialize_OnUnEncodedData_returnsEmbeddingWithEncodedData() {
+    void deserialize_OnUnEncodedData_returnsEmbeddingWithEncodedData() {
 
         // given
         EmbeddingDeserializer embeddingDeserializer = new EmbeddingDeserializer();
@@ -79,11 +72,11 @@ public class EmbeddingDeserializerTest {
         Embedding embedding = embeddingDeserializer.deserialize(node, configuration);
 
         // then
-        assertEquals("The Decoded Data should be the same as the input Data", data, embedding.getDecodedData());
+        assertEquals(data, embedding.getDecodedData(), "The Decoded Data should be the same as the input Data");
     }
 
     @Test
-    public void deserialize_OnUnEncodedDataWithOnlyValidCharsAndWhiteSpaces_returnsEmbeddingWithEncodedData() {
+    void deserialize_OnUnEncodedDataWithOnlyValidCharsAndWhiteSpaces_returnsEmbeddingWithEncodedData() {
 
         // given
         EmbeddingDeserializer embeddingDeserializer = new EmbeddingDeserializer();
@@ -98,6 +91,6 @@ public class EmbeddingDeserializerTest {
         Embedding embedding = embeddingDeserializer.deserialize(node, configuration);
 
         // thens
-        assertEquals("The Decoded Data should be the same as the input Data", data, embedding.getDecodedData());
+        assertEquals(data, embedding.getDecodedData(), "The Decoded Data should be the same as the input Data");
     }
 }

--- a/src/test/java/net/masterthought/cucumber/json/deserializers/StatusDeserializerTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/deserializers/StatusDeserializerTest.java
@@ -2,29 +2,22 @@ package net.masterthought.cucumber.json.deserializers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Locale;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import net.masterthought.cucumber.json.support.Status;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(value = JsonNode.class)
-@PowerMockIgnore("jdk.internal.reflect.*")
-public class StatusDeserializerTest {
+class StatusDeserializerTest {
 
     @Test
-    public void deserialize_OnDefaultStatus_ReturnsStatus() {
+    void deserialize_OnDefaultStatus_ReturnsStatus() {
 
         // given
         Status status = Status.PASSED;
@@ -41,7 +34,7 @@ public class StatusDeserializerTest {
     }
 
     @Test
-    public void deserialize_OnFailedStatus_ReturnsStatus() {
+    void deserialize_OnFailedStatus_ReturnsStatus() {
 
         // given
         Status status = Status.FAILED;
@@ -59,7 +52,7 @@ public class StatusDeserializerTest {
 
 
     @Test
-    public void deserialize_OnAdditionalStatus_ReturnsUndefinedStatus() {
+    void deserialize_OnAdditionalStatus_ReturnsUndefinedStatus() {
 
         // given
         Status status = Status.UNDEFINED;
@@ -77,7 +70,7 @@ public class StatusDeserializerTest {
     }
 
     @Test
-    public void deserialize_OnUnknownStatus_ThrowsException() {
+    void deserialize_OnUnknownStatus_ThrowsException() {
 
         // given
         String status = "thisIsNotStatus";

--- a/src/test/java/net/masterthought/cucumber/json/deserializers/TagsDeserializerTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/deserializers/TagsDeserializerTest.java
@@ -1,8 +1,8 @@
 package net.masterthought.cucumber.json.deserializers;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,19 +10,12 @@ import java.util.List;
 import com.fasterxml.jackson.databind.JsonNode;
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.json.Tag;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.Test;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(value = JsonNode.class)
-@PowerMockIgnore("jdk.internal.reflect.*")
-public class TagsDeserializerTest {
+class TagsDeserializerTest {
 
     @Test
-    public void deserialize_returnsTags() {
+    void deserialize_returnsTags() {
 
         // given
         TagsDeserializer tagsDeserializer = new TagsDeserializer();
@@ -46,7 +39,7 @@ public class TagsDeserializerTest {
     }
 
     @Test
-    public void deserialize_OnExcludedTags_returnsTags() {
+    void deserialize_OnExcludedTags_returnsTags() {
 
         // given
         TagsDeserializer tagsDeserializer = new TagsDeserializer();

--- a/src/test/java/net/masterthought/cucumber/json/support/StatusTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/support/StatusTest.java
@@ -7,15 +7,15 @@ import static net.masterthought.cucumber.json.support.Status.SKIPPED;
 import static net.masterthought.cucumber.json.support.Status.UNDEFINED;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class StatusTest {
+class StatusTest {
 
     @Test
-    public void valuesOf_ReturnsOrderedStatuses() {
+    void valuesOf_ReturnsOrderedStatuses() {
 
         // given
         // tables displays result with following order
@@ -29,7 +29,7 @@ public class StatusTest {
     }
 
     @Test
-    public void getName_ReturnsNameAsLowerCase() {
+    void getName_ReturnsNameAsLowerCase() {
 
         // given
         final Status status = PASSED;
@@ -43,7 +43,7 @@ public class StatusTest {
     }
 
     @Test
-    public void getLabel_ReturnsNameStartingFromUpperCase() {
+    void getLabel_ReturnsNameStartingFromUpperCase() {
 
         // given
         final Status status = UNDEFINED;
@@ -57,7 +57,7 @@ public class StatusTest {
     }
 
     @Test
-    public void isPassed_ReturnsTrueForPASSEDStatus() {
+    void isPassed_ReturnsTrueForPASSEDStatus() {
 
         // given
         Status status = PASSED;
@@ -70,7 +70,7 @@ public class StatusTest {
     }
 
     @Test
-    public void hasPassed_ReturnsFalseForNoPASSED() {
+    void hasPassed_ReturnsFalseForNoPASSED() {
 
         // given
         Status[] notPassed = {FAILED, SKIPPED, PENDING, UNDEFINED};

--- a/src/test/java/net/masterthought/cucumber/json/support/StepObjectTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/support/StepObjectTest.java
@@ -4,18 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import net.masterthought.cucumber.ValidationException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Sam Park (midopa@github)
  */
-public class StepObjectTest {
+class StepObjectTest {
 
     private StepObject stepObject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         stepObject = new StepObject("Test step location");
         stepObject.addDuration(1000000000L, Status.PASSED);
         stepObject.addDuration(2200000000L, Status.FAILED);
@@ -23,7 +23,7 @@ public class StepObjectTest {
     }
 
     @Test
-    public void StepObject_OnNullLocation_ThrowsException() {
+    void StepObject_OnNullLocation_ThrowsException() {
 
         // given
         String location = null;
@@ -34,7 +34,7 @@ public class StepObjectTest {
     }
 
     @Test
-    public void getLocation_ReturnsLocation() {
+    void getLocation_ReturnsLocation() {
 
         // given
         // from @Before
@@ -47,7 +47,7 @@ public class StepObjectTest {
     }
 
     @Test
-    public void addDuration_ReturnsSumsDurations() {
+    void addDuration_ReturnsSumsDurations() {
 
         // give
         StepObject step = new StepObject("ble bla ble");
@@ -64,7 +64,7 @@ public class StepObjectTest {
     }
 
     @Test
-    public void getFormattedTotalDuration_ReturnsFormattedSumDurations() {
+    void getFormattedTotalDuration_ReturnsFormattedSumDurations() {
 
         // give
         // from @Before
@@ -77,7 +77,7 @@ public class StepObjectTest {
     }
 
     @Test
-    public void getFormattedMaxDuration_ReturnsFormattedMaxDurations() {
+    void getFormattedMaxDuration_ReturnsFormattedMaxDurations() {
 
         // give
         // from @Before
@@ -90,7 +90,7 @@ public class StepObjectTest {
     }
 
     @Test
-    public void getFormattedMaxDuration_ReturnsMaxDurations() {
+    void getFormattedMaxDuration_ReturnsMaxDurations() {
 
         // give
         // from @Before
@@ -103,7 +103,7 @@ public class StepObjectTest {
     }
 
     @Test
-    public void getAverageDurations_ReturnsTime() {
+    void getAverageDurations_ReturnsTime() {
 
         // given
         // from @Before
@@ -116,7 +116,7 @@ public class StepObjectTest {
     }
 
     @Test
-    public void getFormattedAverageDuration_ReturnsFormattedSumDurations() {
+    void getFormattedAverageDuration_ReturnsFormattedSumDurations() {
 
         // given
         // from @Before
@@ -129,7 +129,7 @@ public class StepObjectTest {
     }
 
     @Test
-    public void getPercentageResult_Returns0Percent() {
+    void getPercentageResult_Returns0Percent() {
 
         // given
         // from @Before
@@ -142,7 +142,7 @@ public class StepObjectTest {
     }
 
     @Test
-    public void getPercentageResult_OnOnlyFailures_Returns0Percent() {
+    void getPercentageResult_OnOnlyFailures_Returns0Percent() {
 
         // given
         StepObject step = new StepObject("Test step location");

--- a/src/test/java/net/masterthought/cucumber/json/support/TagObjectTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/support/TagObjectTest.java
@@ -9,21 +9,21 @@ import net.masterthought.cucumber.ValidationException;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.Element;
 import org.apache.commons.lang3.NotImplementedException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class TagObjectTest extends PageTest {
+class TagObjectTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void TagObject_OnNullTagName_ThrowsException() {
+    void TagObject_OnNullTagName_ThrowsException() {
         // given
         String tagName = null;
 
@@ -32,7 +32,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getName_ReturnsTagName() {
+    void getName_ReturnsTagName() {
 
         // given
         final String refName = "yourName";
@@ -46,7 +46,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getReportFileName_ReturnsFileName() {
+    void getReportFileName_ReturnsFileName() {
 
         // given
         TagObject tag = new TagObject("@client:output");
@@ -59,7 +59,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getElements_ReturnsExactAddedElement() {
+    void getElements_ReturnsExactAddedElement() {
 
         // given
         TagObject tag = new TagObject("@checkout");
@@ -75,7 +75,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getFeatures_ThrowsException() {
+    void getFeatures_ThrowsException() {
 
         // given
         TagObject tag = new TagObject("@checkout");
@@ -86,7 +86,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getPassedFeatures_ThrowsException() {
+    void getPassedFeatures_ThrowsException() {
 
         // given
         TagObject tag = new TagObject("@checkout");
@@ -97,7 +97,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getFailedFeatures_ThrowsException() {
+    void getFailedFeatures_ThrowsException() {
 
         // given
         TagObject tag = new TagObject("@checkout");
@@ -108,7 +108,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getScenarios_ReturnsSumOfScenarios() {
+    void getScenarios_ReturnsSumOfScenarios() {
 
         // given
         TagObject tag = new TagObject("@checkout");
@@ -124,7 +124,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getPassedScenarios_ReturnsSumOfPassingScenarios() {
+    void getPassedScenarios_ReturnsSumOfPassingScenarios() {
 
         // given
         TagObject tag = new TagObject("@checkout");
@@ -140,7 +140,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getFailedScenarios_ReturnsSumOfFailedScenarios() {
+    void getFailedScenarios_ReturnsSumOfFailedScenarios() {
 
         // given
         TagObject tag = new TagObject("@checkout");
@@ -156,7 +156,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getDuration_ReturnsDuration() {
+    void getDuration_ReturnsDuration() {
 
         // given
         TagObject tag = new TagObject("@checkout");
@@ -173,7 +173,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getSteps_ReturnsSumOfSteps() {
+    void getSteps_ReturnsSumOfSteps() {
 
         // given
         TagObject tag = new TagObject("@checkout");
@@ -189,7 +189,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getNumberOfStatus_OnStatus__ReturnsSumOfStatuses() {
+    void getNumberOfStatus_OnStatus__ReturnsSumOfStatuses() {
 
         // given
         TagObject tag = new TagObject("@checkout");
@@ -207,7 +207,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getStatus_ReturnsStatus() {
+    void getStatus_ReturnsStatus() {
 
         // given
         TagObject tag = new TagObject("hello");
@@ -221,7 +221,7 @@ public class TagObjectTest extends PageTest {
     }
 
     @Test
-    public void getRawStatus_ReturnsRawOfFinalStatus() {
+    void getRawStatus_ReturnsRawOfFinalStatus() {
 
         // given
         TagObject tag = new TagObject("@checkout");

--- a/src/test/java/net/masterthought/cucumber/json/support/comparators/StatusCounterTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/support/comparators/StatusCounterTest.java
@@ -4,20 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 
-import org.junit.Test;
-
 import net.masterthought.cucumber.json.support.Resultsable;
 import net.masterthought.cucumber.json.support.ResultsableBuilder;
 import net.masterthought.cucumber.json.support.Status;
 import net.masterthought.cucumber.json.support.StatusCounter;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class StatusCounterTest {
+class StatusCounterTest {
 
     @Test
-    public void StatusCounter_OnFailingStatuses_IncrementsPassing() {
+    void StatusCounter_OnFailingStatuses_IncrementsPassing() {
 
         // given
         Resultsable[] resultsables = ResultsableBuilder.Resultsable(Status.PASSED, Status.FAILED, Status.SKIPPED);
@@ -32,7 +31,7 @@ public class StatusCounterTest {
     }
 
     @Test
-    public void StatusCounter_OnNullFailingStatuses_IncrementsPassing() {
+    void StatusCounter_OnNullFailingStatuses_IncrementsPassing() {
 
         // given
         Resultsable[] resultsables = ResultsableBuilder.Resultsable(Status.PASSED, Status.FAILED, Status.SKIPPED);
@@ -47,7 +46,7 @@ public class StatusCounterTest {
     }
 
     @Test
-    public void StatusCounter_OnEmptyFailingStatuses_IncrementsPassing() {
+    void StatusCounter_OnEmptyFailingStatuses_IncrementsPassing() {
 
         // given
         Resultsable[] resultsables = ResultsableBuilder.Resultsable(Status.PASSED, Status.FAILED, Status.SKIPPED);
@@ -62,7 +61,7 @@ public class StatusCounterTest {
     }
 
     @Test
-    public void getValueFor_ReturnsStatusCounter() {
+    void getValueFor_ReturnsStatusCounter() {
 
         // given
         StatusCounter statusCounter = new StatusCounter();
@@ -81,7 +80,7 @@ public class StatusCounterTest {
     }
 
     @Test
-    public void size_ReturnsAllStatusCounter() {
+    void size_ReturnsAllStatusCounter() {
 
         // given
         StatusCounter statusCounter = new StatusCounter();
@@ -95,7 +94,7 @@ public class StatusCounterTest {
     }
 
     @Test
-    public void getFinalStatus_WithNoStatuses_ReturnsPass() {
+    void getFinalStatus_WithNoStatuses_ReturnsPass() {
 
         // given
         StatusCounter statusCounter = new StatusCounter();
@@ -108,7 +107,7 @@ public class StatusCounterTest {
     }
 
     @Test
-    public void getFinalStatus_OnSameStatuses_ReturnsThatStatus() {
+    void getFinalStatus_OnSameStatuses_ReturnsThatStatus() {
 
         // given
         StatusCounter statusCounter = new StatusCounter();
@@ -122,7 +121,7 @@ public class StatusCounterTest {
     }
 
     @Test
-    public void getFinalStatus_OnDifferentStatuses_ReturnsFailedStatus() {
+    void getFinalStatus_OnDifferentStatuses_ReturnsFailedStatus() {
 
         // given
         StatusCounter statusCounter = new StatusCounter();
@@ -136,7 +135,7 @@ public class StatusCounterTest {
     }
 
     @Test
-    public void getFinalStatus_OnFailedStatus_ReturnsFailedStatus() {
+    void getFinalStatus_OnFailedStatus_ReturnsFailedStatus() {
 
         // given
         StatusCounter statusCounter = new StatusCounter();

--- a/src/test/java/net/masterthought/cucumber/reducers/ElementComparatorTest.java
+++ b/src/test/java/net/masterthought/cucumber/reducers/ElementComparatorTest.java
@@ -3,7 +3,7 @@ package net.masterthought.cucumber.reducers;
 import net.masterthought.cucumber.ReportGenerator;
 import net.masterthought.cucumber.json.Element;
 import net.masterthought.cucumber.json.Feature;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -11,10 +11,10 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ElementComparatorTest extends ReportGenerator {
+class ElementComparatorTest extends ReportGenerator {
 
     @Test
-    public void compare() {
+    void compare() {
         // given
         setUpWithJson(SAMPLE_JSON);
         List<Element> elements = Arrays.stream(getFeatureByName("Second feature").getElements())
@@ -37,7 +37,7 @@ public class ElementComparatorTest extends ReportGenerator {
     }
 
     @Test
-    public void compare_backgrounds() {
+    void compare_backgrounds() {
         // given
         setUpWithJson(SAMPLE_JSON);
         List<Element> elements = Arrays.stream(getFeatureByName("1st feature").getElements())

--- a/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureAppendableMergerTest.java
+++ b/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureAppendableMergerTest.java
@@ -1,17 +1,17 @@
 package net.masterthought.cucumber.reducers;
 
 import net.masterthought.cucumber.json.Feature;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ReportFeatureAppendableMergerTest {
+class ReportFeatureAppendableMergerTest {
 
     @Test
-    public void merge_NullSafe() {
+    void merge_NullSafe() {
         // given
         ReportFeatureAppendableMerger merger = new ReportFeatureAppendableMerger();
 
@@ -23,7 +23,7 @@ public class ReportFeatureAppendableMergerTest {
     }
 
     @Test
-    public void merge_ReturnsOriginArray() {
+    void merge_ReturnsOriginArray() {
         // given
         List<Feature> origin = singletonList(new Feature());
 
@@ -35,7 +35,7 @@ public class ReportFeatureAppendableMergerTest {
     }
 
     @Test
-    public void test_ChecksMergerIsAvailableForAllReducingMethods() {
+    void checksMergerIsAvailableForAllReducingMethods() {
         // given
         ReportFeatureAppendableMerger merger = new ReportFeatureAppendableMerger();
 

--- a/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureByIdMergerTest.java
+++ b/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureByIdMergerTest.java
@@ -2,7 +2,7 @@ package net.masterthought.cucumber.reducers;
 
 import net.masterthought.cucumber.ReportGenerator;
 import net.masterthought.cucumber.json.Feature;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,10 +11,10 @@ import java.util.List;
 import static net.masterthought.cucumber.reducers.ReducingMethod.MERGE_FEATURES_BY_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ReportFeatureByIdMergerTest extends ReportGenerator {
+class ReportFeatureByIdMergerTest extends ReportGenerator {
 
     @Test
-    public void merge_TheSameFeatureTwiceById() {
+    void merge_TheSameFeatureTwiceById() {
         // given
         setUpWithJson(SAMPLE_JSON);
         Integer expectedSize = reportResult.getAllFeatures().size();
@@ -31,7 +31,7 @@ public class ReportFeatureByIdMergerTest extends ReportGenerator {
     }
 
     @Test
-    public void check_MergerIsApplicableByType_NullParam() {
+    void check_MergerIsApplicableByType_NullParam() {
         // given
         ReportFeatureByIdMerger merger = new ReportFeatureByIdMerger();
 
@@ -43,7 +43,7 @@ public class ReportFeatureByIdMergerTest extends ReportGenerator {
     }
 
     @Test
-    public void check_MergerIsApplicableByType_CorrectParam() {
+    void check_MergerIsApplicableByType_CorrectParam() {
         // given
         ReportFeatureByIdMerger merger = new ReportFeatureByIdMerger();
 

--- a/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureMergerFactoryTest.java
+++ b/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureMergerFactoryTest.java
@@ -1,16 +1,16 @@
 package net.masterthought.cucumber.reducers;
 
-import org.junit.Test;
-
 import java.util.Collections;
 
 import static net.masterthought.cucumber.reducers.ReducingMethod.MERGE_FEATURES_BY_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ReportFeatureMergerFactoryTest {
+import org.junit.jupiter.api.Test;
+
+class ReportFeatureMergerFactoryTest {
 
     @Test
-    public void get_NullSafe() {
+    void get_NullSafe() {
         // given
         // when
         ReportFeatureMerger merger = new ReportFeatureMergerFactory().get(null);
@@ -20,7 +20,7 @@ public class ReportFeatureMergerFactoryTest {
     }
 
     @Test
-    public void get_FeatureByIdMerger() {
+    void get_FeatureByIdMerger() {
         // given
         // when
         ReportFeatureMerger merger = new ReportFeatureMergerFactory().get(Collections.singletonList(MERGE_FEATURES_BY_ID));

--- a/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureWithRetestMergerTest.java
+++ b/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureWithRetestMergerTest.java
@@ -3,7 +3,7 @@ package net.masterthought.cucumber.reducers;
 import net.masterthought.cucumber.json.Element;
 import net.masterthought.cucumber.json.Feature;
 import org.junit.jupiter.api.Test;
-import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.reflect.Whitebox;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -12,24 +12,19 @@ import java.util.UUID;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static net.masterthought.cucumber.reducers.ReducingMethod.MERGE_FEATURES_WITH_RETEST;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 class ReportFeatureWithRetestMergerTest {
 
     private ReportFeatureWithRetestMerger merger = new ReportFeatureWithRetestMerger();
 
     private Element buildElement(String id, boolean isBackground) {
-        try {
-            Element result = new Element();
-            MemberModifier.field(Element.class, "id").set(result, id);
-            MemberModifier.field(Element.class, "type").set(result, isBackground ? "background" : "scenario");
-            MemberModifier.field(Element.class, "startTime").set(result, LocalDateTime.now());
-            return result;
-        }
-        catch (IllegalAccessException e) {
-            return null;
-        }
+        Element result = new Element();
+        Whitebox.setInternalState(result, "id", id);
+        Whitebox.setInternalState(result, "type", isBackground ? "background" : "scenario");
+        Whitebox.setInternalState(result, "startTime", LocalDateTime.now());
+        return result;
     }
 
     private Element buildBackground() {
@@ -44,9 +39,7 @@ class ReportFeatureWithRetestMergerTest {
     void updateElementsOfGivenFeature_NoCoincidencesById() throws IllegalAccessException {
         // given
         Feature feature = new Feature();
-        MemberModifier
-                .field(Feature.class, "elements")
-                .set(feature, new Element[] {buildBackground(), buildScenario(), buildScenario()});
+        Whitebox.setInternalState(feature, "elements", new Element[] {buildBackground(), buildScenario(), buildScenario()});
 
         Element[] newElements = {buildBackground(), buildScenario()};
 
@@ -64,9 +57,7 @@ class ReportFeatureWithRetestMergerTest {
         // given
         Feature feature = new Feature();
         Element[] elements = {buildScenario(), buildBackground(), buildScenario()};
-        MemberModifier
-                .field(Feature.class, "elements")
-                .set(feature, elements);
+        Whitebox.setInternalState(feature, "elements", elements);
 
         Element[] newElements = {buildElement(elements[0].getId(), false)};
 

--- a/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureWithRetestMergerTest.java
+++ b/src/test/java/net/masterthought/cucumber/reducers/ReportFeatureWithRetestMergerTest.java
@@ -2,7 +2,7 @@ package net.masterthought.cucumber.reducers;
 
 import net.masterthought.cucumber.json.Element;
 import net.masterthought.cucumber.json.Feature;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.api.support.membermodification.MemberModifier;
 
 import java.time.LocalDateTime;
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.when;
 
-public class ReportFeatureWithRetestMergerTest {
+class ReportFeatureWithRetestMergerTest {
 
     private ReportFeatureWithRetestMerger merger = new ReportFeatureWithRetestMerger();
 
@@ -41,7 +41,7 @@ public class ReportFeatureWithRetestMergerTest {
     }
 
     @Test
-    public void test_UpdateElementsOfGivenFeature_NoCoincidencesById() throws IllegalAccessException {
+    void updateElementsOfGivenFeature_NoCoincidencesById() throws IllegalAccessException {
         // given
         Feature feature = new Feature();
         MemberModifier
@@ -60,7 +60,7 @@ public class ReportFeatureWithRetestMergerTest {
     }
 
     @Test
-    public void test_UpdateElementsOfGivenFeature_WithCoincidenceById() throws IllegalAccessException {
+    void updateElementsOfGivenFeature_WithCoincidenceById() throws IllegalAccessException {
         // given
         Feature feature = new Feature();
         Element[] elements = {buildScenario(), buildBackground(), buildScenario()};
@@ -79,7 +79,7 @@ public class ReportFeatureWithRetestMergerTest {
     }
 
     @Test
-    public void test_elementReplaceWithNewest() {
+    void elementReplaceWithNewest() {
         // given
         LocalDateTime currentTime = LocalDateTime.now();
 
@@ -97,7 +97,7 @@ public class ReportFeatureWithRetestMergerTest {
     }
 
     @Test
-    public void test_elementWithGivenIndexIsBackground() {
+    void elementWithGivenIndexIsBackground() {
         // given
         Element first = buildScenario();
         Element second = buildBackground();
@@ -110,7 +110,7 @@ public class ReportFeatureWithRetestMergerTest {
     }
 
     @Test
-    public void test_elementWithGivenIndexIsNotBackground() {
+    void elementWithGivenIndexIsNotBackground() {
         // given
         Element first = buildScenario();
         Element second = buildBackground();
@@ -123,7 +123,7 @@ public class ReportFeatureWithRetestMergerTest {
     }
 
     @Test
-    public void test_isBackgroundCheckFailsDueToNegativeIndex() {
+    void isBackgroundCheckFailsDueToNegativeIndex() {
         // given
         // when
         boolean isBackground = merger.isBackground(-1, new Element[]{});
@@ -133,7 +133,7 @@ public class ReportFeatureWithRetestMergerTest {
     }
 
     @Test
-    public void test_isBackgroundCheckFailsDueToNullCollection() {
+    void isBackgroundCheckFailsDueToNullCollection() {
         // given
         // when
         boolean isBackground = merger.isBackground(1, null);
@@ -143,7 +143,7 @@ public class ReportFeatureWithRetestMergerTest {
     }
 
     @Test
-    public void test_isBackgroundCheckFailsDueToIndexOutOfBounds() {
+    void isBackgroundCheckFailsDueToIndexOutOfBounds() {
         // given
         // when
         boolean isBackground = merger.isBackground(1, new Element[]{});
@@ -153,7 +153,7 @@ public class ReportFeatureWithRetestMergerTest {
     }
 
     @Test
-    public void test_findElementOfTheSameTypeWithSameId() {
+    void findElementOfTheSameTypeWithSameId() {
         // given
         Element first = buildScenario();
         Element second = buildScenario();
@@ -166,7 +166,7 @@ public class ReportFeatureWithRetestMergerTest {
     }
 
     @Test
-    public void test_ThereIsNoElementOfTheSameTypeWithSameId() {
+    void thereIsNoElementOfTheSameTypeWithSameId() {
         // given
         Element first = buildScenario();
         Element second = buildScenario();
@@ -179,7 +179,7 @@ public class ReportFeatureWithRetestMergerTest {
     }
 
     @Test
-    public void check_MergerIsApplicableByType_NullParam() {
+    void check_MergerIsApplicableByType_NullParam() {
         // given
         // when
         boolean isApplicable = merger.test(null);
@@ -189,7 +189,7 @@ public class ReportFeatureWithRetestMergerTest {
     }
 
     @Test
-    public void check_MergerIsApplicableByType_CorrectParam() {
+    void check_MergerIsApplicableByType_CorrectParam() {
         // given
         // when
         boolean isApplicableByType = merger.test(Arrays.asList(MERGE_FEATURES_WITH_RETEST));

--- a/src/test/java/net/masterthought/cucumber/sorting/FeaturesAlphabeticalComparatorTest.java
+++ b/src/test/java/net/masterthought/cucumber/sorting/FeaturesAlphabeticalComparatorTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Comparator;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import net.masterthought.cucumber.generators.integrations.PageTest;
@@ -14,17 +14,17 @@ import net.masterthought.cucumber.json.Feature;
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class FeaturesAlphabeticalComparatorTest extends PageTest {
+class FeaturesAlphabeticalComparatorTest extends PageTest {
 
     private final Comparator<Feature> comparator = new FeaturesAlphabeticalComparator();
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void compareTo_OnSameFeature_ReturnsZero() {
+    void compareTo_OnSameFeature_ReturnsZero() {
 
         // given
         Feature feature1 = features.get(0);
@@ -38,7 +38,7 @@ public class FeaturesAlphabeticalComparatorTest extends PageTest {
     }
 
     @Test
-    public void compareTo_OnSameName_ReturnsNotZero() {
+    void compareTo_OnSameName_ReturnsNotZero() {
 
         // given
         Feature feature1 = features.get(0);
@@ -52,7 +52,7 @@ public class FeaturesAlphabeticalComparatorTest extends PageTest {
     }
 
     @Test
-    public void compareTo_OnSameNameAndId_ReturnsNotZero() {
+    void compareTo_OnSameNameAndId_ReturnsNotZero() {
 
         // given
         Feature feature1 = features.get(0);
@@ -66,7 +66,7 @@ public class FeaturesAlphabeticalComparatorTest extends PageTest {
     }
 
     @Test
-    public void compareTo_OnDifferentName_ReturnsNotZero() {
+    void compareTo_OnDifferentName_ReturnsNotZero() {
 
         // given
         Feature feature1 = features.get(0);

--- a/src/test/java/net/masterthought/cucumber/sorting/SortingFactoryTest.java
+++ b/src/test/java/net/masterthought/cucumber/sorting/SortingFactoryTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import net.masterthought.cucumber.generators.integrations.PageTest;
@@ -17,15 +17,15 @@ import net.masterthought.cucumber.json.support.TagObject;
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class SortingFactoryTest extends PageTest {
+class SortingFactoryTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void sortFeatures_OnNATURAL_ReturnsSameList() {
+    void sortFeatures_OnNATURAL_ReturnsSameList() {
 
         // given
         SortingFactory sortingFactory = new SortingFactory(SortingMethod.NATURAL);
@@ -38,7 +38,7 @@ public class SortingFactoryTest extends PageTest {
     }
 
     @Test
-    public void sortFeatures_OnALPHABETICAL_ReturnsSortedList() {
+    void sortFeatures_OnALPHABETICAL_ReturnsSortedList() {
 
         // given
         SortingFactory sortingFactory = new SortingFactory(SortingMethod.ALPHABETICAL);
@@ -51,7 +51,7 @@ public class SortingFactoryTest extends PageTest {
     }
 
     @Test
-    public void sortFeatures_OnINVALID_ThrowsException() {
+    void sortFeatures_OnINVALID_ThrowsException() {
 
         // given
         // INVALID is available only for test profile and the reason of this shadow Enum in test profile is
@@ -65,7 +65,7 @@ public class SortingFactoryTest extends PageTest {
     }
 
     @Test
-    public void sortTags_OnNATURAL_ReturnsSameList() {
+    void sortTags_OnNATURAL_ReturnsSameList() {
 
         // given
         SortingFactory sortingFactory = new SortingFactory(SortingMethod.NATURAL);
@@ -79,7 +79,7 @@ public class SortingFactoryTest extends PageTest {
     }
 
     @Test
-    public void sortTags_OnALPHABETICAL_ReturnsSameList() {
+    void sortTags_OnALPHABETICAL_ReturnsSameList() {
 
         // given
         SortingFactory sortingFactory = new SortingFactory(SortingMethod.ALPHABETICAL);
@@ -92,7 +92,7 @@ public class SortingFactoryTest extends PageTest {
     }
 
     @Test
-    public void sortTags_OnINVALID_ThrowsException() {
+    void sortTags_OnINVALID_ThrowsException() {
 
         // given
         SortingFactory sortingFactory = new SortingFactory(SortingMethod.INVALID);
@@ -104,7 +104,7 @@ public class SortingFactoryTest extends PageTest {
     }
 
     @Test
-    public void sortSteps_OnNATURAL_ReturnsSameList() {
+    void sortSteps_OnNATURAL_ReturnsSameList() {
 
         // given
         SortingFactory sortingFactory = new SortingFactory(SortingMethod.NATURAL);
@@ -119,7 +119,7 @@ public class SortingFactoryTest extends PageTest {
     }
 
     @Test
-    public void sortSteps_OnALPHABETICAL_ReturnsSameList() {
+    void sortSteps_OnALPHABETICAL_ReturnsSameList() {
 
         // given
         SortingFactory sortingFactory = new SortingFactory(SortingMethod.ALPHABETICAL);
@@ -135,7 +135,7 @@ public class SortingFactoryTest extends PageTest {
     }
 
     @Test
-    public void sortSteps_OnINVALID_ThrowsException() {
+    void sortSteps_OnINVALID_ThrowsException() {
 
         // given
         SortingMethod sortingMethod = SortingMethod.INVALID;
@@ -148,7 +148,7 @@ public class SortingFactoryTest extends PageTest {
     }
 
     @Test
-    public void createUnknownMethodException_CreatesException() throws Exception {
+    void createUnknownMethodException_CreatesException() throws Exception {
 
         // given
         SortingMethod invalidSorthingMethod = SortingMethod.ALPHABETICAL;

--- a/src/test/java/net/masterthought/cucumber/sorting/StepObjectAlphabeticalComparatorTest.java
+++ b/src/test/java/net/masterthought/cucumber/sorting/StepObjectAlphabeticalComparatorTest.java
@@ -5,17 +5,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Comparator;
 
 import net.masterthought.cucumber.json.support.StepObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class StepObjectAlphabeticalComparatorTest {
+class StepObjectAlphabeticalComparatorTest {
 
     private final Comparator<StepObject> comparator = new StepObjectAlphabeticalComparator();
 
     @Test
-    public void compareTo_OnDifferentLocation_ReturnsNoneZero() {
+    void compareTo_OnDifferentLocation_ReturnsNoneZero() {
 
         // given
         StepObject step1 = new StepObject("one");
@@ -29,7 +29,7 @@ public class StepObjectAlphabeticalComparatorTest {
     }
 
     @Test
-    public void compareTo_OnSameLocation_ReturnsZero() {
+    void compareTo_OnSameLocation_ReturnsZero() {
 
         // given
         StepObject step1 = new StepObject("one");

--- a/src/test/java/net/masterthought/cucumber/sorting/TagObjectAlphabeticalComparatorTest.java
+++ b/src/test/java/net/masterthought/cucumber/sorting/TagObjectAlphabeticalComparatorTest.java
@@ -5,17 +5,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Comparator;
 
 import net.masterthought.cucumber.json.support.TagObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class TagObjectAlphabeticalComparatorTest {
+class TagObjectAlphabeticalComparatorTest {
 
     private final Comparator<TagObject> comparator = new TagObjectAlphabeticalComparator();
 
     @Test
-    public void compareTo_OnDifferentTagName_ReturnsNoneZero() {
+    void compareTo_OnDifferentTagName_ReturnsNoneZero() {
 
         // given
         TagObject tag1 = new TagObject("one");
@@ -29,7 +29,7 @@ public class TagObjectAlphabeticalComparatorTest {
     }
 
     @Test
-    public void compareTo_OnSameLocation_ReturnsZero() {
+    void compareTo_OnSameLocation_ReturnsZero() {
 
         // given
         TagObject tag1 = new TagObject("one");

--- a/src/test/java/net/masterthought/cucumber/util/CounterTest.java
+++ b/src/test/java/net/masterthought/cucumber/util/CounterTest.java
@@ -1,14 +1,14 @@
 package net.masterthought.cucumber.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CounterTest {
+class CounterTest {
 
     @Test
-    public void next_shouldIncrement() {
+    void next_shouldIncrement() {
 
         // given
         Counter counter = new Counter();

--- a/src/test/java/net/masterthought/cucumber/util/StepNameFormatterTest.java
+++ b/src/test/java/net/masterthought/cucumber/util/StepNameFormatterTest.java
@@ -2,21 +2,20 @@ package net.masterthought.cucumber.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.Step;
 
-public class StepNameFormatterTest extends PageTest {
+class StepNameFormatterTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void format_OnNoArgument_ReturnsUnchangedValue() {
+    void format_OnNoArgument_ReturnsUnchangedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[1];
@@ -29,7 +28,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_OnLastPosition_ReturnsFormattedValue() {
+    void format_OnLastPosition_ReturnsFormattedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[0];
@@ -42,7 +41,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_OnEmptyArgument_ReturnsFormattedValue() {
+    void format_OnEmptyArgument_ReturnsFormattedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[1];
@@ -55,7 +54,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_OnArgumentAtEndOfString_ReturnsFormattedValue() {
+    void format_OnArgumentAtEndOfString_ReturnsFormattedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[3];
@@ -68,7 +67,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_ReturnsFormattedValue() {
+    void format_ReturnsFormattedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[4];
@@ -81,7 +80,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_StartPosition_ReturnsFormattedValue() {
+    void format_StartPosition_ReturnsFormattedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[2];
@@ -94,7 +93,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_OnMultipleArguments_ReturnsFormattedValue() {
+    void format_OnMultipleArguments_ReturnsFormattedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[3];
@@ -107,7 +106,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_OnEmptyValue_ReturnsUnchangedValue() {
+    void format_OnEmptyValue_ReturnsUnchangedValue() {
 
         // given
         Step step = features.get(0).getElements()[1].getSteps()[3];
@@ -120,7 +119,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_optionalArgumentNotMatched() {
+    void format_optionalArgumentNotMatched() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[0];
@@ -133,7 +132,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_ReturnsEscapedValues() {
+    void format_ReturnsEscapedValues() {
 
         // given
         Step step = features.get(1).getElements()[0].getSteps()[1];
@@ -146,7 +145,7 @@ public class StepNameFormatterTest extends PageTest {
     }
 
     @Test
-    public void format_shouldEscape() {
+    void format_shouldEscape() {
 
         // given
         String text = "I press <ON> & <C> simulatenously";

--- a/src/test/java/net/masterthought/cucumber/util/UtilTest.java
+++ b/src/test/java/net/masterthought/cucumber/util/UtilTest.java
@@ -6,21 +6,21 @@ import java.util.List;
 
 import net.masterthought.cucumber.generators.integrations.PageTest;
 import net.masterthought.cucumber.json.Hook;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damian Szczepanik (damianszczepanik@github)
  */
-public class UtilTest extends PageTest {
+class UtilTest extends PageTest {
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         setUpWithJson(SAMPLE_JSON);
     }
 
     @Test
-    public void formatAsPercentage_ReturnsFormattedValue() {
+    void formatAsPercentage_ReturnsFormattedValue() {
 
         // given
         final int[][] values = {{1, 3}, {2, 2}, {1, 5}, {0, 5}};
@@ -33,7 +33,7 @@ public class UtilTest extends PageTest {
     }
 
     @Test
-    public void formatAsPercentage_OnZeroTotal_ReturnsFormattedValue() {
+    void formatAsPercentage_OnZeroTotal_ReturnsFormattedValue() {
 
         // given
         final int[] values = {1, 2, 0};
@@ -45,7 +45,7 @@ public class UtilTest extends PageTest {
     }
 
     @Test
-    public void formatAsDecimal_ReturnsFormattedValue() {
+    void formatAsDecimal_ReturnsFormattedValue() {
 
         // given
         final int[][] values = {{1, 3}, {2, 2}, {1, 5}, {0, 5}, {0, 0}};
@@ -58,7 +58,7 @@ public class UtilTest extends PageTest {
     }
 
     @Test
-    public void toValidFileName_RemovesInvalidChars() {
+    void toValidFileName_RemovesInvalidChars() {
 
         // given
         final String[] ids = {"simpleFile", "file-dash", "東京", "żółć"};
@@ -71,7 +71,7 @@ public class UtilTest extends PageTest {
     }
 
     @Test
-    public void eliminateEmptyHooks_RemovesEmptyHooks() {
+    void eliminateEmptyHooks_RemovesEmptyHooks() {
 
         // given
         Hook[] hooks = features.get(0).getElements()[0].getBefore();


### PR DESCRIPTION
- Fixed one test used in string builder (was looping 'inners' but instead of appending 'inner' was appending 'inners' over and over
- Used open rewrite to run 95% of the migration from junit 4 to junit5.  See https://docs.openrewrite.org/running-recipes/popular-recipe-guides/migrate-from-junit-4-to-junit-5 for more details.
- Fixed the parameterized tests to allow those to run.  This resulted in 345 tests with 2 skips becoming 601 with 27 skips (all those skips are from the original 2).  I didn't look at those specifically to see if they could be fixed.
- Dropped all powermock usage that is junit 4 style on top of mockito as mockito does all that out of the box now.
- Replaced member modification usage of powermock with powermock whitebox which is far easier to read and allowed for rest of obsolete parts of powermock to be removed.
