### PR TITLE
Use only slf4j (excluding legacy commons-logging*) and remove logging manipulations during tests as not needed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
             <version>2.9.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -280,6 +286,22 @@
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
             <artifactId>owasp-java-html-sanitizer</artifactId>
             <version>20220608.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.9</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- for testing -->
@@ -330,6 +352,12 @@
             <artifactId>commons-beanutils</artifactId>
             <version>1.9.4</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <byte-buddy.version>1.14.11</byte-buddy.version>
         <jackson.version>2.16.0</jackson.version>
         <junit.version>5.10.1</junit.version>
+        <slf4j.version>2.0.11</slf4j.version>
 
         <test.integration.pattern>**/*IntegrationTest*.java</test.integration.pattern>
 
@@ -290,17 +291,17 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.9</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>2.0.9</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.9</version>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -11,8 +11,6 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,10 +27,12 @@ import net.masterthought.cucumber.generators.TrendsOverviewPage;
 import net.masterthought.cucumber.json.Feature;
 import net.masterthought.cucumber.json.support.TagObject;
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ReportBuilder {
 
-    private static final Logger LOG = Logger.getLogger(ReportBuilder.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(ReportBuilder.class);
 
     /**
      * Page that should be displayed when the reports is generated. Shared between {@link FeaturesOverviewPage} and
@@ -173,8 +173,8 @@ public class ReportBuilder {
         try {
             FileUtils.copyFile(srcFile, tempFile);
         } catch (FileNotFoundException e) {
-            LOG.log(Level.WARNING, "File not found: {0}", srcFile.getAbsolutePath());
-            LOG.log(Level.FINE, "", e);
+            LOG.warn("File not found: {}", srcFile.getAbsolutePath());
+            LOG.debug("", e);
         } catch (IOException | IllegalArgumentException e) {
             throw new ValidationException(e);
         }
@@ -258,7 +258,7 @@ public class ReportBuilder {
     }
 
     private void generateErrorPage(Exception exception) {
-        LOG.log(Level.WARNING, "Unexpected error", exception);
+        LOG.warn("Unexpected error", exception);
         ErrorPage errorPage = new ErrorPage(reportResult, configuration, exception, jsonFiles);
         errorPage.generatePage();
     }

--- a/src/main/java/net/masterthought/cucumber/ReportParser.java
+++ b/src/main/java/net/masterthought/cucumber/ReportParser.java
@@ -10,8 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.InjectableValues;
@@ -25,6 +23,8 @@ import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
 import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.lang3.ArrayUtils;
 
 /**
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.ArrayUtils;
  */
 public class ReportParser {
 
-    private static final Logger LOG = Logger.getLogger(ReportParser.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(ReportParser.class);
 
     private final ObjectMapper mapper = new ObjectMapper();
     private final Configuration configuration;
@@ -69,7 +69,7 @@ public class ReportParser {
                 continue;
             }
             Feature[] features = parseForFeature(jsonFile);
-            LOG.log(Level.INFO, () -> String.format("File '%s' contains %d feature(s)", jsonFile, features.length));
+            LOG.info("File '{}' contains {} feature(s)", jsonFile, features.length);
             featureResults.addAll(Arrays.asList(features));
         }
 
@@ -91,7 +91,7 @@ public class ReportParser {
         try (Reader reader = new InputStreamReader(new FileInputStream(jsonFile), StandardCharsets.UTF_8)) {
             Feature[] features = mapper.readValue(reader, Feature[].class);
             if (ArrayUtils.isEmpty(features)) {
-                LOG.log(Level.INFO, () -> String.format("File '%s' does not contain features", jsonFile));
+                LOG.info("File '{}' does not contain features", jsonFile);
             }
             String jsonFileName = extractQualifier(jsonFile);
             Arrays.stream(features).forEach(feature ->

--- a/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
+++ b/src/main/java/net/masterthought/cucumber/generators/AbstractPage.java
@@ -7,8 +7,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import net.masterthought.cucumber.Configuration;
@@ -27,6 +25,8 @@ import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.app.event.EventCartridge;
 import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Delivers common methods for page generation.
@@ -35,7 +35,7 @@ import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
  */
 public abstract class AbstractPage {
 
-    private static final Logger LOG = Logger.getLogger(AbstractPage.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractPage.class);
 
     private final VelocityEngine engine = new VelocityEngine();
     protected final VelocityContext context = new VelocityContext();
@@ -136,7 +136,7 @@ public abstract class AbstractPage {
             if (NumberUtils.isCreatable(buildNumber)) {
                 context.put("build_previous_number", Integer.parseInt(buildNumber) - 1);
             } else {
-                LOG.log(Level.INFO, "Could not parse build number: {0}.", configuration.getBuildNumber());
+                LOG.info("Could not parse build number: {}.", configuration.getBuildNumber());
             }
         }
     }

--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -12,8 +12,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import net.masterthought.cucumber.generators.OverviewReport;
 import net.masterthought.cucumber.json.Feature;
@@ -112,7 +110,6 @@ class ReportBuilderTest extends ReportGenerator {
         };
         ReportBuilder reportBuilder = new ReportBuilder(jsonReports, configuration);
         configuration.setTrendsStatsFile(trendsFileTmp);
-        Logger.getLogger(ReportBuilder.class.getName()).setLevel(Level.OFF);
 
         // when
         reportBuilder.generateReports();
@@ -155,7 +152,6 @@ class ReportBuilderTest extends ReportGenerator {
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
         ReportBuilder builder = new ReportBuilder(Collections.<String>emptyList(), configuration);
-        Logger.getLogger(ReportBuilder.class.getName()).setLevel(Level.OFF);
 
         // when
         Whitebox.invokeMethod(builder, "copyStaticResources");
@@ -521,7 +517,6 @@ class ReportBuilderTest extends ReportGenerator {
         // given
         Configuration configuration = new Configuration(reportDirectory, "myProject");
         ReportBuilder builder = new ReportBuilder(Collections.<String>emptyList(), configuration);
-        Logger.getLogger(ReportBuilder.class.getName()).setLevel(Level.OFF);
 
         // when
         Whitebox.invokeMethod(builder, "generateErrorPage", new Exception());

--- a/src/test/java/net/masterthought/cucumber/ReportGenerator.java
+++ b/src/test/java/net/masterthought/cucumber/ReportGenerator.java
@@ -5,8 +5,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import net.masterthought.cucumber.json.Feature;
 import net.masterthought.cucumber.json.support.StepObject;
@@ -62,7 +60,6 @@ public abstract class ReportGenerator {
     }
 
     protected void setUpWithJson(String... jsonFiles) {
-        Logger.getLogger(ReportParser.class.getName()).setLevel(Level.WARNING);
         initWithJson(jsonFiles);
         createReport();
     }

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=error


### PR DESCRIPTION
* commons-logging has come back to life but older products are likely long off from supporting and it does more to just redirect to slf4j and log4j2 then any other actual reason for existing.  Since slf4j was already a transient of this project, just make use of slf4j directly and exclude commons logging entirely.  Code itself wasn't using that either really but rather java util logger.

Tests manipulating logs appeared to me as being done to make less output show up on the console, achieved the same thing by simply using slf4j-simple in test scope and changing what gets printed out.