### PR TITLE
[tests] Add notes as to why tests are skipped due to usage of assumeThat...

### DIFF
--- a/src/test/java/net/masterthought/cucumber/json/EmbeddingWithNameTest.java
+++ b/src/test/java/net/masterthought/cucumber/json/EmbeddingWithNameTest.java
@@ -37,6 +37,7 @@ public class EmbeddingWithNameTest {
     @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
     void getMimeType_ReturnsMimeType(String mimeType, String data, String name, String decodedData, String fileName) {
         initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
+
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);
 
@@ -51,6 +52,7 @@ public class EmbeddingWithNameTest {
     @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
     void getData_ReturnsContent(String mimeType, String data, String name, String decodedData, String fileName) {
         initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
+
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);
 
@@ -65,8 +67,10 @@ public class EmbeddingWithNameTest {
     @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
     void getDecodedData_ReturnsDecodedContent(String mimeType, String data, String name, String decodedData, String fileName) {
         initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
+
+        // This assumeThat will cause 6 tests to be skipped from our 'data' usage
         assumeThat(this.decodedData).isNotEqualTo(NO_DECODING);
-        
+
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);
 
@@ -81,6 +85,8 @@ public class EmbeddingWithNameTest {
     @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
     void getFileName_ReturnsFileName(String mimeType, String data, String name, String decodedData, String fileName) {
         initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
+
+        // This assumeThat will cause 6 tests to be skipped from our 'data' usage
         assumeThat(this.fileName).matches("^[^\\.]+\\.[^\\.]+$");
 
         // given
@@ -97,6 +103,7 @@ public class EmbeddingWithNameTest {
     @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
     void getExtension_ReturnsFileExtension(String mimeType, String data, String name, String decodedData, String fileName) {
         initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
+
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);
 
@@ -111,6 +118,7 @@ public class EmbeddingWithNameTest {
     @ParameterizedTest(name = "\"{0}\" into \"{2}\"")
     void getName_ReturnsName(String mimeType, String data, String name, String decodedData, String fileName) {
         initEmbeddingWithNameTest(mimeType, data, name, decodedData, fileName);
+
         // given
         Embedding embedding = new Embedding(this.mimeType, this.data, this.name);
 


### PR DESCRIPTION
having to match to proceed with tests

Cleaned up format within test so it matches throughout.  Reviewed the no_decoding one specifically which like the regex one skips 6 tests.  There are 6 no_decoding so when that is hit it does not continue on as the test is not applicable to be tested.  While I don't know what the original intention was, that is the reason so making it clear as to why those tests are skipped (12 in all).