### PR TITLE
Change the visibility of the reportParser field

### DIFF
--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -53,8 +53,7 @@ public class ReportBuilder {
     private static final ObjectMapper mapper = new ObjectMapper();
 
     private ReportResult reportResult;
-    private final ReportParser reportParser;
-
+    private ReportParser reportParser;
     private Configuration configuration;
     private List<String> jsonFiles;
 
@@ -69,6 +68,20 @@ public class ReportBuilder {
         this.jsonFiles = jsonFiles;
         this.configuration = configuration;
         reportParser = new ReportParser(configuration);
+    }
+
+    public ReportBuilder(List<String> jsonFiles, Configuration configuration, ReportParser reportParser){
+        this.jsonFiles = jsonFiles;
+        this.configuration = configuration;
+        setReportParser(reportParser);
+    }
+
+    public ReportParser getReportParser() {
+        return reportParser;
+    }
+
+    public void setReportParser(ReportParser reportParser) {
+        this.reportParser = reportParser;
     }
 
     /**

--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -70,7 +70,7 @@ public class ReportBuilder {
         reportParser = new ReportParser(configuration);
     }
 
-    public ReportBuilder(List<String> jsonFiles, Configuration configuration, ReportParser reportParser){
+    public ReportBuilder(List<String> jsonFiles, Configuration configuration, ReportParser reportParser) {
         this.jsonFiles = jsonFiles;
         this.configuration = configuration;
         setReportParser(reportParser);

--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -53,7 +53,7 @@ public class ReportBuilder {
     private static final ObjectMapper mapper = new ObjectMapper();
 
     private ReportResult reportResult;
-    protected ReportParser reportParser;
+    private final ReportParser reportParser;
 
     private Configuration configuration;
     private List<String> jsonFiles;

--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -70,12 +70,6 @@ public class ReportBuilder {
         reportParser = new ReportParser(configuration);
     }
 
-    public ReportBuilder(List<String> jsonFiles, Configuration configuration, ReportParser reportParser) {
-        this.jsonFiles = jsonFiles;
-        this.configuration = configuration;
-        setReportParser(reportParser);
-    }
-
     public ReportParser getReportParser() {
         return reportParser;
     }

--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -53,7 +53,7 @@ public class ReportBuilder {
     private static final ObjectMapper mapper = new ObjectMapper();
 
     private ReportResult reportResult;
-    private final ReportParser reportParser;
+    protected ReportParser reportParser;
 
     private Configuration configuration;
     private List<String> jsonFiles;

--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -74,12 +74,8 @@ class ReportBuilderTest extends ReportGenerator {
         builder.setReportParser(reportParser);
 
         // then
-        List<String> assignedJsonReports = Whitebox.getInternalState(builder, "jsonFiles");
-        Configuration assignedConfiguration = Whitebox.getInternalState(builder, "configuration");
         ReportParser assignedReportParser = Whitebox.getInternalState(builder, "reportParser");
 
-        assertThat(assignedJsonReports).isSameAs(jsonFiles);
-        assertThat(assignedConfiguration).isSameAs(configuration);
         assertThat(assignedReportParser).isSameAs(builder.getReportParser());
     }
 

--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -63,26 +63,6 @@ class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
-    void ReportBuilder_usesCustomReportParser(){
-        // given
-        final List<String> jsonFiles = new ArrayList<>();
-        final Configuration configuration = new Configuration(null, null);
-        final ReportParser reportParser = new ReportParser(configuration);
-
-        // when
-        ReportBuilder builder = new ReportBuilder(jsonFiles, configuration, reportParser);
-
-        // then
-        List<String> assignedJsonReports = Whitebox.getInternalState(builder, "jsonFiles");
-        Configuration assignedConfiguration = Whitebox.getInternalState(builder, "configuration");
-        ReportParser assignedReportParser = Whitebox.getInternalState(builder, "reportParser");
-
-        assertThat(assignedJsonReports).isSameAs(jsonFiles);
-        assertThat(assignedConfiguration).isSameAs(configuration);
-        assertThat(assignedReportParser).isSameAs(reportParser);
-    }
-
-    @Test
     void ReportBuilder_setsAndGetsCustomReportParser(){
         // given
         final List<String> jsonFiles = new ArrayList<>();

--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -63,6 +63,47 @@ class ReportBuilderTest extends ReportGenerator {
     }
 
     @Test
+    void ReportBuilder_usesCustomReportParser(){
+        // given
+        final List<String> jsonFiles = new ArrayList<>();
+        final Configuration configuration = new Configuration(null, null);
+        final ReportParser reportParser = new ReportParser(configuration);
+
+        // when
+        ReportBuilder builder = new ReportBuilder(jsonFiles, configuration, reportParser);
+
+        // then
+        List<String> assignedJsonReports = Whitebox.getInternalState(builder, "jsonFiles");
+        Configuration assignedConfiguration = Whitebox.getInternalState(builder, "configuration");
+        ReportParser assignedReportParser = Whitebox.getInternalState(builder, "reportParser");
+
+        assertThat(assignedJsonReports).isSameAs(jsonFiles);
+        assertThat(assignedConfiguration).isSameAs(configuration);
+        assertThat(assignedReportParser).isSameAs(reportParser);
+    }
+
+    @Test
+    void ReportBuilder_setsAndGetsCustomReportParser(){
+        // given
+        final List<String> jsonFiles = new ArrayList<>();
+        final Configuration configuration = new Configuration(null, null);
+        final ReportParser reportParser = new ReportParser(configuration);
+
+        // when
+        ReportBuilder builder = new ReportBuilder(jsonFiles, configuration);
+        builder.setReportParser(reportParser);
+
+        // then
+        List<String> assignedJsonReports = Whitebox.getInternalState(builder, "jsonFiles");
+        Configuration assignedConfiguration = Whitebox.getInternalState(builder, "configuration");
+        ReportParser assignedReportParser = Whitebox.getInternalState(builder, "reportParser");
+
+        assertThat(assignedJsonReports).isSameAs(jsonFiles);
+        assertThat(assignedConfiguration).isSameAs(configuration);
+        assertThat(assignedReportParser).isSameAs(builder.getReportParser());
+    }
+
+    @Test
     void generateReports_GeneratesPages() {
 
         // given


### PR DESCRIPTION
## Description
This pull request adds getter and setter methods for reportParser field with an overloaded constructor so that developers can extend the functionality of `ReportBuilder` with their own parsers, which provides greater flexibility for customized report processing.

## Changes
1. Changed `reportParser` from `private final` to `private`, 
2. Add getter and setter methods for `reportParser`.
3. Added unit test

## Motivation
In projects that require customized parsing behavior, developers may want to extend `ReportParser` with additional functionality. Adjusting the visibility of `reportParser` facilitates these extensions while maintaining the original functionality of `ReportBuilder`.

## Testing
Verified that existing functionality remains unaffected after the changes.
Confirmed that a custom parser can now be added by sub classing `ReportParser` and utilized effectively.
