### PR TITLE
[pom] Add byte-buddy directly as a java agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,14 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <maven.compile.encoding>UTF-8</maven.compile.encoding>
 
+        <byte-buddy.version>1.14.11</byte-buddy.version>
         <jackson.version>2.16.0</jackson.version>
         <junit.version>5.10.1</junit.version>
 
         <test.integration.pattern>**/*IntegrationTest*.java</test.integration.pattern>
+
+        <!-- Surefire Setup -->
+        <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar</argLine>
     </properties>
 
     <!-- 'oss-parent' should not be used, it was deprecated years ago -->
@@ -116,7 +120,7 @@
                 <jdk>[17,)</jdk>
             </activation>
             <properties>
-                <argLine>--add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
+                <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
             </properties>
         </profile>
     </profiles>
@@ -295,6 +299,18 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>5.8.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${byte-buddy.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>${byte-buddy.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This resolves newer jdk 19+ that suggests java will block this in the future from dynamically adding.  Therefore this is no longer dynamically added both for lower jdks as well as jdk 17+

How and where byte-buddy is used?
- mockito
- assertj

While the agent is the concern here, we need to make sure both stay in sync as they are well known to fail if out of sync on more recent versions (such as latest here) due to the versions mockito / assertj are using.  That is even if its true, assertj just released new and is up to date now.

For an extremely lengthy discussion on it as well as links/mentions to the JSR involved, see https://github.com/mockito/mockito/issues/3037.  What is being done here is all the way at the bottom and best that can be done for maven currently.