### PR TITLE
cleanup: remove unneeded setTrendsStatsFile line and fix indentation

### DIFF
--- a/src/main/resources/templates/js/trends-chart.js.vm
+++ b/src/main/resources/templates/js/trends-chart.js.vm
@@ -376,30 +376,30 @@ $(document).ready(function() {
         ]
     };
 
-  function formatDuration(duration) {
-    // gets in nanosecs, outs in secs
-    return moment.duration(duration / 1000000).humanize();
-  }
-
-  var durationsContext = document.getElementById("trends-durations-chart");
-  new Chart(durationsContext, {
-    type: "line",
-    data: chartDurationsData,
-    options: {
-      scales: {
-        yAxes: [{
-          ticks: {
-            userCallback: function(value) { return formatDuration(value); }
-          }
-        }]
-      },
-      tooltips: {
-        callbacks: {
-          label: function(tooltipItem, data) {
-            return data.datasets[tooltipItem.datasetIndex].label + ": " + formatDuration(tooltipItem.yLabel);
-          }
-        }
-      }
+    function formatDuration(duration) {
+        // gets in nanosecs, outs in secs
+        return moment.duration(duration / 1000000).humanize();
     }
-  });
+
+    var durationsContext = document.getElementById("trends-durations-chart");
+    new Chart(durationsContext, {
+        type: "line",
+        data: chartDurationsData,
+        options: {
+            scales: {
+                yAxes: [{
+                    ticks: {
+                        userCallback: function(value) { return formatDuration(value); }
+                    }
+                }]
+            },
+            tooltips: {
+                callbacks: {
+                    label: function(tooltipItem, data) {
+                        return data.datasets[tooltipItem.datasetIndex].label + ": " + formatDuration(tooltipItem.yLabel);
+                    }
+                }
+            }
+        }
+    });
 });

--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -284,7 +284,6 @@ class ReportBuilderTest extends ReportGenerator {
 
         // given
         setUpWithJson(SAMPLE_JSON);
-        configuration.setTrendsStatsFile(trendsFileTmp);
         ReportBuilder builder = new ReportBuilder(jsonReports, configuration);
         Whitebox.setInternalState(builder, "reportResult", new ReportResult(features, configuration));
 

--- a/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
+++ b/src/test/java/net/masterthought/cucumber/ReportBuilderTest.java
@@ -284,6 +284,7 @@ class ReportBuilderTest extends ReportGenerator {
 
         // given
         setUpWithJson(SAMPLE_JSON);
+        configuration.setTrendsStatsFile(trendsFileTmp);
         ReportBuilder builder = new ReportBuilder(jsonReports, configuration);
         Whitebox.setInternalState(builder, "reportResult", new ReportResult(features, configuration));
 


### PR DESCRIPTION
Cleanup follow-up from #1333 as suggested by @damianszczepanik:

   - Remove unneeded `configuration.setTrendsStatsFile(trendsFileTmp)` line
     from `collectPages_CollectsPages` test in ReportBuilderTest.java
   - Fix indentation of `formatDuration` function and durations chart block
     in trends-chart.js.vm to be consistent with the rest of the file (4 spaces)