### PR TITLE
[GHA] Do not run sonarcloud on forks

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - master
-  # do not validate pull requests because SONAR_TOKEN is available only for project owner
+  # Run against master only to not overwhelm sonar given master branch is the base used branch
 
 jobs:
   build:
+    # Do not run sonar on forks because SONAR_TOKEN is available only for project owner
     if: github.repository_owner == 'damianszczepanik'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: github.repository_owner == 'damianszczepanik'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  # Run against master only to not overwhelm sonar given master branch is the base used branch
+  # Community version only allows running against 'main' branch, see https://docs.sonarsource.com/sonarqube/latest/devops-platform-integration/github-integration/
 
 jobs:
   build:


### PR DESCRIPTION
currently this runs on every fork then fails as it should not have been run, this corrects the issue so that it only runs on the upstream repo here as expected.